### PR TITLE
feat/timesynch

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -74,7 +74,7 @@ extern "C" {
 //  <o> major           <0-255> 
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          31
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          32
 
 //  </h>version
 
@@ -82,13 +82,13 @@ extern "C" {
 //  <o> year            <2010-2020> 
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2020
 //  <o> month           <1-12> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          27
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
 //  <o> hour            <0-23> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         9
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          41
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          32
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMN_fun_ems4rd.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMN_fun_ems4rd.c
@@ -47,6 +47,8 @@
 
 #include "EOtheServices.h"
 
+#include "EOVtheSystem.h"
+
 
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of extern public interface
@@ -407,6 +409,39 @@ extern void eoprot_fun_UPDT_mn_appl_cmmnds_go2state(const EOnv* nv, const eOropd
         } break;        
     }
 
+}
+
+extern void eoprot_fun_UPDT_mn_appl_cmmnds_timeset(const EOnv* nv, const eOropdescriptor_t* rd) 
+{
+    eOabstime_t *timeset = (eOabstime_t *)nv->ram;
+    #warning TODO: review eoprot_fun_UPDT_mn_appl_cmmnds_timesetfill()
+    //
+    // first implementation: if the received time is not much different, then i apply it
+    eOabstime_t currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
+    int64_t delta = *timeset - currtime;
+    eObool_t apply = eobool_false;
+    if(delta > 0)
+    {
+        // we go in the future. do we go much?
+        if(delta >= eok_reltime1ms)
+        {
+            apply = eobool_true;
+        }        
+    }
+    else
+    {
+        // it is either zero or negative (we go in the past)
+        delta = -delta;
+        if(delta >= eok_reltime1ms)
+        {
+            apply = eobool_true;
+        }        
+    }
+    
+    if(eobool_true == apply)
+    {
+        eov_sys_LifeTimeSet(eov_sys_GetHandle(), *timeset);
+    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMN_fun_ems4rd.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMN_fun_ems4rd.c
@@ -415,10 +415,38 @@ extern void eoprot_fun_UPDT_mn_appl_cmmnds_timeset(const EOnv* nv, const eOropde
 {
     eOabstime_t *timeset = (eOabstime_t *)nv->ram;
     #warning TODO: review eoprot_fun_UPDT_mn_appl_cmmnds_timesetfill()
-    //
+    
     // first implementation: if the received time is not much different, then i apply it
+    
     eOabstime_t currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
     int64_t delta = *timeset - currtime;
+    
+    char str[96];
+    uint32_t sec = *timeset/(1000*1000);
+    uint32_t tmp = *timeset%(1000*1000);
+    uint32_t msec = tmp / 1000;
+    uint32_t usec = tmp % 1000;
+    uint32_t years = sec/3600/24/365;
+    char str0[64];            
+    snprintf(str0, sizeof(str0), "s%d m%d u%d", sec, msec, usec);
+    snprintf(str, sizeof(str), "RQST of time change to %s [or years = %d", str0, years);
+    eo_errman_Trace(eo_errman_GetHandle(), str, "timeset callback");  
+    
+    eOerrmanDescriptor_t descriptor = {0};
+    char msg[64] = {0};    
+    
+    descriptor.par16 = 0;
+    descriptor.par64 = currtime;
+    descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
+    descriptor.sourceaddress = 0;
+    descriptor.code = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag00);
+    snprintf(msg, sizeof(msg), "synch rqst = %lld", *timeset);
+    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, msg, NULL, &descriptor); 
+    
+    
+    //
+    // first implementation: if the received time is not much different, then i apply it
+
     eObool_t apply = eobool_false;
     if(delta > 0)
     {
@@ -442,6 +470,18 @@ extern void eoprot_fun_UPDT_mn_appl_cmmnds_timeset(const EOnv* nv, const eOropde
     {
         eov_sys_LifeTimeSet(eov_sys_GetHandle(), *timeset);
     }
+    
+    
+    currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
+    
+    descriptor.par16 = apply;
+    descriptor.par64 = currtime;
+    descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
+    descriptor.sourceaddress = 0;
+    descriptor.code = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag01);
+    snprintf(msg, sizeof(msg), "time = %lld", currtime);
+    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, msg, NULL, &descriptor); 
+              
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -163,12 +163,12 @@
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>cfg,0x0A</ItemText>
+          <ItemText>p,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>s_eo_theethmonitor,0x0A</ItemText>
+          <ItemText>*timeset,0x0A</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -192,7 +192,7 @@
         <Mm>
           <WinNumber>1</WinNumber>
           <SubType>0</SubType>
-          <ItemText>0x200109A8</ItemText>
+          <ItemText>data</ItemText>
           <AccSizeX>0</AccSizeX>
         </Mm>
       </MemoryWindow1>
@@ -2540,7 +2540,7 @@
 
   <Group>
     <GroupName>appl-services</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3548,7 +3548,7 @@
 
   <Group>
     <GroupName>embot::prot::eth</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -2925,7 +2925,7 @@
 
   <Group>
     <GroupName>eo-comm-transport</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3109,18 +3109,6 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
-    <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>117</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\ctrloop\EOtheInfoDispatcher2.c</PathWithFileName>
-      <FilenameWithoutPath>EOtheInfoDispatcher2.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
   </Group>
 
   <Group>
@@ -3131,7 +3119,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3143,7 +3131,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3155,7 +3143,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3167,7 +3155,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3179,7 +3167,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3191,7 +3179,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3203,7 +3191,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3215,7 +3203,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3227,7 +3215,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3239,7 +3227,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3251,7 +3239,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <FileNumber>127</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3263,7 +3251,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3275,7 +3263,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3287,7 +3275,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3299,7 +3287,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3311,7 +3299,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <FileNumber>132</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3331,7 +3319,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3343,7 +3331,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3355,7 +3343,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <FileNumber>135</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3367,7 +3355,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3387,7 +3375,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3399,7 +3387,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3411,7 +3399,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3431,7 +3419,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3443,7 +3431,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3455,7 +3443,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <FileNumber>142</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3467,7 +3455,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <FileNumber>143</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3479,7 +3467,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <FileNumber>144</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3491,7 +3479,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <FileNumber>145</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3511,7 +3499,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <FileNumber>146</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3523,7 +3511,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3543,7 +3531,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <FileNumber>148</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3555,7 +3543,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <FileNumber>149</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3567,7 +3555,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <FileNumber>150</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3579,7 +3567,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <FileNumber>151</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3599,7 +3587,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <FileNumber>152</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3611,7 +3599,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <FileNumber>153</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3623,7 +3611,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <FileNumber>154</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3635,7 +3623,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <FileNumber>155</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3647,7 +3635,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <FileNumber>156</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -158,7 +158,40 @@
           <Name>-UV0153FBE -O14 -S0 -C0 -N00("ARM CoreSight JTAG-DP") -D00(3BA00477) -L00(4) -N01("Unknown JTAG device") -D01(06418041) -L01(5) -TO18 -TC10000000 -TP21 -TDS8007 -TDT0 -TDC1F -TIEFFFFFFFF -TIP8 -FO7 -FD20000000 -FC800 -FN1 -FF0STM32F10x_CL -FS08000000 -FL040000</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint/>
+      <Breakpoint>
+        <Bp>
+          <Number>0</Number>
+          <Type>0</Type>
+          <LineNumber>182</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134396606</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\..\embot\cif\embot_cif_diagnostic.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\ems004\../../../../../embot/cif/embot_cif_diagnostic.cpp\182</Expression>
+        </Bp>
+        <Bp>
+          <Number>1</Number>
+          <Type>0</Type>
+          <LineNumber>192</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\eoappservices\EOtheServices.c</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
+      </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -1568,7 +1601,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3076,6 +3109,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>117</FileNumber>
+      <FileType>1</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\ctrloop\EOtheInfoDispatcher2.c</PathWithFileName>
+      <FilenameWithoutPath>EOtheInfoDispatcher2.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -3086,7 +3131,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3098,7 +3143,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3110,7 +3155,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3122,7 +3167,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3134,7 +3179,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3146,7 +3191,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3158,7 +3203,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3170,7 +3215,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3182,7 +3227,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3194,7 +3239,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>127</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3206,7 +3251,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3218,7 +3263,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3230,7 +3275,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3242,7 +3287,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3254,7 +3299,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <FileNumber>132</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3266,7 +3311,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3286,7 +3331,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3298,7 +3343,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <FileNumber>135</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3310,7 +3355,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3322,7 +3367,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3342,7 +3387,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3354,7 +3399,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3366,7 +3411,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3386,7 +3431,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3398,7 +3443,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <FileNumber>142</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3410,7 +3455,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <FileNumber>143</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3422,7 +3467,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <FileNumber>144</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3434,7 +3479,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <FileNumber>145</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3446,7 +3491,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <FileNumber>146</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3466,7 +3511,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3478,7 +3523,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <FileNumber>148</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3498,7 +3543,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <FileNumber>149</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3510,7 +3555,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <FileNumber>150</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3522,7 +3567,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <FileNumber>151</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3534,7 +3579,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <FileNumber>152</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3554,7 +3599,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <FileNumber>153</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3566,7 +3611,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <FileNumber>154</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3578,7 +3623,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <FileNumber>155</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3590,7 +3635,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <FileNumber>156</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3602,7 +3647,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <FileNumber>157</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -1102,11 +1102,6 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport\EOtheInfoDispatcher.c</FilePath>
             </File>
-            <File>
-              <FileName>EOtheInfoDispatcher2.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOtheInfoDispatcher2.c</FilePath>
-            </File>
           </Files>
         </Group>
         <Group>
@@ -2441,11 +2436,6 @@
               <FileName>EOtheInfoDispatcher.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport\EOtheInfoDispatcher.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheInfoDispatcher2.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOtheInfoDispatcher2.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -10,7 +10,7 @@
       <TargetName>ems4rd</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6130001::V6.13.1::.\ARMCLANG</pCCUsed>
+      <pCCUsed>6140000::V6.14::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -185,6 +185,7 @@
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -312,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>6</Optim>
             <oTime>1</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -336,7 +337,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DUSE_EMS4RD -DUSE_OLD_BUGGY_MODE_TO_SEND_UP_FULLSCALE_WITH_INVERTED_BYTES</MiscControls>
-              <Define></Define>
+              <Define>DIAGNOSTIC2_enabled DIAGNOSTIC2_send_to_daemon</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\libs\midware\eventviewer\api;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\embobj\plus\board\ems001;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\cfg\eoprot-callbacks;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\cfg\eoprot-boards;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\cfg\eoemsappl;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-mapping;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\board;..\..\..\..\mc4plus\appl\v2\src\eoappservices;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embot;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth</IncludePath>
             </VariousControls>
@@ -351,7 +352,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>1</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -965,7 +966,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -1399,7 +1400,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -1588,6 +1589,7 @@
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1754,7 +1756,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>1</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls>--cpreproc</MiscControls>
               <Define></Define>
@@ -2733,7 +2735,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -2761,5 +2763,20 @@
     </components>
     <files/>
   </RTE>
+
+  <LayerInfo>
+    <Layers>
+      <Layer>
+        <LayName>&lt;Project Info&gt;</LayName>
+        <LayDesc></LayDesc>
+        <LayUrl></LayUrl>
+        <LayKeys></LayKeys>
+        <LayCat></LayCat>
+        <LayLic></LayLic>
+        <LayTarg>0</LayTarg>
+        <LayPrjMark>1</LayPrjMark>
+      </Layer>
+    </Layers>
+  </LayerInfo>
 
 </Project>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -337,7 +337,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DUSE_EMS4RD -DUSE_OLD_BUGGY_MODE_TO_SEND_UP_FULLSCALE_WITH_INVERTED_BYTES</MiscControls>
-              <Define>DIAGNOSTIC2_enabled DIAGNOSTIC2_send_to_daemon</Define>
+              <Define>DIAGNOSTIC2_enabled DIAGNOSTIC2_send_to_daemon noDIAGNOSTIC2_send_to_yarprobotinterface</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\libs\midware\eventviewer\api;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\embobj\plus\board\ems001;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\cfg\eoprot-callbacks;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\cfg\eoprot-boards;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\cfg\eoemsappl;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-mapping;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\board;..\..\..\..\mc4plus\appl\v2\src\eoappservices;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embot;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth</IncludePath>
             </VariousControls>
@@ -1101,6 +1101,11 @@
               <FileName>EOtheInfoDispatcher.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport\EOtheInfoDispatcher.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheInfoDispatcher2.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOtheInfoDispatcher2.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2436,6 +2441,11 @@
               <FileName>EOtheInfoDispatcher.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport\EOtheInfoDispatcher.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheInfoDispatcher2.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOtheInfoDispatcher2.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheETHmonitor.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheETHmonitor.c
@@ -79,7 +79,7 @@
 
 #undef USE_ethmonitor_verifyTXropframe
 
-#undef TEST_ETHMON_OK_1SEC
+#define TEST_ETHMON_OK_1SEC
 
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheETHmonitor.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheETHmonitor.c
@@ -79,6 +79,8 @@
 
 #undef USE_ethmonitor_verifyTXropframe
 
+#undef TEST_ETHMON_OK_1SEC
+
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of extern variables. deprecated: better using _get(), _set() on static variables 
@@ -89,7 +91,11 @@ const eOethmonitor_cfg_t eo_ethmonitor_DefaultCfg =
     EO_INIT(.priority)      10,
     EO_INIT(.stacksize)     1024,
     EO_INIT(.taskperiod)    100*EOK_reltime1ms,
+#if defined(TEST_ETHMON_OK_1SEC)    
+    EO_INIT(.txOKperiod)    1*EOK_reltime1sec
+#else
     EO_INIT(.txOKperiod)    300*EOK_reltime1sec
+#endif    
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheETHmonitor.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheETHmonitor.c
@@ -79,7 +79,7 @@
 
 #undef USE_ethmonitor_verifyTXropframe
 
-#define TEST_ETHMON_OK_1SEC
+//#define TEST_ETHMON_OK_1SEC
 
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices.c
@@ -180,8 +180,16 @@ extern EOtheServices* eo_services_Initialise(eOipv4addr_t ipaddress)
         return(&s_eo_theservices);
     }
     EOtheServices *p = &s_eo_theservices;
-    
+          
     eo_errman_Trace(eo_errman_GetHandle(), "eo_services_Initialise() starts", s_eobj_ownname);  
+    
+    eOerrmanDescriptor_t errdes = {0};
+    errdes.code             = eoerror_code_get(eoerror_category_System, eoerror_value_SYS_bootstrapping);
+    errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+    errdes.sourceaddress    = 0;
+    errdes.par16            = 0x0000;
+    errdes.par64            = 0;
+    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, NULL, s_eobj_ownname, &errdes); 
     
     p->initted = eobool_true;
     p->nvset = eom_emstransceiver_GetNVset(eom_emstransceiver_GetHandle()); 
@@ -652,7 +660,7 @@ static void s_eo_services_initialise(EOtheServices *p)
     errdes.sourceaddress    = 0;
     errdes.par16            = 0x0000;
     errdes.par64            = 0;
-    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);     
+    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, NULL, s_eobj_ownname, &errdes);     
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -74,20 +74,20 @@ extern "C" {
 //  <o> major           <0-255> 
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          15
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          16
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2020> 
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2020
 //  <o> month           <1-12> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          27
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
 //  <o> hour            <0-23> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          36
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -76,7 +76,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          24
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          25
 
 
 //  </h>version
@@ -85,14 +85,14 @@ extern "C" {
 //  <o> year            <2010-2020> 
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2020
 //  <o> month           <1-12> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31> 
 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          27
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
 //  <o> hour            <0-23> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         9
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59> 
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          42
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          35
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/board/strain2/application/proj/strain2-application-v6.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/strain2/application/proj/strain2-application-v6.uvprojx
@@ -185,6 +185,7 @@
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -351,7 +352,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -831,7 +832,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -1023,6 +1024,7 @@
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1189,7 +1191,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -1669,7 +1671,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -1861,6 +1863,7 @@
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -2027,7 +2030,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>0</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls></MiscControls>
               <Define></Define>
@@ -2526,7 +2529,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -2555,5 +2558,20 @@
     </components>
     <files/>
   </RTE>
+
+  <LayerInfo>
+    <Layers>
+      <Layer>
+        <LayName>&lt;Project Info&gt;</LayName>
+        <LayDesc></LayDesc>
+        <LayUrl></LayUrl>
+        <LayKeys></LayKeys>
+        <LayCat></LayCat>
+        <LayLic></LayLic>
+        <LayTarg>0</LayTarg>
+        <LayPrjMark>1</LayPrjMark>
+      </Layer>
+    </Layers>
+  </LayerInfo>
 
 </Project>

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiagnostic.cpp
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiagnostic.cpp
@@ -40,6 +40,12 @@
 
 #include "lock_guard"
 
+#include "EoProtocolMN.h"
+
+#include "EOVtheSystem.h"
+
+#include "EOtheLEDpulser.h"
+
 extern void eo_diagnostic(void *p)
 {
     eom_task_Start((EOMtask*)p);
@@ -77,8 +83,10 @@ bool EOMtheEMSDiagnostic::initialise(const Params& cfg)
     eo_packet_Size_Set(txpkt_, 0); 
     
     embot::prot::eth::diagnostic::Node::Config config {}; // to be filled properly after
-    node_.init(config);    
-        
+    node_.init(config); 
+#if defined(DIAGNOSTIC2_enabled) & defined(DIAGNOSTIC2_send_to_daemon)
+    host_.init({});        
+#endif        
     // create the task
     task_ = eom_task_New(eom_mtask_EventDriven, 
                         params_.taskpriority_, 
@@ -150,6 +158,79 @@ void EOMtheEMSDiagnostic::processEventRxPacket()
     }     
 }
 
+#if defined(DIAGNOSTIC2_enabled) & defined(DIAGNOSTIC2_send_to_daemon)
+static bool callback(const embot::prot::eth::IPv4 &ipv4, const embot::prot::eth::rop::Descriptor &rop)
+{
+    if(rop.id32 == embot::prot::eth::getID32(embot::prot::eth::EP::management, embot::prot::eth::EN::mnApp, 0, eoprot_tag_mn_appl_cmmnds_timeset))
+    {
+        uint64_t *timeset = reinterpret_cast<uint64_t*>(rop.value.pointer);
+
+    eOabstime_t currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
+    int64_t delta = *timeset - currtime;
+    
+    char str[96];
+    uint32_t sec = *timeset/(1000*1000);
+    uint32_t tmp = *timeset%(1000*1000);
+    uint32_t msec = tmp / 1000;
+    uint32_t usec = tmp % 1000;
+    uint32_t years = sec/3600/24/365;
+    char str0[64];            
+    snprintf(str0, sizeof(str0), "s%d m%d u%d", sec, msec, usec);
+    snprintf(str, sizeof(str), "RQST of time change to %s [or years = %d", str0, years);
+    eo_errman_Trace(eo_errman_GetHandle(), str, "timeset cbk");  
+    
+    eOerrmanDescriptor_t descriptor = {0};
+    char msg[64] = {0};    
+    
+    snprintf(msg, sizeof(msg), "synch rqst = %lld", *timeset);
+    eo_errman_Trace(eo_errman_GetHandle(), msg, "timeset cbk"); 
+    
+    
+    //
+    // first implementation: if the received time is not much different, then i apply it
+
+    eObool_t apply = eobool_false;
+    if(delta > 0)
+    {
+        // we go in the future. do we go much?
+        if(delta >= eok_reltime1ms)
+        {
+            apply = eobool_true;
+        }        
+    }
+    else
+    {
+        // it is either zero or negative (we go in the past)
+        delta = -delta;
+        if(delta >= eok_reltime1ms)
+        {
+            apply = eobool_true;
+        }        
+    }
+    
+    if(eobool_true == apply)
+    {
+        eov_sys_LifeTimeSet(eov_sys_GetHandle(), *timeset);
+    }
+    
+    
+    currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
+    
+    snprintf(msg, sizeof(msg), "time = %lld", currtime);
+    eo_errman_Trace(eo_errman_GetHandle(), msg, "timeset cbk");    
+
+    eo_ledpulser_Start(eo_ledpulser_GetHandle(), eo_ledpulser_led_one, 100000, 10);
+        
+
+    
+        return true;        
+    }
+    
+    return false;
+}
+
+#endif 
+
 bool EOMtheEMSDiagnostic::manageArrivedMessage(EOpacket* package)
 {
     uint8_t *data = NULL;
@@ -157,6 +238,14 @@ bool EOMtheEMSDiagnostic::manageArrivedMessage(EOpacket* package)
     eo_packet_Payload_Get(rxpkt_,&data,&size);
     //TODO add RX msg code
 
+#if defined(DIAGNOSTIC2_enabled) & defined(DIAGNOSTIC2_send_to_daemon)
+    
+    const embot::prot::eth::IPv4 ipv4 {10, 0, 1, 104};
+    embot::core::Data da {data, size};
+    host_.accept(ipv4, da, callback);
+    
+#endif    
+    
     return true;
 }
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiagnostic.cpp
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiagnostic.cpp
@@ -46,6 +46,8 @@
 
 #include "EOtheLEDpulser.h"
 
+#include "EoError.h"
+
 extern void eo_diagnostic(void *p)
 {
     eom_task_Start((EOMtask*)p);
@@ -165,64 +167,51 @@ static bool callback(const embot::prot::eth::IPv4 &ipv4, const embot::prot::eth:
     {
         uint64_t *timeset = reinterpret_cast<uint64_t*>(rop.value.pointer);
 
-    eOabstime_t currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
-    int64_t delta = *timeset - currtime;
-    
-    char str[96];
-    uint32_t sec = *timeset/(1000*1000);
-    uint32_t tmp = *timeset%(1000*1000);
-    uint32_t msec = tmp / 1000;
-    uint32_t usec = tmp % 1000;
-    uint32_t years = sec/3600/24/365;
-    char str0[64];            
-    snprintf(str0, sizeof(str0), "s%d m%d u%d", sec, msec, usec);
-    snprintf(str, sizeof(str), "RQST of time change to %s [or years = %d", str0, years);
-    eo_errman_Trace(eo_errman_GetHandle(), str, "timeset cbk");  
-    
-    eOerrmanDescriptor_t descriptor = {0};
-    char msg[64] = {0};    
-    
-    snprintf(msg, sizeof(msg), "synch rqst = %lld", *timeset);
-    eo_errman_Trace(eo_errman_GetHandle(), msg, "timeset cbk"); 
-    
-    
-    //
-    // first implementation: if the received time is not much different, then i apply it
-
-    eObool_t apply = eobool_false;
-    if(delta > 0)
-    {
-        // we go in the future. do we go much?
-        if(delta >= eok_reltime1ms)
-        {
-            apply = eobool_true;
-        }        
-    }
-    else
-    {
-        // it is either zero or negative (we go in the past)
-        delta = -delta;
-        if(delta >= eok_reltime1ms)
-        {
-            apply = eobool_true;
-        }        
-    }
-    
-    if(eobool_true == apply)
-    {
-        eov_sys_LifeTimeSet(eov_sys_GetHandle(), *timeset);
-    }
-    
-    
-    currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
-    
-    snprintf(msg, sizeof(msg), "time = %lld", currtime);
-    eo_errman_Trace(eo_errman_GetHandle(), msg, "timeset cbk");    
-
-    eo_ledpulser_Start(eo_ledpulser_GetHandle(), eo_ledpulser_led_one, 100000, 10);
+        eOabstime_t currtime = eov_sys_LifeTimeGet(eov_sys_GetHandle());
+        int64_t delta = *timeset - currtime;
         
+//        char str[96];
+//        uint32_t sec = *timeset/(1000*1000);
+//        uint32_t tmp = *timeset%(1000*1000);
+//        uint32_t msec = tmp / 1000;
+//        uint32_t usec = tmp % 1000;
+//        uint32_t years = sec/3600/24/365;
+//        char str0[64];            
+//        snprintf(str0, sizeof(str0), "s%d m%d u%d", sec, msec, usec);
+//        snprintf(str, sizeof(str), "RQST of time change to %s [or years = %d", str0, years);
+//        eo_errman_Trace(eo_errman_GetHandle(), str, "timeset cbk");  
+//                 
+//        snprintf(str0, sizeof(str0), "synch rqst = %lld", *timeset);
+//        eo_errman_Trace(eo_errman_GetHandle(), str0, "timeset cbk"); 
+        
+        
+        // first implementation: if the received time is not much different, then i apply it
 
-    
+        eObool_t apply = eobool_false;
+        if(delta > 0)
+        {
+            // we go in the future. do we go much?
+            if(delta >= eok_reltime1ms)
+            {
+                apply = eobool_true;
+            }        
+        }
+        else
+        {
+            // it is either zero or negative (we go in the past)
+            delta = -delta;
+            if(delta >= eok_reltime1ms)
+            {
+                apply = eobool_true;
+            }        
+        }
+        
+        if(eobool_true == apply)
+        {
+            eov_sys_LifeTimeSet(eov_sys_GetHandle(), *timeset);
+        }
+        
+            
         return true;        
     }
     

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiagnostic.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiagnostic.h
@@ -36,6 +36,7 @@
 #include "embot_prot_eth_diagnostic.h"
 
 #include "embot_prot_eth_diagnostic_Node.h" 
+#include "embot_prot_eth_diagnostic_Host.h"
 
 class EOMtheEMSDiagnostic
 {
@@ -109,6 +110,9 @@ class EOMtheEMSDiagnostic
         static constexpr char s_eobj_ownname[]{"EOMtheEMSdiagnostic"};        
        
         embot::prot::eth::diagnostic::Node node_;
+#if defined(DIAGNOSTIC2_enabled) & defined(DIAGNOSTIC2_send_to_daemon)        
+        embot::prot::eth::diagnostic::Host host_;
+#endif        
 };
 
 #endif  // include-guard

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMStransceiver.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMStransceiver.c
@@ -166,12 +166,14 @@ extern EOMtheEMStransceiver * eom_emstransceiver_Initialise(const eOemstransceiv
     
     s_eom_emstransceiver_update_diagnosticsinfo();
     
-   
+#if defined(DIAGNOSTIC2_enabled) & !defined(DIAGNOSTIC2_send_to_yarprobotinterface)
+    #warning DIAGNOSTIC2_enabled has disabled the EOtheInfoDispatcher
+#else
     eOinfodispatcher_cfg_t config = {0};
     config.capacity     = 24; // 16 or or eo_sizecntnr_dynamic ....
     config.transmitter  = eo_transceiver_GetTransmitter(eom_emstransceiver_GetTransceiver(eom_emstransceiver_GetHandle()));
     eo_infodispatcher_Initialise(&config);    
-    
+#endif    
     
 //    char str[eomn_info_status_extra_sizeof];
 //    uint8_t *ipaddr = (uint8_t*) &cfg->hostipv4addr;
@@ -207,7 +209,11 @@ extern void eom_emstransceiver_DeInitialise(EOMtheEMStransceiver* p)
         return;
     }
     
+#if defined(DIAGNOSTIC2_enabled) & !defined(DIAGNOSTIC2_send_to_yarprobotinterface)
+    #warning DIAGNOSTIC2_enabled has disabled the EOtheInfoDispatcher
+#else    
     eo_infodispatcher_DeInitialise(eo_infodispatcher_GetHandle());
+#endif
     
     eo_boardtransceiver_DeInitialise(eo_boardtransceiver_GetHandle());
     
@@ -290,10 +296,13 @@ extern eOresult_t eom_emstransceiver_Form(EOMtheEMStransceiver* p, EOpacket** tx
         return(eores_NOK_nullpointer);
     }
 
-    
+#if defined(DIAGNOSTIC2_enabled) & !defined(DIAGNOSTIC2_send_to_yarprobotinterface)
+    #warning DIAGNOSTIC2_enabled has disabled the EOtheInfoDispatcher
+#else    
     // call the info-dispatcher so that it may insert sig<info> rops in occasional ropframe.
     eo_infodispatcher_Send(eo_infodispatcher_GetHandle(), eoinfodispatcher_sendnumber_all, NULL, &remaining);
-       
+#endif
+    
     res = eo_transceiver_outpacket_Prepare(s_emstransceiver_singleton.transceiver, &numofrops, ropsnum);
     if(eores_OK != res)
     {

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMStransceiver.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMStransceiver.c
@@ -322,7 +322,7 @@ extern eOresult_t eom_emstransceiver_Form(EOMtheEMStransceiver* p, EOpacket** tx
         res = eo_transceiver_outpacket_Get(s_emstransceiver_singleton.transceiver, txpkt);
     }
     
-    // if we have some more dignaostics to transmit, we do a new tx request.
+    // if we have some more diagnostic to transmit, we do a new tx request.
     if(remaining > 0)
     {
         eom_emsappl_SendTXRequest(eom_emsappl_GetHandle());

--- a/emBODY/eBcode/arch-arm/embot/cif/embot_cif_diagnostic.cpp
+++ b/emBODY/eBcode/arch-arm/embot/cif/embot_cif_diagnostic.cpp
@@ -91,7 +91,7 @@ extern void embot_cif_diagnostic_OnError(eOerrmanErrorType_t errtype, const char
     s_manage_dispatch(errtype, info, caller, errdes);
         
     // if fatal we manage it in a particular way
-    if(eo_errortype_error == errtype)
+    if(eo_errortype_fatal == errtype)
     {
         s_manage_fatal(info, caller, errdes);
     }


### PR DESCRIPTION
This PR is associated with a [PR](https://github.com/robotology/icub-firmware-shared/pull/38) in `icub-firmware-shared` with the same name. 

The purpose of these two joint PRs is to give to the ETH boards the possibility to synchronize their clock reference by means of suitable messages which carry the desired time in micro-seconds format. 

See the [PR](https://github.com/robotology/icub-firmware-shared/pull/38) for more details about what code is in `icub-firmware-shared`.

In `icub-firmware` there is the use of such messages by the boards `ems`, `mc4plus`, `mc2plus`.

The boards, by default, are able to decode them when they arrive to port 12345, which is the one used by `yarprobotinterface`. The produced binary has been tested to work successfully with  `yarprobotinterface` even if , so far, it does not manage the sending of these messages. 

However, by special macro definition, it is possible to produce a binary which is able to decode the messages also when they arrive on port 11000. This port can be used by any process, maybe dedicated to the synchronization task of the embedded boards.

One of such processes is the `diagnostic-daemon`, which can be always running and is able to broadcast in the ETH network to port 11000 a time synchronization beacon which uses the `set<..microsecondvalue>` message with time aligned to Linux/YARP/NTP server. Details on the `diagnostic-daemon` will soon be available.

Just after the merging of this PR and of the [PR](https://github.com/robotology/icub-firmware-shared/pull/38), I shall produce the relevant binaries `ems.hex`, `mc4plus.hex`, `mc2plus.hex` in `icub-firmware-build:devel` able to decode from port 12345 and also from port 11000.


 