### PR TITLE
Increased PWM freq to 40kHz

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
@@ -76,7 +76,7 @@
 // I2T parameters for FILTER implementation
 #define UDEF_I2T_LIMIT 90 // %
 
-#define PWMFREQUENCY  20000
+#define PWMFREQUENCY  40000
 
 // Deadtime in seconds (range 1.6 us to 25 ns)
 // DHES accept a greater zero cross distortion in order to keep lower temperature

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          1
+#define FW_VERSION_BUILD          2
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -136,7 +136,8 @@ _FICD(ICS_PGD3 & JTAGEN_OFF); // & COE_ON ); //BKBUG_OFF
 //#define CALIBRATION
 
 #define BOARD_CAN_ADDR_DEFAULT 0xE
-#define VOLT_REF_SHIFT 5
+#define VOLT_REF_SHIFT 5 // for a PWM resolution of 1000
+#define PWM_50_DUTY_CYC (LOOPINTCY/2)
 
 #define isDriveEnabled() bDriveEnabled
 
@@ -189,7 +190,7 @@ volatile int iQerror_old = 0;
 volatile int iDerror_old = 0;
 volatile char limit = 0;
 
-static const int PWM_MAX = (8*LOOPINTCY)/20; // = 80%
+static const int PWM_MAX = 8*PWM_50_DUTY_CYC/10; // = 80%
 
 volatile int gMaxCurrent = 0;
 volatile long sI2Tlimit = 0;
@@ -959,6 +960,11 @@ void __attribute__((__interrupt__, no_auto_psv)) _DMA0Interrupt(void)
             FaultConditionsHandler();
         }
     }
+    
+    // Re-scale Vq, Vd with respect to the PWM resolution and fullscale.
+    Vq = Vq/(1000/PWM_50_DUTY_CYC);
+    Vd = Vd/(1000/PWM_50_DUTY_CYC);
+    
     //
     ////////////////////////////////////////////////////////////////////////////
 
@@ -1028,7 +1034,7 @@ void DisableAuxServiceTimer()
 void DriveInit()
 // Perform drive SW/HW init
 {
-    pwmInit(LOOPINTCY/2, DDEADTIME, (8*LOOPINTCY)/20 /*pwm max = 80%*/);
+    pwmInit(PWM_50_DUTY_CYC, DDEADTIME, PWM_MAX /*pwm max = 80%*/);
 
     // setup and perform ADC offset calibration in MeasCurrParm.Offseta and Offsetb
     ADCDoOffsetCalibration();

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/PWM.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/PWM.c
@@ -30,7 +30,7 @@ void pwmInit(short pwm_50_duty_cycle, short pwm_deadtime, short pwm_max)
     // Note: The PWM period setting register is set to LoopInTcy/2 but since it counts up and
     // then down => the interrupt flag is set to 1 at zero => actual
     // interrupt period is LoopInTcy
-    PTPER = PWM_50_DUTY_CYCLE; // Setup PWM period to Loop Time defined in parms.h
+    PTPER = PWM_50_DUTY_CYCLE-1; // Setup PWM period to Loop Time defined in parms.h
     PWMCON1 = 0x0077; // Enable PWM 1,2,3 pairs (L+H) for complementary mode
     DTCON1 = (0x00 | (PWM_DEADTIME)); // Dead time. Prescaler 0
     DTCON2 = 0;
@@ -44,8 +44,10 @@ void pwmInit(short pwm_50_duty_cycle, short pwm_deadtime, short pwm_max)
     // SEVTCMP: Special Event Compare Count Register
     // Phase of ADC capture set relative to PWM cycle: when arrive to PTPER offset and counting down
     // to avoid ripple on the current measurement
-    SEVTCMP = 0;
-    SEVTCMPbits.SEVTDIR = 1;
+    P1SECMP = 0;
+    P1SECMPbits.SEVTDIR = 1; // when PWM time base is counting down
+    P1SECMPbits.SEVTCMP = 0; // at the end of countdown
+    PWM1CON2bits.SEVOPS = 0b0000; // Output Postscale value to 1:1    
 }
 
 volatile unsigned char PWM_ovcurr_fault = 0;


### PR DESCRIPTION
Implements https://github.com/robotology/icub-firmware/issues/87. List of changes:
- set PWMFREQUENCY define.
- re-scale Vq, Vd with respect to the PWM resolution and fullscale.
- fixed PTPER computation.
- set P1SECMPbits instead of SEVTCMPbits.