### PR TITLE
fix/canframedecoding

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4/bootloader/src/main-bootloader.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/bootloader/src/main-bootloader.cpp
@@ -15,7 +15,7 @@ constexpr std::uint8_t defADDRESS = 11;
 constexpr embot::app::theCANboardInfo::bootloaderInfo btlInfo 
 { 
     embot::prot::can::Board::mtb4, 
-    embot::prot::can::versionOfBOOTLOADER {1, 6}, 
+    embot::prot::can::versionOfBOOTLOADER {1, 7}, 
     defADDRESS,                                                  
     "I am a mtb4" 
 };

--- a/emBODY/eBcode/arch-arm/board/mtb4/updaterofbootloader/src/main-updaterofbootloader.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/updaterofbootloader/src/main-updaterofbootloader.cpp
@@ -37,7 +37,7 @@ static const embot::core::relTime BlinkSlowPeriod = 500*embot::core::time1millis
 static ActivityParam activity_param = { .blinkingperiod = BlinkSlowPeriod };
 
 // use build 222 for all the updaterofbootloader
-static const embot::prot::can::versionOfAPPLICATION vAP = {1, 5 , 222};
+static const embot::prot::can::versionOfAPPLICATION vAP = {1, 6 , 222};
 static const embot::prot::can::versionOfCANPROTOCOL vCP = {2, 0};
 
 static const std::uint32_t address = embot::hw::flash::getpartition(embot::hw::FLASH::application).address;

--- a/emBODY/eBcode/arch-arm/board/psc/bootloader/src/main-bootloader.cpp
+++ b/emBODY/eBcode/arch-arm/board/psc/bootloader/src/main-bootloader.cpp
@@ -15,7 +15,7 @@ constexpr std::uint8_t defADDRESS = 1;
 constexpr embot::app::theCANboardInfo::bootloaderInfo btlInfo 
 { 
     embot::prot::can::Board::psc, 
-    embot::prot::can::versionOfBOOTLOADER {1, 5}, 
+    embot::prot::can::versionOfBOOTLOADER {1, 6}, 
     defADDRESS,                                                       
     "I am a psc" 
 };

--- a/emBODY/eBcode/arch-arm/board/rfe/bootloader/src/rfe-bootloader-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/bootloader/src/rfe-bootloader-main.cpp
@@ -15,7 +15,7 @@ constexpr std::uint8_t defADDRESS = 1;
 constexpr embot::app::theCANboardInfo::bootloaderInfo btlInfo 
 { 
     embot::prot::can::Board::rfe, 
-    embot::prot::can::versionOfBOOTLOADER {1, 7}, 
+    embot::prot::can::versionOfBOOTLOADER {1, 8}, 
     defADDRESS,                                                  
     "I am a beautiful rfe" 
 };

--- a/emBODY/eBcode/arch-arm/board/rfe/updaterofbootloader/src/rfe-updaterofbootloader-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/updaterofbootloader/src/rfe-updaterofbootloader-main.cpp
@@ -37,7 +37,7 @@ static ActivityParam activity_param = { .blinkingperiod = BlinkSlowPeriod };
 
    
 // use build 222 for all the updaterofbootloader
-static const embot::prot::can::versionOfAPPLICATION vAP = {1, 4 , 222};
+static const embot::prot::can::versionOfAPPLICATION vAP = {1, 5 , 222};
 static const embot::prot::can::versionOfCANPROTOCOL vCP = {2, 0};
 
 static const std::uint32_t address = embot::hw::flash::getpartition(embot::hw::FLASH::application).address;

--- a/emBODY/eBcode/arch-arm/board/sg3/bootloader/src/main-bootloader.cpp
+++ b/emBODY/eBcode/arch-arm/board/sg3/bootloader/src/main-bootloader.cpp
@@ -15,7 +15,7 @@ constexpr std::uint8_t defADDRESS = 12;
 constexpr embot::app::theCANboardInfo::bootloaderInfo btlInfo 
 { 
     embot::prot::can::Board::sg3, 
-    embot::prot::can::versionOfBOOTLOADER {1, 5}, 
+    embot::prot::can::versionOfBOOTLOADER {1, 6}, 
     defADDRESS,                                                  
     "I am a sg3" 
 };

--- a/emBODY/eBcode/arch-arm/board/strain2/bootloader/src/main-bootloader.cpp
+++ b/emBODY/eBcode/arch-arm/board/strain2/bootloader/src/main-bootloader.cpp
@@ -15,7 +15,7 @@ constexpr std::uint8_t defADDRESS = 13;
 constexpr embot::app::theCANboardInfo::bootloaderInfo btlInfo 
 { 
     embot::prot::can::Board::strain2, 
-    embot::prot::can::versionOfBOOTLOADER {2, 5}, 
+    embot::prot::can::versionOfBOOTLOADER {2, 6}, 
     defADDRESS,                                                  
     "I am a strain2" 
 };

--- a/emBODY/eBcode/arch-arm/board/strain2/updaterofbootloader/src/main-updaterofbootloader.cpp
+++ b/emBODY/eBcode/arch-arm/board/strain2/updaterofbootloader/src/main-updaterofbootloader.cpp
@@ -13,7 +13,7 @@
 
 constexpr embot::app::theCANboardInfo::applicationInfo appInfo 
 { 
-    embot::prot::can::versionOfAPPLICATION {2, 6 , 222}, // keep build = 222 so that we recognise it
+    embot::prot::can::versionOfAPPLICATION {2, 7, 222}, // keep build = 222 so that we recognise it
     embot::prot::can::versionOfCANPROTOCOL {2, 0} 
 };
 

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can.h
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can.h
@@ -35,7 +35,7 @@ namespace embot { namespace prot { namespace can {
         std::uint8_t        filler[3]   {0};
         std::uint8_t        data[8]     {0};  
         Frame() = default;
-        Frame(std::uint32_t i, std::uint8_t s, std::uint8_t *d) : id(i), size(std::max(s, static_cast<std::uint8_t>(8))) 
+        Frame(std::uint32_t i, std::uint8_t s, std::uint8_t *d) : id(i), size(std::min(s, static_cast<std::uint8_t>(8))) 
         {
             if(nullptr != d) { std::memmove(data, d, size); }
         }


### PR DESCRIPTION
This PR is required because of a bug on the size of the received can frame in embot-based boards (`strain2`, `mtb4`, `rfe`, `psc` and `sg3`) for which size was erroneously set always equal 8.

This bug affects only the correct decoding of the CAN message bootloader::DATA which is used by `bootloader` and `updaterofbootloader`. 

For this reason I have also released new versions for `bootloader` and `updaterofbootloader` of the above boards.