### PR TITLE
Fix access to non aligned memory through (int*)

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          2
+#define FW_VERSION_BUILD          3
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c
@@ -257,16 +257,14 @@ static int s_canIcubProtoParser_parse_pollingMsg(tCanData *rxpayload, unsigned c
 
         if (rxlen==8)
         {
-            //int  kp=((int)rxpayload->b[1])|(((int)rxpayload->b[2])<<8);
-            //int  ki=((int)rxpayload->b[3])|(((int)rxpayload->b[4])<<8);
-            //char ks=rxpayload->b[7];
+            int  kp=((int)rxpayload->b[1])|(((int)rxpayload->b[2])<<8);
+            int  ki=((int)rxpayload->b[3])|(((int)rxpayload->b[4])<<8);
+            char ks=rxpayload->b[7];
 
-            //setIPid(kp,ki,ks);
+            setIPid(kp,ki,ks);
 
-            setIPid(*(int*)(&rxpayload->b[1]),*(int*)(&rxpayload->b[3]),rxpayload->b[7]);
-
-        return 1;
-    }
+            return 1;
+        }
         else if (rxlen==6)
         {
             static float fkp = 0.0f;
@@ -285,7 +283,7 @@ static int s_canIcubProtoParser_parse_pollingMsg(tCanData *rxpayload, unsigned c
             int exponent = 0;
             
             for (exponent = 0; exponent < 16; ++exponent)
-    {
+            {
                 float power = (float)(1<<exponent);
         
                 if (max < power)
@@ -308,13 +306,11 @@ static int s_canIcubProtoParser_parse_pollingMsg(tCanData *rxpayload, unsigned c
 
         if (rxlen==8)
         {
-            //int  kp=((int)rxpayload->b[1])|(((int)rxpayload->b[2])<<8);
-            //int  ki=((int)rxpayload->b[3])|(((int)rxpayload->b[4])<<8);
-            //char ks=rxpayload->b[7];
+            int  kp=((int)rxpayload->b[1])|(((int)rxpayload->b[2])<<8);
+            int  ki=((int)rxpayload->b[3])|(((int)rxpayload->b[4])<<8);
+            char ks=rxpayload->b[7];
 
-            //setSPid(kp,ki,ks);
-            
-            setSPid(*(int*)(&rxpayload->b[1]),*(int*)(&rxpayload->b[3]),rxpayload->b[7]);
+            setSPid(kp,ki,ks);
             
             return 1;
         }
@@ -342,8 +338,8 @@ static int s_canIcubProtoParser_parse_pollingMsg(tCanData *rxpayload, unsigned c
                 if (max < power)
                 {
                     setSPid((int)(fkp*32768.0f/power),(int)(fki*32768.0f/power),15-exponent);
-
-        return 1;
+                    
+                    return 1;
                 }
             }
             


### PR DESCRIPTION
Fixes issue #93.

Reverted the parsing of the Kp, Ki, Ks parameters back to the a copy byte by byte.