### PR TITLE
extension of embot::hw::i2c driver

### DIFF
--- a/emBODY/eBcode/arch-arm/board/nucleoh7/application/proj/nucleoh7-embot-os-application.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/nucleoh7/application/proj/nucleoh7-embot-os-application.uvoptx
@@ -152,78 +152,98 @@
         <Bp>
           <Number>0</Number>
           <Type>0</Type>
-          <LineNumber>133</LineNumber>
+          <LineNumber>498</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>135282118</Address>
+          <Address>135282734</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
           <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\embot\hw\embot_hw_ads122c04.cpp</Filename>
+          <Filename>..\..\..\..\embot\hw\embot_hw_ad7147.cpp</Filename>
           <ExecCommand></ExecCommand>
-          <Expression>\\nucleoh7\../../../../embot/hw/embot_hw_ads122c04.cpp\133</Expression>
+          <Expression>\\nucleoh7\../../../../embot/hw/embot_hw_ad7147.cpp\498</Expression>
         </Bp>
         <Bp>
           <Number>1</Number>
           <Type>0</Type>
-          <LineNumber>171</LineNumber>
+          <LineNumber>496</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134234862</Address>
+          <Address>135282698</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
           <BreakIfRCount>1</BreakIfRCount>
-          <Filename>../src/main-nucleoh7-embot-os-application.cpp</Filename>
+          <Filename>..\..\..\..\embot\hw\embot_hw_ad7147.cpp</Filename>
           <ExecCommand></ExecCommand>
-          <Expression>\\nucleoh7\../src/main-nucleoh7-embot-os-application.cpp\171</Expression>
+          <Expression>\\nucleoh7\../../../../embot/hw/embot_hw_ad7147.cpp\496</Expression>
+        </Bp>
+        <Bp>
+          <Number>2</Number>
+          <Type>0</Type>
+          <LineNumber>492</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>135282680</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\embot\hw\embot_hw_ad7147.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\nucleoh7\../../../../embot/hw/embot_hw_ad7147.cpp\492</Expression>
+        </Bp>
+        <Bp>
+          <Number>3</Number>
+          <Type>0</Type>
+          <LineNumber>622</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>135273230</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\embot\hw\embot_hw_i2c.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\nucleoh7\../../../../embot/hw/embot_hw_i2c.cpp\622</Expression>
         </Bp>
       </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>_ads_config</ItemText>
+          <ItemText>data</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>r0</ItemText>
+          <ItemText>datav</ItemText>
         </Ww>
         <Ww>
           <count>2</count>
           <WinNumber>1</WinNumber>
-          <ItemText>v1</ItemText>
+          <ItemText>content.pointer</ItemText>
         </Ww>
         <Ww>
           <count>3</count>
           <WinNumber>1</WinNumber>
-          <ItemText>acq,0x0A</ItemText>
-        </Ww>
-        <Ww>
-          <count>4</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_ready</ItemText>
-        </Ww>
-        <Ww>
-          <count>5</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_start</ItemText>
-        </Ww>
-        <Ww>
-          <count>6</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_delta,0x0A</ItemText>
-        </Ww>
-        <Ww>
-          <count>7</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_duration_of_acquisition_start,0x0A</ItemText>
+          <ItemText>s_privatedata</ItemText>
         </Ww>
       </WatchWindow1>
+      <MemoryWindow1>
+        <Mm>
+          <WinNumber>1</WinNumber>
+          <SubType>0</SubType>
+          <ItemText>content.pointer</ItemText>
+          <AccSizeX>0</AccSizeX>
+        </Mm>
+      </MemoryWindow1>
       <Tracepoint>
         <THDelay>0</THDelay>
       </Tracepoint>
@@ -278,7 +298,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -350,7 +370,7 @@
 
   <Group>
     <GroupName>embot-core</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -530,17 +550,29 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>5</GroupNumber>
+      <FileNumber>19</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\embot\hw\embot_hw_ad7147.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_ad7147.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
     <GroupName>embot-os</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -552,7 +584,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -564,7 +596,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -576,7 +608,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -588,7 +620,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -600,7 +632,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -612,7 +644,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -624,7 +656,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -644,7 +676,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -656,7 +688,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -676,7 +708,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -688,7 +720,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/nucleoh7/application/proj/nucleoh7-embot-os-application.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/nucleoh7/application/proj/nucleoh7-embot-os-application.uvprojx
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>6</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -594,6 +594,11 @@
               <FileName>embot_hw_ads122c04.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\embot\hw\embot_hw_ads122c04.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_ad7147.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\embot\hw\embot_hw_ad7147.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/nucleoh7/application/src/main-nucleoh7-embot-os-application.cpp
+++ b/emBODY/eBcode/arch-arm/board/nucleoh7/application/src/main-nucleoh7-embot-os-application.cpp
@@ -172,7 +172,6 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
         return;
     }
 
-#if 0
     if(true == embot::core::binary::mask::check(eventmask, evtAcquisition)) 
     {
 #if defined(enableTRACE_all)        
@@ -225,7 +224,6 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
 #endif        
         s_transmit();
     }
-#endif
 
 }
 
@@ -329,16 +327,16 @@ static void s_chips_init()
     embot::hw::ads122c04::Config adsconfig { embot::hw::i2c::Descriptor { embot::hw::I2C::one, i2cspeed } };
     embot::hw::ads122c04::init(embot::hw::ADS122C04::one, adsconfig);   
 
-    volatile embot::hw::result_t rr1 = embot::hw::result_t::NOK;
-    volatile embot::hw::result_t rr2 = embot::hw::result_t::NOK;
-    
-    //embot::core::delay(500*embot::core::time1millisec);
-    embot::hw::ad7147::Config skconfig { embot::hw::i2c::Descriptor { embot::hw::I2C::one, i2cspeed } };
-    rr1 = embot::hw::ad7147::init(embot::hw::AD7147::one, skconfig);
-    rr2 = embot::hw::ad7147::init(embot::hw::AD7147::two, skconfig);      
-        
-    rr1 = rr1;
-    rr2 = rr2;
+//    volatile embot::hw::result_t rr1 = embot::hw::result_t::NOK;
+//    volatile embot::hw::result_t rr2 = embot::hw::result_t::NOK;
+//    
+//    //embot::core::delay(500*embot::core::time1millisec);
+//    embot::hw::ad7147::Config skconfig { embot::hw::i2c::Descriptor { embot::hw::I2C::one, i2cspeed } };
+//    rr1 = embot::hw::ad7147::init(embot::hw::AD7147::one, skconfig);
+//    rr2 = embot::hw::ad7147::init(embot::hw::AD7147::two, skconfig);      
+//        
+//    rr1 = rr1;
+//    rr2 = rr2;
     
 #endif
     

--- a/emBODY/eBcode/arch-arm/board/nucleoh7/application/src/main-nucleoh7-embot-os-application.cpp
+++ b/emBODY/eBcode/arch-arm/board/nucleoh7/application/src/main-nucleoh7-embot-os-application.cpp
@@ -22,6 +22,9 @@
 
 #include "embot_hw_bno055.h"
 #include "embot_hw_ads122c04.h"
+#include "embot_hw_ad7147.h"
+
+#include <array>
 
 
 // macro definition. we keep some behaviours in the same code.
@@ -120,14 +123,56 @@ uint64_t timeadc_delta[2] = {0, 0};
 
 uint64_t timeadc_duration_of_acquisition_start[2] = {0, 0};
 
+#if 0
+static volatile bool IMUpinged {false};
+static volatile bool SK0pinged {false};
+static volatile bool SK1pinged {false};
+
+static volatile bool BOHpinged {false};
+
+std::array<bool, 128> pinged {false};
+volatile uint32_t cnt {0};
+
+void testi2c()
+{
+    
+    if(cnt >= 128)
+    {
+       cnt = cnt; 
+    }
+    else
+    {
+    // ping the board    
+        pinged[cnt] = embot::hw::i2c::ping(embot::hw::I2C::one, 2*cnt);        
+    }
+    // imu -> 41 (0x29)
+    // sk0 -> 44 (0x2c)
+    // sk1 -> 45 (0x2d)
+    // ads -> 64 (0x40)
+//    IMUpinged = embot::hw::i2c::ping(embot::hw::I2C::one, 0x52);
+//    SK0pinged = embot::hw::i2c::ping(embot::hw::I2C::one, 0x58);
+//    SK1pinged = embot::hw::i2c::ping(embot::hw::I2C::one, 0x5A);
+//    BOHpinged = embot::hw::i2c::ping(embot::hw::I2C::one, 0x6C);
+
+    
+//    IMUpinged = IMUpinged;
+    
+    cnt++;
+}
+
+// 0x58 (con << 1)
+// 0x5A (con << 1)
+#endif
 
 void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventmask, void *param)
-{   
+{ 
+//  testi2c();    
     if(0 == eventmask)
-    {   // timeout ...         
+    {   // timeout ...          
         return;
     }
 
+#if 0
     if(true == embot::core::binary::mask::check(eventmask, evtAcquisition)) 
     {
 #if defined(enableTRACE_all)        
@@ -179,7 +224,9 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
         embot::hw::sys::puts("evthread-onevent: evtDATAtransmit received @ time = " + tf.to_string());    
 #endif        
         s_transmit();
-    }    
+    }
+#endif
+
 }
 
 
@@ -280,7 +327,18 @@ static void s_chips_init()
 
 
     embot::hw::ads122c04::Config adsconfig { embot::hw::i2c::Descriptor { embot::hw::I2C::one, i2cspeed } };
-    embot::hw::ads122c04::init(embot::hw::ADS122C04::one, adsconfig);     
+    embot::hw::ads122c04::init(embot::hw::ADS122C04::one, adsconfig);   
+
+    volatile embot::hw::result_t rr1 = embot::hw::result_t::NOK;
+    volatile embot::hw::result_t rr2 = embot::hw::result_t::NOK;
+    
+    //embot::core::delay(500*embot::core::time1millisec);
+    embot::hw::ad7147::Config skconfig { embot::hw::i2c::Descriptor { embot::hw::I2C::one, i2cspeed } };
+    rr1 = embot::hw::ad7147::init(embot::hw::AD7147::one, skconfig);
+    rr2 = embot::hw::ad7147::init(embot::hw::AD7147::two, skconfig);      
+        
+    rr1 = rr1;
+    rr2 = rr2;
     
 #endif
     

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ad7147.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ad7147.cpp
@@ -1,0 +1,676 @@
+
+/*
+ * Copyright (C) 2020 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame, Andrea Mura
+ * email:   marco.accame@iit.it, andrea.mura@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_ad7147.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include <cstring>
+#include <vector>
+#include "stm32hal.h"
+#include "embot_hw_bsp.h"
+#include "embot_hw_bsp_config.h"
+
+using namespace std;
+
+#include "embot_core_binary.h"
+#include "embot_hw_sys.h"
+
+
+using namespace embot::hw;
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+#define ad7147_WIPmode
+
+#if defined(ad7147_WIPmode)
+#warning WIP: ad7147_WIPmode is still defined 
+#endif
+
+//#define ad7147_FAKEmode
+
+#if defined(ad7147_FAKEmode)
+#warning WIP: ad7147_FAKEmode is still defined 
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+#if !defined(EMBOT_ENABLE_hw_ad7147)
+
+namespace embot { namespace hw { namespace ad7147 {
+
+    bool supported(AD7147 s)                                                                         { return false; }
+    bool initialised(AD7147 s)                                                                       { return false; }
+    result_t init(AD7147 s, const Config &config)                                                    { return resNOK; }    
+    bool isalive(embot::hw::AD7147 s, embot::core::relTime timeout)                                  { return false; }    
+    bool isacquiring(embot::hw::AD7147 s)                                                            { return false; }    
+    bool canacquire(embot::hw::AD7147 s)                                                             { return false; }        
+    result_t acquisition(embot::hw::AD7147 s, const embot::core::Callback &oncompletion)             { return resNOK; }
+    bool operationdone(embot::hw::AD7147 s)                                                          { return false; }
+    result_t read(embot::hw::AD7147 s, Value &temp)                                                  { return resNOK; }   
+
+}}} // namespace embot { namespace hw { namespace AD7147 {
+
+
+#else
+
+namespace embot { namespace hw { namespace ad7147 {
+              
+    // initialised mask       
+    static std::uint32_t initialisedmask = 0;
+    
+    bool supported(AD7147 a)
+    {
+        return embot::hw::bsp::ad7147::getBSP().supported(a);
+    }
+    
+    bool initialised(AD7147 a)
+    {
+        return embot::core::binary::bit::check(initialisedmask, embot::core::tointegral(a));
+    }    
+      
+
+    struct Acquisition
+    {
+        static constexpr uint8_t sizeofdata = 3; // 24 bits, one sample
+        volatile bool done {false};
+        volatile bool ongoing {false};
+        //Channel channel {Channel::one};
+        Value value {};
+        std::uint8_t rxdata[sizeofdata] {0};
+        embot::core::Callback userdefCBK {};  
+        void clear() { done = false; ongoing = false; /*channel = Channel::one;*/ memset(rxdata, 0, sizeof(rxdata)); userdefCBK.clear(); }        
+        Acquisition() = default;        
+    };
+    
+    struct PrivateData
+    {
+        std::uint8_t i2caddress[embot::core::tointegral(AD7147::maxnumberof)] = {0};   
+        Config config[embot::core::tointegral(AD7147::maxnumberof)];        
+        Acquisition acquisition[embot::core::tointegral(AD7147::maxnumberof)];
+        PrivateData() = default;
+    };
+    
+    
+    
+    static PrivateData s_privatedata;
+    
+    static void sharedCBK(void *p)
+    {
+        Acquisition *acq = reinterpret_cast<Acquisition*>(p);        
+        
+#if defined(ad7147_FAKEmode)        
+        static volatile uint32_t tmp = 0;
+        tmp++;
+        acq->value = tmp;
+#else
+              
+        uint32_t tmp = (static_cast<uint32_t>(acq->rxdata[0]) << 16) + (static_cast<uint32_t>(acq->rxdata[1]) << 8) + static_cast<uint32_t>(acq->rxdata[2]);
+
+    #if defined(ad7147_WIPmode)
+    #else        
+        if(Channel::one == acq->channel)
+        {
+            acq->value = tmp;
+        }
+        else if(Channel::two == acq->channel)
+        {
+            acq->values.v2 = tmp;
+        }
+    #endif // WIP
+       
+#endif        
+        acq->ongoing = false;
+        acq->done = true;
+               
+        acq->userdefCBK.execute();
+    }
+
+#if defined(ad7147_WIPmode)
+#else    
+    // build the registers of the ADS upon embot::hw::REG<>
+
+    struct REG0 : public REG<reg08type, 3>
+    {   // [ mux:4 | gain:3 | bypass:1 ]
+        enum class FIELD : uint8_t { bypass = 0, gain = 1, mux = 2 };
+        static constexpr REG::Fields fields {1, 3, 4};
+        REG0(reg08type *mem = nullptr) : REG<reg08type, 3>(mem, &fields) {}
+            
+        static constexpr uint8_t address {0};            
+        void load(reg08type *mem) { memory = mem; }                
+        bool set(const FIELD tag, const uint8_t value) { return setfield(embot::core::tointegral(tag), value); }
+        reg08type get(const FIELD tag) { return getfield(embot::core::tointegral(tag)); }
+    };    
+    
+    struct REG1 : public REG<reg08type, 5>
+    {   // [ dr:3 | mode:1 | cm:1 | vref:2 | ts:1 ]
+        enum class FIELD : uint8_t { ts = 0, vref = 1, cm = 2, mode = 3, dr = 4 };
+        static constexpr REG::Fields fields {1, 2, 1, 1, 3};
+        REG1(reg08type *mem = nullptr) : REG<reg08type, 5>(mem, &fields) {}
+            
+        static constexpr uint8_t address {1};            
+        void load(reg08type *mem) { memory = mem; }                
+        bool set(const FIELD tag, const uint8_t value) { return setfield(embot::core::tointegral(tag), value); }
+        reg08type get(const FIELD tag) { return getfield(embot::core::tointegral(tag)); }
+    };    
+           
+    struct REG2 : public REG<reg08type, 5>
+    {   // [ drdy:1 | dcnt:1 | crc:2 | bcs:1 | idad:3 ]
+        enum class FIELD : uint8_t { idad = 0, bcs = 1, crc = 2, dcnt = 3, drdy = 4 };
+        static constexpr REG::Fields fields {3, 1, 2, 1, 1};
+        REG2(reg08type *mem = nullptr) : REG<reg08type, 5>(mem, &fields) {}
+            
+        static constexpr uint8_t address {2};            
+        void load(reg08type *mem) { memory = mem; }                
+        bool set(const FIELD tag, const uint8_t value) { return setfield(embot::core::tointegral(tag), value); }
+        reg08type get(const FIELD tag) { return getfield(embot::core::tointegral(tag)); }
+    };      
+   
+    struct REG3 : public REG<reg08type, 3>
+    {   // [ i1mux:3 | i2mux:3 | unused:2 ]
+        enum class FIELD : uint8_t { unused = 0, i2mux = 3, i1mux = 3 };
+        static constexpr REG::Fields fields {2, 3, 3};
+        REG3(reg08type *mem = nullptr) : REG<reg08type, 3>(mem, &fields) {}
+            
+        static constexpr uint8_t address {3};            
+        void load(reg08type *mem) { memory = mem; }                
+        bool set(const FIELD tag, const uint8_t value) { return setfield(embot::core::tointegral(tag), value); }
+        reg08type get(const FIELD tag) { return getfield(embot::core::tointegral(tag)); }
+    }; 
+    
+//#define AD7147_RESET         0x06
+//#define AD7147_START         0x08
+//#define AD7147_POWERDOWN     0x02
+//#define AD7147_RDATA         0x10
+//#define AD7147_RREG          0x20
+//#define AD7147_WREG          0x40
+//#define AD7147_REGISTER0     0
+//#define AD7147_REGISTER1     1
+//#define AD7147_REGISTER2     2
+//#define AD7147_REGISTER3     3
+
+// REGISTER0
+//#define AD7147_CHANNEL1          0x00        // MUX[3:0] = 0000 : AINP = AIN0, AINN = AIN1
+//#define AD7147_CHANNEL2          0x06        // MUX[3:0] = 0110 : AINP = AIN2, AINN = AIN3
+//#define AD7147_GAINx1            0x00        // GAIN[2:0]
+//#define AD7147_PGA_BYPASS_EN     0x00        // PGA enabled (default)
+//#define AD7147_PGA_BYPASS_DIS    0x01        // PGA disabled and bypassed
+
+// REGISTER1
+//#define AD7147_DR_1kSPS          0x06        // DR[2:0]
+//#define AD7147_NORMAL            0x00        // 0 : Normal mode (256-kHz modulator clock, default)
+//#define AD7147_TURBO             0x01        // 1 : Turbo mode (512-kHz modulator clock)
+//#define AD7147_SINGLESHOT        0x00        // Single-shot conversion mode
+//#define AD7147_CM                0x01        // Continuous conversion mode
+
+    
+    // use a struct to model the behaviour of the ADS
+    
+    struct chipAD7147
+    {
+        embot::hw::I2C bus { embot::hw::I2C::one};
+        embot::hw::i2c::ADR adr {0};
+        embot::core::relTime conversiontime {1040};
+        
+        enum class REG : uint8_t { zero = 0, one = 1, two = 2, three = 3 };
+        
+        enum class CMD : uint8_t { reset = 0x06, start = 0x08, powerdown = 0x02, none = 0xff };
+        
+        static constexpr std::uint8_t RDATA = 0x10;
+        static constexpr std::uint8_t RREG  = 0x20;
+        static constexpr std::uint8_t WREG  = 0x40;
+        static constexpr std::uint8_t CHANNEL1 = 0x00;
+        static constexpr std::uint8_t CHANNEL2 = 0x06;
+        static constexpr std::uint8_t DR_1kSPS = 0x06;
+        static constexpr std::uint8_t CM_SINGLESHOT = 0x00;
+        
+        // direct access to registers w/ set() / get()
+        REG0 r0 {&memory[0]};
+        REG1 r1 {&memory[1]};
+        REG2 r2 {&memory[2]};
+        REG3 r3 {&memory[3]};
+        
+        
+        uint8_t memory[4] {0};  
+        
+        chipAD7147() = default; 
+
+        void setaddress(embot::hw::I2C b, embot::hw::i2c::ADR a)
+        {
+            bus = b;
+            adr = a;            
+        }
+        
+        result_t writeregister(REG r, embot::core::relTime timeout = 3*embot::core::time1millisec)
+        {
+            uint8_t regWrite[2] = {0};
+            regWrite[0] = WREG + (embot::core::tointegral(r)<<2);
+            regWrite[1] = memory[embot::core::tointegral(r)];
+            return embot::hw::i2c::transmit(bus, adr, {&regWrite, 2}, timeout);
+        } 
+        
+        result_t readregister(REG r, embot::core::relTime timeout = 3*embot::core::time1millisec)
+        {
+            embot::hw::i2c::REG reg = RREG + (embot::core::tointegral(r)<<2);
+            embot::core::Data dest = {&memory[embot::core::tointegral(r)], 1};
+            return embot::hw::i2c::read(bus, adr, reg, dest, timeout);
+        }  
+                
+        result_t readeveryregister(embot::core::relTime timeout = 12*embot::core::time1millisec)
+        {
+            result_t res = readregister(REG::zero, timeout/4);
+            
+            if(result_t::OK == res)
+                res = readregister(REG::one, timeout/4);
+            if(result_t::OK == res)
+                res = readregister(REG::two, timeout/4);
+            if(result_t::OK == res)
+                res = readregister(REG::three, timeout/4);
+            
+            return res;
+        } 
+
+        result_t sendcommand(CMD cmd, embot::core::relTime timeout = 3*embot::core::time1millisec)
+        {
+            volatile result_t res = result_t::NOK;     
+            volatile uint8_t v1 = 0;        
+            // 1. reset
+            uint8_t command {embot::core::tointegral(CMD::none)}; 
+            embot::core::relTime delay = 0;
+            switch(cmd)
+            {
+                case CMD::reset:
+                {
+                    delay = embot::core::time1millisec;
+                    command = embot::core::tointegral(CMD::reset);
+                } break;
+                
+                case CMD::start:
+                {
+                    delay = 0;
+                    command = embot::core::tointegral(CMD::start);
+                } break;
+                            
+                default:
+                {                    
+                } break;
+            }
+            
+            if(255 != command)
+            {
+                res = embot::hw::i2c::transmit(bus, adr, {&command, 1}, timeout);
+                if(delay > 0)
+                {
+                    embot::hw::sys::delay(delay);  
+                }
+            }            
+
+            return res;                        
+        }
+        
+        result_t setchannel(Channel chn, embot::core::relTime timeout = 3*embot::core::time1millisec)
+        {
+            result_t res = result_t::NOK;
+            volatile uint8_t v1 = 0;
+            r0.set(REG0::FIELD::mux, (Channel::one == chn) ? CHANNEL1 : CHANNEL2);
+            v1 = r0.get(REG0::FIELD::mux);
+            res = writeregister(chipAD7147::REG::zero, timeout);                
+            return res;
+        }
+        
+        enum class CFG : uint8_t { normal = 0, turbo = 1  };
+        result_t sendconfig(CFG cfg, embot::core::relTime timeout = 3*embot::core::time1millisec)
+        {
+            switch(cfg)
+            {
+                default:
+                case CFG::normal:
+                {
+                    r1.set(REG1::FIELD::cm, CM_SINGLESHOT);
+                    // normal mode @ 1000 sps
+                    r1.set(REG1::FIELD::mode, 0); 
+                    r1.set(REG1::FIELD::dr, DR_1kSPS);                
+                    conversiontime = 1040; // see datasheet page 28 (8.3.6 Conversion Times)                   
+                } break;
+
+                case CFG::turbo:
+                {
+                    r1.set(REG1::FIELD::cm, CM_SINGLESHOT);
+                    // turbo mode @ 2000 sps
+                    r1.set(REG1::FIELD::mode, 1); 
+                    r1.set(REG1::FIELD::dr, DR_1kSPS);
+                    conversiontime = 520;  // see datasheet page 28 (8.3.6 Conversion Times)                   
+                } break;
+            }
+
+            return writeregister(chipAD7147::REG::one, timeout);
+        }
+
+/*
+8.4.3.2 Turbo Mode
+Applications that require higher data rates up to 2 kSPS can operate the device in turbo mode. In this mode, the
+internal modulator runs at a higher frequency of fMOD = fCLK / 4 = 512 kHz. Compared to normal mode, the device
+power consumption increases because the modulator runs at a higher frequency. Running the AD7147 in
+turbo mode at a comparable output data rate as in normal mode yields better noise performance. For example,
+the input-referred noise at 90 SPS in turbo mode is lower than the input-referred noise at 90 SPS in normal
+mode.                
+*/
+        enum class SPS : uint8_t { twothousand = 6, onethousandtwohundred = 5, sixhundredsixty = 4, threehundredfifty = 3 };
+        enum class GAIN : uint8_t { one = 0, two = 1, four = 2, eigth = 3, sixteen = 4, thirtytwo = 5, sixtyfour = 6, onehundredtwentyeigth = 7 };
+        result_t configure(SPS sps, GAIN gain, embot::core::relTime timeout = 3*embot::core::time1millisec)
+        {
+            static constexpr embot::core::relTime LUTconversiontimesturbo[] = 
+            {   // as indexed by valure of register DR. see see datasheet page 28 (8.3.6 Conversion Times) and page 41 (8.6.2 Register Descriptions)
+                25010, 11140, 5650, 2900, 1540, 860, 520 
+            };
+            
+            // single shot, always turbo mode
+            r1.set(REG1::FIELD::cm, CM_SINGLESHOT);
+            r1.set(REG1::FIELD::mode, 1);
+            
+            // the values of GAIN and SPS are already the values of the related registers ...
+            r0.set(REG0::FIELD::gain, embot::core::tointegral(gain));
+            r1.set(REG1::FIELD::dr, embot::core::tointegral(sps));
+            conversiontime = LUTconversiontimesturbo[embot::core::tointegral(sps)];
+            
+            // now i write the registers
+            result_t r = writeregister(chipAD7147::REG::zero, timeout);
+            if(result_t::OK != r)
+            {
+                return r;
+            }
+            return writeregister(chipAD7147::REG::one, timeout);
+        }  
+        
+        // blocking mode
+        result_t startconversion()
+        {
+            return sendcommand(chipAD7147::CMD::start); 
+        }
+        
+        // after startconversion() we must wait for some time that the conversion is effectively done
+        embot::core::relTime getConversionTime() const
+        {
+            return conversiontime;
+        }   
+        
+        // non blocking mode: at end it puts results inside data and execute the callback
+        result_t retrievevalue(embot::core::Data &destination, const embot::core::Callback &oncompletion)
+        {
+            return embot::hw::i2c::read(bus, adr, chipAD7147::RDATA, destination, oncompletion);
+        }
+        
+
+
+    }; 
+
+
+    // in future, if multiple chips are required: do it a array and put it into s_privatedata;
+    chipAD7147 _ads_chip;
+
+#endif //WIP   
+
+volatile uint16_t datav {0};
+              
+    result_t init(AD7147 s, const Config &config)
+    {
+        if(false == supported(s))
+        {
+            return resNOK;
+        }
+        
+        if(true == initialised(s))
+        {
+            return resOK;
+        }
+        
+        // init peripheral
+        embot::hw::bsp::ad7147::getBSP().init(s);
+        
+        std::uint8_t index = embot::core::tointegral(s);
+        
+#if defined(ad7147_FAKEmode)
+#else        
+                
+        // init i2c ..
+        embot::hw::i2c::init(config.i2cdes.bus, config.i2cdes.config);
+        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::ad7147::getBSP().getPROP(s)->i2caddress))
+        {
+            return resNOK;
+        }
+                       
+#endif        
+        s_privatedata.i2caddress[index] = embot::hw::bsp::ad7147::getBSP().getPROP(s)->i2caddress;
+        s_privatedata.config[index] = config;
+        s_privatedata.acquisition[index].clear();
+        
+        // ora leggo il Device ID Register in address 0x017
+        
+        // devo usae registri a due bytes.
+        uint8_t data[2] {0};
+        embot::core::Data dest = {data, 2};
+        
+        // read Device ID Register 0x017
+        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x017, dest, 10*1000);
+        
+        // ok but in big endian. data[0] contains the msb and data[1] contains the lsb.
+        // data[0] = 0x14 dat[1] = 0x71 and the correct value is [14:4] [3:0] -> 0x 147 1
+        datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
+        datav = datav;
+        
+        // read default value of AMB_COMP_CTRL0 Register 0x002
+        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, dest, 10*1000);
+        datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
+        datav = datav;
+        // i read data[0] = 0x0f data[1] = 0xf0
+        // default values must be from 15->00: 0x 0 f f 0
+        
+        // write AMB_COMP_CTRL0 with 
+        uint8_t txdata[2] = {0};
+        txdata[0] = 0x3e;   // nibble 3 is: bits 13:12 PWR_DOWN_TIMEOUT, nibble 0 is the bit 15 (CONV_RESET) and 16 (FORCED_CAL)
+                            // nibble e is: bits 11:8 LP_PROXIMITY_CNT
+        txdata[1] = 0xa1;   // nibble a is: bits 7:4 FP_PROXIMITY_CNT
+                            // nibble 1 is: bits 3:0 FF_SKIP_CNT 
+        embot::core::Data content = {txdata, 2};
+        embot::hw::i2c::write16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, content, 10*1000);
+        
+        
+        // read back the value of AMB_COMP_CTRL0 Register 0x002
+        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, dest, 10*1000);
+        datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
+        datav = datav;        
+
+        // read default value of AMB_COMP_CTRL1 Register 0x003
+        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x003, dest, 10*1000);
+        datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
+        datav = datav;
+        // i read data[0] = 0x01 data[1] = 0x64
+        // default values must be from 15->00: 0x 0 1 6 4
+     
+        // read default value of AMB_COMP_CTRL2 Register 0x004
+        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x004, dest, 10*1000);
+        datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
+        datav = datav;
+        // i read data[0] = 0x01 data[1] = 0x64
+        // default values must be from 15->00: 0x f f f f        
+
+#if defined(ad7147_WIPmode)
+#else    
+        // we need to perform chip initialization
+        
+        _ads_chip.setaddress(config.i2cdes.bus, embot::hw::bsp::ad7147::getBSP().getPROP(s)->i2caddress);
+        
+        volatile result_t res = result_t::NOK;     
+        // 1. reset
+        _ads_chip.sendcommand(chipAD7147::CMD::reset);
+        
+        // 2. configure registers                 
+        res = _ads_chip.configure(chipAD7147::SPS::threehundredfifty, chipAD7147::GAIN::onehundredtwentyeigth, 3*embot::core::time1millisec);
+       
+//        // 3. sanity check: reading back the config registers.
+//        memset(_ads_chip.memory, 0, sizeof(_ads_chip.memory));
+//        res = _ads_chip.readeveryregister();
+//        volatile uint8_t v1 = _ads_chip.r1.get(REG1::FIELD::dr);
+//        v1 = v1;   
+
+#endif // WIP
+     
+   
+        embot::core::binary::bit::set(initialisedmask, embot::core::tointegral(s));
+                
+        return resOK;
+    }
+
+    
+    bool isacquiring(AD7147 s)
+    {
+        if(false == initialised(s))
+        {
+            return false;
+        } 
+
+        std::uint8_t index = embot::core::tointegral(s);        
+        return s_privatedata.acquisition[index].ongoing;     
+    }
+    
+    
+    bool canacquire(AD7147 s)
+    {
+        if(false == initialised(s))
+        {
+            return false;
+        } 
+
+        std::uint8_t index = embot::core::tointegral(s);  
+        
+        if(true == s_privatedata.acquisition[index].ongoing)
+        {
+            return false;
+        }
+#if defined(ad7147_FAKEmode)
+        return true;
+#else         
+        return !embot::hw::i2c::isbusy(s_privatedata.config[index].i2cdes.bus);  
+#endif        
+    }    
+    
+    result_t acquisition(AD7147 s, const embot::core::Callback &oncompletion)
+    {
+        if(false == canacquire(s))
+        {
+            return resNOK;
+        }
+        
+        std::uint8_t index = embot::core::tointegral(s);  
+        
+        // set channel
+        volatile result_t res = result_t::NOK;
+
+#if defined(ad7147_WIPmode)
+#else 
+        // the following two operations are in blocking mode ... ahi! and take about 200 usec in total.
+        // think of a non blocking mode.
+        //#warning ADS122: think of a non-blocking acquisition start mode
+        res = _ads_chip.setchannel(channel, 3*embot::core::time1millisec); 
+        //embot::hw::sys::delay(50);
+        // start the conversion        
+        res = _ads_chip.startconversion(); 
+        // we must wait for the conversion to be done
+        embot::hw::sys::delay(_ads_chip.getConversionTime()); 
+#endif // WIP   
+               
+        s_privatedata.acquisition[index].clear();
+        s_privatedata.acquisition[index].ongoing = true;
+        s_privatedata.acquisition[index].done = false;
+//        s_privatedata.acquisition[index].channel = channel;
+        s_privatedata.acquisition[index].userdefCBK = oncompletion;
+      
+
+#if defined(ad7147_FAKEmode)
+        embot::core::Callback cbk(sharedCBK, &s_privatedata.acquisition[index]);
+        cbk.execute();
+#else         
+        // ok, now i trigger the reading of the value.
+        embot::core::Callback cbk(sharedCBK, &s_privatedata.acquisition[index]);
+        embot::core::Data data = embot::core::Data(&s_privatedata.acquisition[index].rxdata[0], sizeof(s_privatedata.acquisition[index].rxdata));
+//        _ads_chip.retrievevalue(data, cbk);
+#endif                
+        return resOK;
+    }
+    
+    bool isalive(AD7147 s, embot::core::relTime timeout)
+    {
+        if(false == initialised(s))
+        {
+            return false;
+        } 
+#if defined(ad7147_FAKEmode)
+        return true;
+#else 
+        std::uint8_t index = embot::core::tointegral(s);
+        return embot::hw::i2c::ping(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], timeout);  
+#endif
+    }
+
+    
+    bool operationdone(AD7147 s)
+    {
+        if(false == initialised(s))
+        {
+            return false;
+        } 
+
+        return s_privatedata.acquisition[embot::core::tointegral(s)].done;        
+    } 
+    
+    
+    result_t read(AD7147 s, Value &val)
+    {
+        if(false == initialised(s))
+        {
+            return resNOK;
+        } 
+
+        if(false == operationdone(s))
+        {
+            return resNOK;
+        }
+        
+        std::uint8_t index = embot::core::tointegral(s);
+        val = s_privatedata.acquisition[index].value;
+        //val = s_privatedata.acquisition[index].values.v2;
+  
+        return resOK;        
+    }
+    
+ 
+}}} // namespace embot { namespace hw { namespace ad7147 {
+
+
+
+#endif //defined(EMBOT_AD7147_ENABLED)
+
+
+    
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ad7147.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ad7147.cpp
@@ -451,7 +451,7 @@ volatile uint16_t datav {0};
                 
         // init i2c ..
         embot::hw::i2c::init(config.i2cdes.bus, config.i2cdes.config);
-        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::ad7147::getBSP().getPROP(s)->i2caddress))
+        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::ad7147::getBSP().getPROP(s)->i2caddress, 3*embot::core::time1millisec))
         {
             return resNOK;
         }
@@ -463,12 +463,19 @@ volatile uint16_t datav {0};
         
         // ora leggo il Device ID Register in address 0x017
         
-        // devo usae registri a due bytes.
+        // devo usare registri a due bytes.
+        embot::hw::i2c::Reg reg_DeviceID {0x017, embot::hw::i2c::Reg::Size::sixteenbits};
+        embot::hw::i2c::Reg reg_AMB_COMP_CTRL0 {0x002, embot::hw::i2c::Reg::Size::sixteenbits};
+        embot::hw::i2c::Reg reg_AMB_COMP_CTRL1 {0x003, embot::hw::i2c::Reg::Size::sixteenbits};
+        embot::hw::i2c::Reg reg_AMB_COMP_CTRL2 {0x004, embot::hw::i2c::Reg::Size::sixteenbits};
+        
         uint8_t data[2] {0};
         embot::core::Data dest = {data, 2};
         
         // read Device ID Register 0x017
-        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x017, dest, 10*1000);
+        embot::hw::i2c::read(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_DeviceID, dest, 10*1000);
+        //embot::hw::i2c::read(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_DeviceID, dest, embot::core::Callback{});
+        //embot::core::delay(10*1000);
         
         // ok but in big endian. data[0] contains the msb and data[1] contains the lsb.
         // data[0] = 0x14 dat[1] = 0x71 and the correct value is [14:4] [3:0] -> 0x 147 1
@@ -476,7 +483,7 @@ volatile uint16_t datav {0};
         datav = datav;
         
         // read default value of AMB_COMP_CTRL0 Register 0x002
-        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, dest, 10*1000);
+        embot::hw::i2c::read(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_AMB_COMP_CTRL0, dest, 10*1000);
         datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
         datav = datav;
         // i read data[0] = 0x0f data[1] = 0xf0
@@ -489,23 +496,24 @@ volatile uint16_t datav {0};
         txdata[1] = 0xa1;   // nibble a is: bits 7:4 FP_PROXIMITY_CNT
                             // nibble 1 is: bits 3:0 FF_SKIP_CNT 
         embot::core::Data content = {txdata, 2};
-        embot::hw::i2c::write16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, content, 10*1000);
+        embot::hw::i2c::write(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_AMB_COMP_CTRL0, content, 10*1000);
+        //embot::hw::i2c::write16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, content, 10*1000);
         
         
         // read back the value of AMB_COMP_CTRL0 Register 0x002
-        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x002, dest, 10*1000);
+        embot::hw::i2c::read(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_AMB_COMP_CTRL0, dest, 10*1000);
         datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
         datav = datav;        
 
         // read default value of AMB_COMP_CTRL1 Register 0x003
-        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x003, dest, 10*1000);
+        embot::hw::i2c::read(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_AMB_COMP_CTRL1, dest, 10*1000);
         datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
         datav = datav;
         // i read data[0] = 0x01 data[1] = 0x64
         // default values must be from 15->00: 0x 0 1 6 4
      
         // read default value of AMB_COMP_CTRL2 Register 0x004
-        embot::hw::i2c::read16(config.i2cdes.bus, s_privatedata.i2caddress[index], 0x004, dest, 10*1000);
+        embot::hw::i2c::read(config.i2cdes.bus, s_privatedata.i2caddress[index], reg_AMB_COMP_CTRL2, dest, 10*1000);
         datav = data[1] + (static_cast<uint16_t>(data[0]) << 8);
         datav = datav;
         // i read data[0] = 0x01 data[1] = 0x64

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ad7147.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ad7147.h
@@ -1,0 +1,71 @@
+
+/*
+ * Copyright (C) 2020 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef _EMBOT_HW_AD7147_H_
+#define _EMBOT_HW_AD7147_H_
+
+#include "embot_core.h"
+#include "embot_hw_types.h"
+
+
+#include "embot_hw_i2c.h"
+
+    
+namespace embot { namespace hw { namespace ad7147 {
+         
+        
+    struct Config
+    {   // each sensor may use different i2c addresses, hence they can share teh same i2c bus
+        embot::hw::i2c::Descriptor i2cdes {};        
+        constexpr Config(embot::hw::I2C b, std::uint32_t s) : i2cdes(b, s) {}        
+        constexpr Config() : i2cdes(embot::hw::I2C::one, 400000) {}
+        constexpr Config(const embot::hw::i2c::Descriptor &des) : i2cdes(des) {}
+    };
+    
+    
+    using Value = std::uint32_t; 
+    
+    
+    bool supported(embot::hw::AD7147 s);
+    
+    bool initialised(embot::hw::AD7147 s);
+    
+    result_t init(embot::hw::AD7147 s, const Config &config);
+        
+    
+    // after that init() returns resOK we can check if it is alive. we can specify a timeout
+    bool isalive(embot::hw::AD7147 s, embot::core::relTime timeout = 3*embot::core::time1millisec);
+    
+    // we must check that nobody is using the sensor, maybe in non-blocking mode some time earlier
+    bool isacquiring(embot::hw::AD7147 s);
+    
+    // we check isacquiring() but also if any other device is using i2c bus
+    bool canacquire(embot::hw::AD7147 s);    
+    
+    
+    // we start acquisition
+    // if returns resOK, we know that acquisition is over if it is called oncompletion() or when operationdone() is true;
+    result_t acquisition(embot::hw::AD7147 s, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
+
+    // it tells if a previous operation of acquisition is over
+    bool operationdone(embot::hw::AD7147 s);
+    
+    // ok, now we can read temperature previously acquired
+    result_t read(embot::hw::AD7147 s, Value &value);   
+
+ 
+}}} // namespace embot { namespace hw { namespace ad7147 {
+    
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ads122c04.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_ads122c04.cpp
@@ -253,14 +253,14 @@ namespace embot { namespace hw { namespace ads122c04 {
             uint8_t regWrite[2] = {0};
             regWrite[0] = WREG + (embot::core::tointegral(r)<<2);
             regWrite[1] = memory[embot::core::tointegral(r)];
-            return embot::hw::i2c::transmit(bus, adr, {&regWrite, 2}, timeout);
+            return embot::hw::i2c::tx(bus, adr, {&regWrite, 2}, timeout);
         } 
         
         result_t readregister(REG r, embot::core::relTime timeout = 3*embot::core::time1millisec)
         {
-            embot::hw::i2c::REG reg = RREG + (embot::core::tointegral(r)<<2);
+            uint8_t reg = RREG + (embot::core::tointegral(r)<<2);
             embot::core::Data dest = {&memory[embot::core::tointegral(r)], 1};
-            return embot::hw::i2c::read(bus, adr, reg, dest, timeout);
+            return embot::hw::i2c::read(bus, adr, {reg, embot::hw::i2c::Reg::Size::eightbits}, dest, timeout);
         }  
                 
         result_t readeveryregister(embot::core::relTime timeout = 12*embot::core::time1millisec)
@@ -305,7 +305,7 @@ namespace embot { namespace hw { namespace ads122c04 {
             
             if(255 != command)
             {
-                res = embot::hw::i2c::transmit(bus, adr, {&command, 1}, timeout);
+                res = embot::hw::i2c::tx(bus, adr, {&command, 1}, timeout);
                 if(delay > 0)
                 {
                     embot::hw::sys::delay(delay);  
@@ -438,7 +438,7 @@ mode.
                 
         // init i2c ..
         embot::hw::i2c::init(config.i2cdes.bus, config.i2cdes.config);
-        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::ads122c04::getBSP().getPROP(s)->i2caddress))
+        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::ads122c04::getBSP().getPROP(s)->i2caddress, 3*embot::core::time1millisec))
         {
             return resNOK;
         }

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.cpp
@@ -2403,7 +2403,63 @@ namespace embot { namespace hw { namespace bsp { namespace ads122c04 {
 
 #endif // ads122c04
 
-// - support map: end of embot::hw::ads122c04
+// - support map: begin of embot::hw::ad7147
+
+namespace embot { namespace hw { namespace bsp { namespace ad7147 {
+           
+    static_assert(embot::core::tointegral(embot::hw::AD7147::none) < 8*sizeof(SUPP::supportedmask), "AD7147::none must be less than 32 to be able to address a std::uint32_t mask");
+    static_assert(embot::core::tointegral(embot::hw::AD7147::maxnumberof) < 8*sizeof(SUPP::supportedmask), "AD7147::maxnumberof must be less than 32 to be able to address a std::uint32_t mask");
+    static_assert(embot::core::tointegral(embot::hw::AD7147::maxnumberof) < embot::core::tointegral(embot::hw::AD7147::none), "AD7147::maxnumberof must be higher that AD7147::none, so that we can optimise code");
+
+}}}}
+
+#if   !defined(HAL_I2C_MODULE_ENABLED) || !defined(EMBOT_ENABLE_hw_ad7147)
+
+namespace embot { namespace hw { namespace bsp { namespace ad7147 {
+    
+    constexpr BSP thebsp { };
+    void BSP::init(embot::hw::AD7147 h) const {}    
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }
+    
+}}}}
+
+#else
+
+namespace embot { namespace hw { namespace bsp { namespace ad7147 {
+           
+    #if defined(STM32HAL_BOARD_NUCLEOH7)
+        
+    constexpr PROP prop01 { .i2cbus = embot::hw::I2C::one, .i2caddress = 0x58 }; 
+    constexpr PROP prop02 { .i2cbus = embot::hw::I2C::one, .i2caddress = 0x5A }; 
+
+    constexpr BSP thebsp {        
+        // maskofsupported
+        mask::pos2mask<uint32_t>(AD7147::one) | mask::pos2mask<uint32_t>(AD7147::two),        
+        // properties
+        {{
+            &prop01, &prop02
+        }}        
+    };
+
+    void BSP::init(embot::hw::AD7147 h) const {}
+
+    #else
+        #error embot::hw::bsp::ad7147::thebsp must be defined    
+    #endif
+    
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }
+              
+}}}} // namespace embot { namespace hw { namespace bsp {  namespace ad7147 {
+
+#endif // ad7147
+
+// - support map: end of embot::hw::ad7147
 
 
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.h
@@ -485,6 +485,31 @@ namespace embot { namespace hw { namespace bsp { namespace ads122c04 {
               
 }}}} // namespace embot { namespace hw { namespace bsp {  namespace ads122c04 {
 
+
+namespace embot { namespace hw { namespace bsp { namespace ad7147 {
+       
+    struct PROP
+    {   
+        embot::hw::I2C i2cbus;
+        std::uint8_t i2caddress;        
+    };
+    
+    struct BSP : public embot::hw::bsp::SUPP
+    {
+        constexpr static std::uint8_t maxnumberof = embot::core::tointegral(embot::hw::AD7147::maxnumberof);
+        constexpr BSP(std::uint32_t msk, std::array<const PROP*, maxnumberof> pro) : SUPP(msk), properties(pro) {} 
+        constexpr BSP() : SUPP(0), properties({0}) {}
+            
+        std::array<const PROP*, maxnumberof> properties;    
+        constexpr const PROP * getPROP(embot::hw::AD7147 h) const { return supported(h) ? properties[embot::core::tointegral(h)] : nullptr; }
+        void init(embot::hw::AD7147 h) const;
+    };
+    
+    const BSP& getBSP();
+              
+}}}} // namespace embot { namespace hw { namespace bsp {  namespace ad7147 {
+
+
 #endif  // include-guard
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp_config.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp_config.h
@@ -102,6 +102,7 @@
     #define EMBOT_ENABLE_hw_i2c
     #define EMBOT_ENABLE_hw_bno055
     #define EMBOT_ENABLE_hw_ads122c04 
+    #define EMBOT_ENABLE_hw_ad7147
 #endif
 
 #elif   defined(STM32HAL_BOARD_STM32G4EVAL)

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_i2c.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_i2c.cpp
@@ -61,25 +61,68 @@ namespace embot { namespace hw { namespace i2c {
     bool initialised(I2C b)                                                                         { return false; }
     result_t init(I2C b, const Config &config)                                                      { return resNOK; }
           
-    bool isbusy(embot::hw::I2C b) { return false; }   
-    bool isbusy(embot::hw::I2C b, embot::core::relTime timeout, embot::core::relTime &remaining) { return false; }   
-    
+    // blocking   
+    bool isbusy(embot::hw::I2C b, embot::core::relTime timeout, embot::core::relTime &remaining) { return false; }      
     bool ping(embot::hw::I2C b, ADR adr, embot::core::relTime timeout) { return false; }   
-    result_t transmit(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout) { return resNOK; }           
-    result_t read(embot::hw::I2C b, ADR adr, REG reg, embot::core::Data &destination, const embot::core::Callback &oncompletion) { return resNOK; }     
-    result_t read(embot::hw::I2C b, ADR adr, REG reg, embot::core::Data &destination, embot::core::relTime timeout) { return resNOK; } 
-    result_t write(embot::hw::I2C b, ADR adr, REG reg, const embot::core::Data &content, const embot::core::Callback &oncompletion) { return resNOK; } 
-    result_t write(embot::hw::I2C b, ADR adr, REG reg, const embot::core::Data &content, embot::core::relTime timeout) { return resNOK; }         
+    result_t read(embot::hw::I2C b, ADR adr, Reg reg, embot::core::Data &destination, embot::core::relTime timeout) { return resNOK; } 
+    result_t write(embot::hw::I2C b, ADR adr, Reg reg, const embot::core::Data &content, embot::core::relTime timeout) { return resNOK; }     
+    result_t receive(embot::hw::I2C b, ADR adr, embot::core::Data &destination, embot::core::relTime timeout) { return resNOK; }  
+    result_t transmit(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout) { return resNOK; } 
+    result_t transmitzeroaddress(embot::hw::I2C b, embot::core::relTime timeout) { return resNOK; }   
+         
+    // non blocking
+    bool isbusy(embot::hw::I2C b) { return false; }
+    result_t read(embot::hw::I2C b, ADR adr, Reg reg, embot::core::Data &destination, const embot::core::Callback &oncompletion) { return resNOK; }         
+    result_t write(embot::hw::I2C b, ADR adr, Reg reg, const embot::core::Data &content, const embot::core::Callback &oncompletion) { return resNOK; }     
+    result_t receive(embot::hw::I2C b, ADR adr, embot::core::Data &destination, const embot::core::Callback &oncompletion) { return resNOK; } 
+    result_t transmit(I2C b, ADR adr, const embot::core::Data &content, const embot::core::Callback &oncompletion) { return resNOK; }
 
 }}} // namespace embot { namespace hw { namespace i2c {
 
 #else
 
 namespace embot { namespace hw { namespace i2c {
+    
+    // types
+    struct Transaction
+    {
+        volatile bool ongoing;
+        static constexpr uint8_t txbuffercapacity = 16;
+        ADR addr;
+        embot::core::Data recdata;
+        std::uint8_t txbuffer[txbuffercapacity];
+        std::uint8_t txbuffersize;
+        embot::core::Callback oncompletion;
+        void clear() { ongoing = false; addr = 0; recdata.clear(); oncompletion.clear(); std::memset(txbuffer, 0, sizeof(txbuffer)); txbuffersize = 0;}    
+        Transaction () { clear(); }        
+    };
         
+    struct PrivateData
+    {    
+        Config config[embot::core::tointegral(I2C::maxnumberof)];  
+        Transaction  transaction[embot::core::tointegral(I2C::maxnumberof)]; 
+        I2C_HandleTypeDef* handles[embot::core::tointegral(I2C::maxnumberof)];           
+        PrivateData() { }
+    };
+    
+    // utility functions
+    
       
+    static result_t s_wait_for_transaction_completion(I2C b, embot::core::relTime timeout);   
+    static result_t s_DMA_write_transaction_start(I2C b, ADR adr, Reg reg, const embot::core::Data &content, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
+    static result_t s_DMA_read_transaction_start(I2C b, ADR adr, Reg reg, embot::core::Data &destination, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));        
+    
+    void ontransactionterminated(std::uint8_t index);  
+    
+    
+    
+    // internal variables
+    static PrivateData s_privatedata;
+              
     // initialised mask       
     static std::uint32_t initialisedmask = 0;
+    
+    // the public functions
     
     bool supported(embot::hw::I2C p)
     {
@@ -90,44 +133,7 @@ namespace embot { namespace hw { namespace i2c {
     {
         return embot::core::binary::bit::check(initialisedmask, embot::core::tointegral(p));
     }    
- 
-     
-    struct Transaction
-    {
-        volatile bool ongoing;
-        static constexpr uint8_t txbuffercapacity = 16;
-        ADR addr;
-        embot::core::Data recdata;
-        std::uint8_t txbuffer[txbuffercapacity];
-        std::uint8_t txbuffersize;
-        embot::core::Callback oncompletion;
-        void clear() { ongoing = false; addr = 0; recdata.clear(); oncompletion.clear(); std::memset(txbuffer, 0, sizeof(txbuffer)); txbuffersize = 0;} 
-//        bool loadtx(const embot::core::Data &txdata) 
-//        { 
-//            if(txdata.size >= txbuffercapacity) { return false; } 
-//            
-    };
-    
-    
-    struct PrivateData
-    {    
-        Config config[embot::core::tointegral(I2C::maxnumberof)];  
-        Transaction  transaction[embot::core::tointegral(I2C::maxnumberof)]; 
-        I2C_HandleTypeDef* handles[embot::core::tointegral(I2C::maxnumberof)];  
-        //DMA_HandleTypeDef* handlesdmatx[static_cast<unsigned int>(I2C::maxnumberof)];   
-        //DMA_HandleTypeDef* handlesdmarx[static_cast<unsigned int>(I2C::maxnumberof)];         
-        PrivateData() { }
-    };
-    
-    static PrivateData s_privatedata;
-    
-    static result_t s_read(I2C b, ADR adr, REG reg, embot::core::Data &destination, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
-    static result_t s_write(I2C b, ADR adr, REG reg, const embot::core::Data &content, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
-    static result_t s_wait(I2C b, embot::core::relTime timeout);
-   
-    static result_t s_read16(I2C b, ADR adr, REG16 reg16, embot::core::Data &destination, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));    
-    static result_t s_write16(I2C b, ADR adr, REG16 reg16, const embot::core::Data &content, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
-    
+        
     result_t init(I2C b, const Config &config)
     {
         if(false == supported(b))
@@ -145,204 +151,39 @@ namespace embot { namespace hw { namespace i2c {
         std::uint8_t index = embot::core::tointegral(b);
         s_privatedata.config[index] = config;
         s_privatedata.handles[index] = embot::hw::bsp::i2c::getBSP().getPROP(b)->handle;
-        //s_privatedata.handlesdmatx[index] = embot::hw::bsp::i2c::getBSP().getPROP(b)->handledmatx);
-        //s_privatedata.handlesdmarx[index] = embot::hw::bsp::i2c::getBSP().getPROP(b)->handledmarx);
-        
-        
-
-        
+                       
         embot::core::binary::bit::set(initialisedmask, embot::core::tointegral(b));
                 
         return resOK;
     }
     
     
-    bool ping(I2C b, ADR adr, embot::core::relTime timeout)
-    {
-        if(false == initialised(b))
-        {
-            return false;
-        } 
-          
-        embot::core::relTime remaining = timeout;
-        if(true == isbusy(b, timeout, remaining))
-        {
-            return false;
-        }
-        
-        std::uint8_t index = embot::core::tointegral(b);
-        
-        s_privatedata.transaction[index].ongoing = true;
-                
-        HAL_StatusTypeDef status = HAL_I2C_IsDeviceReady(s_privatedata.handles[index], adr, 1, remaining/1000);
-        
-        s_privatedata.transaction[index].ongoing = false;
-        
-        return (HAL_OK == status) ? true : false;       
-    }
-
+    // -
+    // blocking mode
     
-    result_t read(I2C b, ADR adr, REG reg, embot::core::Data &destination, const embot::core::Callback &oncompletion)
+    result_t tx(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout)
     {
         if(false == initialised(b))
         {
             return resNOK;
         } 
-        
-        if(false == destination.isvalid())
-        {
-            return resNOK;
-        }     
                 
-        if(true == isbusy(b))
-        {
-            return resNOK;
-        }
-                           
-        return s_read(b, adr, reg, destination, oncompletion);
-    }
-    
-    result_t read(I2C b, ADR adr, REG reg, embot::core::Data &destination, embot::core::relTime timeout)
-    {
-        if(false == initialised(b))
-        {
-            return resNOK;
-        } 
-             
-        if(false == destination.isvalid())
-        {
-            return resNOK;
-        }
-        
         embot::core::relTime remaining = timeout;       
         if(true == isbusy(b, timeout, remaining))
         {
-            return resNOK;
-        }
-                        
-        result_t r = s_read(b, adr, reg, destination);
-        
-        if(resOK == r)
-        {
-            r = s_wait(b, remaining);
-        }        
-        return r;                      
-    }
-
-    result_t read16(I2C b, ADR adr, REG16 reg16, embot::core::Data &destination, embot::core::relTime timeout)
-    {
-        if(false == initialised(b))
-        {
-            return resNOK;
-        } 
-             
-        if(false == destination.isvalid())
-        {
-            return resNOK;
+            return resNOKtimeout;
         }
         
-        embot::core::relTime remaining = timeout;       
-        if(true == isbusy(b, timeout, remaining))
-        {
-            return resNOK;
-        }
-                        
-        result_t r = s_read16(b, adr, reg16, destination);
+        // in here we just transmit over the bus w/ HAL_I2C_Master_Transmit() w/out DMA. the call is blocking w/ timeout
+        // we must nevertheless set the bus busy before trasmission and set it free afterwards. 
+        std::uint8_t index = embot::core::tointegral(b);             
+        embot::hw::i2c::s_privatedata.transaction[index].ongoing = true;       
+        volatile HAL_StatusTypeDef r = HAL_I2C_Master_Transmit(s_privatedata.handles[index], static_cast<uint16_t>(adr), reinterpret_cast<uint8_t*>(content.pointer), static_cast<uint16_t>(content.capacity), timeout/1000);               
+        embot::hw::i2c::s_privatedata.transaction[index].ongoing = false;
         
-        if(resOK == r)
-        {
-            r = s_wait(b, remaining);
-        }        
-        return r;                      
-    }    
-
-    result_t write(I2C b, ADR adr, REG reg, const embot::core::Data &content, const embot::core::Callback &oncompletion)
-    {
-        if(false == initialised(b))
-        {
-            return resNOK;
-        } 
-        
-        if(false == content.isvalid())
-        {
-            return resNOK;
-        } 
-        
-        if(true == isbusy(b))
-        {
-            return resNOK;
-        }
-                        
-        return s_write(b, adr, reg, content, oncompletion);
-    }    
-
-
-    result_t write(I2C b, ADR adr, REG reg, const embot::core::Data &content, embot::core::relTime timeout)
-    {
-        if(false == initialised(b))
-        {
-            return resNOK;
-        } 
-
-        if(false == content.isvalid())
-        {
-            return resNOK;
-        }
-        
-        embot::core::relTime remaining = timeout;
-        if(true == isbusy(b, timeout, remaining))
-        {
-            return resNOK;
-        }        
-         
-        result_t r = s_write(b, adr, reg, content);
-        
-        if(resOK == r)
-        {
-            r = s_wait(b, remaining);
-        }
-        
-        return r;
-    }
-
-    result_t write16(I2C b, ADR adr, REG16 reg16, const embot::core::Data &content, embot::core::relTime timeout)
-    {
-        if(false == initialised(b))
-        {
-            return resNOK;
-        } 
-
-        if(false == content.isvalid())
-        {
-            return resNOK;
-        }
-        
-        embot::core::relTime remaining = timeout;
-        if(true == isbusy(b, timeout, remaining))
-        {
-            return resNOK;
-        }        
-         
-        result_t r = s_write16(b, adr, reg16, content);
-        
-        if(resOK == r)
-        {
-            r = s_wait(b, remaining);
-        }
-        
-        return r;
-    }
+        return (HAL_OK == r) ? resOK : resNOK;
+    }        
     
-    bool isbusy(I2C b)
-    {
-        if(false == initialised(b))
-        {
-            return false;
-        } 
-
-        return s_privatedata.transaction[embot::core::tointegral(b)].ongoing;     
-    }
-
     
     bool isbusy(I2C b, embot::core::relTime timeout, embot::core::relTime &remaining)
     {
@@ -356,8 +197,7 @@ namespace embot { namespace hw { namespace i2c {
             remaining = timeout;
             return s_privatedata.transaction[embot::core::tointegral(b)].ongoing;   
         }
-       
-        
+              
         embot::core::Time deadline = embot::core::now() + timeout;
         
         bool res = true;
@@ -382,29 +222,192 @@ namespace embot { namespace hw { namespace i2c {
         
         return res;        
     }   
-
-//    result_t clear(embot::hw::I2C b)
-//    {
-//        if(false == initialised(b))
-//        {
-//            return resNOK;
-//        } 
-//        
-//        std::uint8_t index = embot::core::tointegral(b);
-//        
-//        embot::hw::i2c::s_privatedata.transaction[index].clear();
-//        
-//        return resOK;
-//    }    
+        
     
-    void ontransactionterminated(std::uint8_t index)
+    bool ping(I2C b, ADR adr, embot::core::relTime timeout)
     {
-        embot::hw::i2c::s_privatedata.transaction[index].ongoing = false;        
-        embot::hw::i2c::s_privatedata.transaction[index].oncompletion.execute();                                
+        if(false == initialised(b))
+        {
+            return false;
+        } 
+          
+        embot::core::relTime remaining = timeout;
+        if(true == isbusy(b, timeout, remaining))
+        {
+            return false;
+        }
+        
+        // we use a call to HAL_I2C_IsDeviceReady() which has a timeout. nevertheless we set the bus busy and we clear afterwards. 
+        std::uint8_t index = embot::core::tointegral(b);        
+        s_privatedata.transaction[index].ongoing = true;                
+        HAL_StatusTypeDef status = HAL_I2C_IsDeviceReady(s_privatedata.handles[index], adr, 1, remaining/1000);        
+        s_privatedata.transaction[index].ongoing = false;
+        
+        return (HAL_OK == status) ? true : false;       
+    }
+
+
+    result_t read(I2C b, ADR adr, Reg reg, embot::core::Data &destination, embot::core::relTime timeout)
+    {
+        if(false == initialised(b))
+        {
+            return resNOK;
+        } 
+             
+        if(false == destination.isvalid())
+        {
+            return resNOK;
+        }
+        
+        embot::core::relTime remaining = timeout;       
+        if(true == isbusy(b, timeout, remaining))
+        {
+            return resNOKtimeout;
+        }
+          
+        result_t r = s_DMA_read_transaction_start(b, adr, reg, destination);
+        
+        if(resOK == r)
+        {   // it transaction has started, we must wait for its completion
+            r = s_wait_for_transaction_completion(b, remaining);
+        }
+        
+        return r;                      
+    }    
+    
+
+    result_t write(I2C b, ADR adr, Reg reg, const embot::core::Data &content, embot::core::relTime timeout)
+    {
+        if(false == initialised(b))
+        {
+            return resNOK;
+        } 
+
+        if(false == content.isvalid())
+        {
+            return resNOK;
+        }
+        
+        embot::core::relTime remaining = timeout;
+        if(true == isbusy(b, timeout, remaining))
+        {
+            return resNOKtimeout;
+        }        
+        
+        // s_DMA_write_transaction_start() starts the transaction.        
+        result_t r = s_DMA_write_transaction_start(b, adr, reg, content);
+        
+        if(resOK == r)
+        {   // it transaction has started, we must wait for its completion
+            r = s_wait_for_transaction_completion(b, remaining);
+        }
+        
+        return r;
     }
     
     
-    static result_t s_wait(I2C b, embot::core::relTime timeout)
+    result_t receive(I2C b, ADR adr, embot::core::Data &destination, embot::core::relTime timeout)
+    {
+        constexpr Reg regnone { Reg::addressNONE, Reg::Size::none }; 
+        // with addressNONE, inside read() the function s_DMA_read_transaction_start() starts a single-stage transaction using DMA
+        return read(b, adr, regnone, destination, timeout);
+    }    
+        
+    result_t transmit(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout)
+    {
+        constexpr Reg regnone { Reg::addressNONE, Reg::Size::none }; 
+        // with addressNONE, inside read() the function s_DMA_read_transaction_start() starts a single-stage transaction using DMA
+        return write(b, adr, regnone, content, timeout);       
+    }
+        
+    
+//    result_t transmitzeroaddress(embot::hw::I2C b, embot::core::relTime timeout)
+//    {
+//        return tx(b, 0, {nullptr, 0}, timeout);
+//    }
+    
+
+   
+           
+    
+    // -
+    // non-blocking mode
+    
+        
+    bool isbusy(I2C b)
+    {
+        if(false == initialised(b))
+        {
+            return false;
+        } 
+        return s_privatedata.transaction[embot::core::tointegral(b)].ongoing;     
+    }
+
+    
+    result_t read(I2C b, ADR adr, Reg reg, embot::core::Data &destination, const embot::core::Callback &oncompletion)
+    {
+        if(false == initialised(b))
+        {
+            return resNOK;
+        } 
+        
+        if(false == destination.isvalid())
+        {
+            return resNOK;
+        }     
+                
+        if(true == isbusy(b))
+        {
+            return resNOK;
+        }
+               
+        // we start a DMA reading transaction and we dont wait for its completion
+        return s_DMA_read_transaction_start(b, adr, reg, destination, oncompletion);
+    }    
+    
+
+    result_t write(I2C b, ADR adr, Reg reg, const embot::core::Data &content, const embot::core::Callback &oncompletion)
+    {
+        if(false == initialised(b))
+        {
+            return resNOK;
+        } 
+        
+        if(false == content.isvalid())
+        {
+            return resNOK;
+        } 
+        
+        if(true == isbusy(b))
+        {
+            return resNOK;
+        }
+         
+        // we start a DMA writing transaction and we dont wait for its completion        
+        return s_DMA_write_transaction_start(b, adr, reg, content, oncompletion);
+    }    
+    
+
+    result_t receive(I2C b, ADR adr, embot::core::Data &destination, const embot::core::Callback &oncompletion)
+    {
+        constexpr Reg regnone { Reg::addressNONE, Reg::Size::none };        
+        // with addressNONE, inside read() the function s_DMA_read_transaction_start() starts a single-stage transaction using DMA
+        return read(b, adr, regnone, destination, oncompletion);
+    }  
+
+    
+    result_t transmit(I2C b, ADR adr, const embot::core::Data &content, const embot::core::Callback &oncompletion)
+    {
+        constexpr Reg regnone { Reg::addressNONE, Reg::Size::none }; 
+        // with addressNONE, inside read() the function s_DMA_read_transaction_start() starts a single-stage transaction using DMA
+        return write(b, adr, regnone, content, oncompletion);       
+    }    
+    
+    // -
+    // utility functions
+    
+            
+    static result_t s_wait_for_transaction_completion(I2C b, embot::core::relTime timeout)
     {
         embot::core::Time start = embot::core::now();
         
@@ -425,44 +428,24 @@ namespace embot { namespace hw { namespace i2c {
 
         return res;
     }   
-    
-    
-    result_t transmit(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout)
-    {
-        if(false == initialised(b))
-        {
-            return resNOK;
-        } 
-                
-        if(true == isbusy(b))
-        {
-            return resNOK;
-        }
         
-        std::uint8_t index = embot::core::tointegral(b);     
+    static result_t s_DMA_write_transaction_start(I2C b, ADR adr, Reg reg, const embot::core::Data &content, const embot::core::Callback &oncompletion)
+    { 
+        result_t res = resNOK; 
         
-        embot::hw::i2c::s_privatedata.transaction[index].ongoing = true; 
-       
-        volatile HAL_StatusTypeDef r = HAL_I2C_Master_Transmit(s_privatedata.handles[index], static_cast<uint16_t>(adr), reinterpret_cast<uint8_t*>(content.pointer), static_cast<uint16_t>(content.capacity), timeout/1000);        
-        
-        embot::hw::i2c::s_privatedata.transaction[index].ongoing = false;
-        
-        return (HAL_OK == r) ? resOK : resNOK;
-    }
-    
-    static result_t s_write(I2C b, ADR adr, REG reg, const embot::core::Data &content, const embot::core::Callback &oncompletion)
-    {   
         std::uint8_t index = embot::core::tointegral(b);        
         s_privatedata.transaction[index].addr = adr;
         s_privatedata.transaction[index].oncompletion = oncompletion;
         s_privatedata.transaction[index].ongoing = true;
         s_privatedata.transaction[index].recdata.clear(); // invalide recdata, so that HAL_I2C_MasterTxCpltCallback() knows it is a write operation.
         
-        if(regNONE == reg)
+        if(Reg::addressNONE == reg.address)
         {
             // i need to transmit the pattern [data] because the slave already knows into which register to put data. and does not expect a [reg] byte.
-            if(content.capacity > Transaction::txbuffercapacity)
+            uint16_t txsize = content.capacity;
+            if(txsize > Transaction::txbuffercapacity)
             {
+                s_privatedata.transaction[index].ongoing = false;
                 return resNOK;
             }
             std::memmove(&s_privatedata.transaction[index].txbuffer[0], content.pointer, content.capacity);
@@ -470,58 +453,41 @@ namespace embot { namespace hw { namespace i2c {
         }
         else
         {
-            // i need to transmit the pattern [reg][data] because the slave must know into which register to put data.
-            if(content.capacity >= Transaction::txbuffercapacity)
+            // i need to transmit the pattern [reg.address][data] because the slave must know into which register to put data.            
+            uint16_t txsize = (Reg::Size::eightbits == reg.size) ? (content.capacity + 1) : (content.capacity + 2);
+            if(txsize > Transaction::txbuffercapacity)
             {
+                s_privatedata.transaction[index].ongoing = false;
                 return resNOK;
             }
-            s_privatedata.transaction[index].txbuffer[0] = reg;
-            std::memmove(&s_privatedata.transaction[index].txbuffer[1], content.pointer, content.capacity);
-            s_privatedata.transaction[index].txbuffersize = content.capacity + 1;
+            
+            if(Reg::Size::eightbits == reg.size)
+            {
+                s_privatedata.transaction[index].txbuffer[0] = reg.address & 0xff;
+                std::memmove(&s_privatedata.transaction[index].txbuffer[1], content.pointer, content.capacity);
+                s_privatedata.transaction[index].txbuffersize = content.capacity + 1;                
+            }
+            else
+            {
+                s_privatedata.transaction[index].txbuffer[0] = (reg.address >> 8 ) & 0xff;
+                s_privatedata.transaction[index].txbuffer[1] = reg.address & 0xff;                
+                std::memmove(&s_privatedata.transaction[index].txbuffer[2], content.pointer, content.capacity);
+                s_privatedata.transaction[index].txbuffersize = content.capacity + 2;
+            }
         }
         
         HAL_StatusTypeDef r = HAL_I2C_Master_Transmit_DMA(s_privatedata.handles[index], adr, static_cast<std::uint8_t*>(s_privatedata.transaction[index].txbuffer), s_privatedata.transaction[index].txbuffersize);        
-                
-        return (HAL_OK == r) ? resOK : resNOK;
-    }    
-    
-    static result_t s_write16(I2C b, ADR adr, REG16 reg16, const embot::core::Data &content, const embot::core::Callback &oncompletion)
-    {   
-        std::uint8_t index = embot::core::tointegral(b);        
-        s_privatedata.transaction[index].addr = adr;
-        s_privatedata.transaction[index].oncompletion = oncompletion;
-        s_privatedata.transaction[index].ongoing = true;
-        s_privatedata.transaction[index].recdata.clear(); // invalide recdata, so that HAL_I2C_MasterTxCpltCallback() knows it is a write operation.
+        res = (HAL_OK == r) ? resOK : resNOK;
         
-        if(reg16NONE == reg16)
+        if(resOK != res)
         {
-            // i need to transmit the pattern [data] because the slave already knows into which register to put data. and does not expect a [reg] byte.
-            if(content.capacity > Transaction::txbuffercapacity)
-            {
-                return resNOK;
-            }
-            std::memmove(&s_privatedata.transaction[index].txbuffer[0], content.pointer, content.capacity);
-            s_privatedata.transaction[index].txbuffersize = content.capacity;            
-        }
-        else
-        {
-            // i need to transmit the pattern [reg16][data] because the slave must know into which register to put data.
-            if(content.capacity >= Transaction::txbuffercapacity)
-            {
-                return resNOK;
-            }
-            s_privatedata.transaction[index].txbuffer[0] = reg16 & 0xff; 
-            s_privatedata.transaction[index].txbuffer[1] = (reg16 >> 8 ) & 0xff;
-            std::memmove(&s_privatedata.transaction[index].txbuffer[2], content.pointer, content.capacity);
-            s_privatedata.transaction[index].txbuffersize = content.capacity + 2;
-        }
-        
-        HAL_StatusTypeDef r = HAL_I2C_Master_Transmit_DMA(s_privatedata.handles[index], adr, static_cast<std::uint8_t*>(s_privatedata.transaction[index].txbuffer), s_privatedata.transaction[index].txbuffersize);        
-                
-        return (HAL_OK == r) ? resOK : resNOK;
-    }    
+            s_privatedata.transaction[index].ongoing = false;
+        }        
+        return res;
+    }        
 
-    static result_t s_read(I2C b, ADR adr, REG reg, embot::core::Data &destination, const embot::core::Callback &oncompletion)
+
+    static result_t s_DMA_read_transaction_start(I2C b, ADR adr, Reg reg, embot::core::Data &destination, const embot::core::Callback &oncompletion)
     {
         result_t res = resNOK;
         
@@ -531,7 +497,7 @@ namespace embot { namespace hw { namespace i2c {
         s_privatedata.transaction[index].ongoing = true;
         s_privatedata.transaction[index].recdata = destination;  
         
-        if(reg == regNONE)
+        if(reg.address == Reg::addressNONE)
         {
             // it is a single-stage operation: read<values>
             // i dont need to ask which register to read from because the slave already knows what to send.
@@ -555,65 +521,40 @@ namespace embot { namespace hw { namespace i2c {
             // the completion of reading operation is signalled by the call of HAL_I2C_MasterRxCpltCallback(). 
             // at this stage recdata will contain the received data.
                     
-            // so far we only manage addresses which are 1 byte long ...
-            s_privatedata.transaction[index].txbuffer[0] = reg;
-            s_privatedata.transaction[index].txbuffersize = 1;
+            // so far we only manage addresses which are 1 or 2 bytes long ...
+            if(Reg::Size::eightbits == reg.size)
+            {
+                s_privatedata.transaction[index].txbuffer[0] = reg.address & 0xff;
+                s_privatedata.transaction[index].txbuffersize = 1;
+            }
+            else
+            {   // big endianess ....
+                s_privatedata.transaction[index].txbuffer[0] = (reg.address >> 8 ) & 0xff;
+                s_privatedata.transaction[index].txbuffer[1] = reg.address & 0xff;
+                s_privatedata.transaction[index].txbuffersize = 2;
+            }
             HAL_StatusTypeDef r = HAL_I2C_Master_Transmit_DMA(s_privatedata.handles[index], adr, static_cast<std::uint8_t*>(s_privatedata.transaction[index].txbuffer), s_privatedata.transaction[index].txbuffersize);        
             res = (HAL_OK == r) ? resOK : resNOK;
         }
-
+        
+        if(resOK != res)
+        {
+            s_privatedata.transaction[index].ongoing = false;
+        }
         return res;
-    }
+    } 
     
-    
-    static result_t s_read16(I2C b, ADR adr, REG16 reg16, embot::core::Data &destination, const embot::core::Callback &oncompletion)
+
+    void ontransactionterminated(std::uint8_t index)
     {
-        result_t res = resNOK;
-        
-        std::uint8_t index = embot::core::tointegral(b);
-        s_privatedata.transaction[index].addr = adr;
-        s_privatedata.transaction[index].oncompletion = oncompletion;
-        s_privatedata.transaction[index].ongoing = true;
-        s_privatedata.transaction[index].recdata = destination;  
-        
-        if(reg16 == reg16NONE)
-        {
-            // it is a single-stage operation: read<values>
-            // i dont need to ask which register to read from because the slave already knows what to send.
-            // i do the read<> request with HAL_I2C_Master_Receive_DMA(recdata).
-            // the completion of reading operation is signalled by the call of HAL_I2C_MasterRxCpltCallback(). 
-            // at this stage recdata will contain the received data.            
-            I2C_HandleTypeDef* hi2cx = embot::hw::i2c::s_privatedata.handles[index];
-            HAL_StatusTypeDef r = HAL_I2C_Master_Receive_DMA( hi2cx, 
-                                        embot::hw::i2c::s_privatedata.transaction[index].addr, 
-                                        static_cast<std::uint8_t*>(embot::hw::i2c::s_privatedata.transaction[index].recdata.pointer),  
-                                        static_cast<std::uint16_t>(embot::hw::i2c::s_privatedata.transaction[index].recdata.capacity)
-                                    );  
-            res = (HAL_OK == r) ? resOK : resNOK;                                        
-        }
-        else
-        {
-            // it is a two-stage operation: write<reg>, read<values>
-            // i must at first tx the value of the register i want to read from. i use HAL_I2C_Master_Transmit_DMA().
-            // the call of HAL_I2C_MasterTxCpltCallback() signals the end of teh fist stage and ... if recdata.isvalid() then ...
-            // i perform the read<> request with HAL_I2C_Master_Receive_DMA(recdata).
-            // the completion of reading operation is signalled by the call of HAL_I2C_MasterRxCpltCallback(). 
-            // at this stage recdata will contain the received data.
-                    
-            // so far we only manage addresses which are 2 byte long ...
-            s_privatedata.transaction[index].txbuffer[1] = reg16 & 0xff;
-            s_privatedata.transaction[index].txbuffer[0] = (reg16 >> 8 ) & 0xff;
-            s_privatedata.transaction[index].txbuffersize = 2;
-            HAL_StatusTypeDef r = HAL_I2C_Master_Transmit_DMA(s_privatedata.handles[index], adr, static_cast<std::uint8_t*>(s_privatedata.transaction[index].txbuffer), s_privatedata.transaction[index].txbuffersize);        
-            res = (HAL_OK == r) ? resOK : resNOK;
-        }
-
-        return res;
+        embot::hw::i2c::s_privatedata.transaction[index].ongoing = false;        
+        embot::hw::i2c::s_privatedata.transaction[index].oncompletion.execute();                                
     }    
      
 }}} // namespace embot { namespace hw { namespace i2c {
 
 
+// functions required by the hal of stm32. they are called by the hw at the completion of a tx or rx transaction
     
 void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *I2cHandle)
 {    
@@ -635,8 +576,7 @@ void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *I2cHandle)
     {
         return;
     }
-        
-        
+               
     if(false == embot::hw::i2c::s_privatedata.transaction[index].recdata.isvalid())
     {
         // it is a write operation: the transaction is terminated

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_i2c.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_i2c.h
@@ -35,7 +35,10 @@ namespace embot { namespace hw { namespace i2c {
     using ADR = std::uint8_t;
     using REG = std::uint8_t;
     
-    static const std::uint8_t regNONE = 0xff;
+    using REG16 = std::uint16_t;
+    
+    constexpr REG regNONE = 0xff;
+    constexpr REG16 reg16NONE = 0xffff;
     
     enum class Speed : uint32_t { standard100 = 100000, fast400 = 400000, fastplus1000 = 1000000, high3400 = 3400000 };
         
@@ -81,6 +84,7 @@ namespace embot { namespace hw { namespace i2c {
     // if result is resOK, destination.pointer contains the data; if resNOKtimeout, the timeout expired. if resNOK the operation was not even started
     // the functions internally waits until not busy for the timeout ... however, please check isbusy() outside. 
     result_t read(embot::hw::I2C b, ADR adr, REG reg, embot::core::Data &destination, embot::core::relTime timeout);
+    result_t read16(embot::hw::I2C b, ADR adr, REG16 reg16, embot::core::Data &destination, embot::core::relTime timeout);
         
     // not blocking write to REG. we write in register reg the content.size byte pointed by content.pointer.
     // when the write is done, the function oncompletion.callback() is called to alert the user.
@@ -89,7 +93,8 @@ namespace embot { namespace hw { namespace i2c {
     // blocking write to REG. we write in register reg the content.size byte pointed by content.pointer and we wait until a timeout.
     // if result is resOK, the operation is successful. if resNOKtimeout, the timeout expired. if resNOK the operation was not even started
     // the functions internally waits until not busy for the timeout ... however, please check isbusy() outside.
-    result_t write(embot::hw::I2C b, ADR adr, REG reg, const embot::core::Data &content, embot::core::relTime timeout);    
+    result_t write(embot::hw::I2C b, ADR adr, REG reg, const embot::core::Data &content, embot::core::relTime timeout);  
+    result_t write16(embot::hw::I2C b, ADR adr, REG16 reg16, const embot::core::Data &content, embot::core::relTime timeout);     
 
 }}} // namespace embot { namespace hw { namespace i2c {
     

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_i2c.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_i2c.h
@@ -32,28 +32,38 @@
 
 namespace embot { namespace hw { namespace i2c {
     
-    using ADR = std::uint8_t;
-    using REG = std::uint8_t;
-    
-    using REG16 = std::uint16_t;
-    
-    constexpr REG regNONE = 0xff;
-    constexpr REG16 reg16NONE = 0xffff;
-    
+    // speeds so far are those
     enum class Speed : uint32_t { standard100 = 100000, fast400 = 400000, fastplus1000 = 1000000, high3400 = 3400000 };
-        
+    
+    // address is always expressed by <= 8 bits
+    using ADR = std::uint8_t;
+   
+    // device registers can be addressed in multiple address modes. in this implementation <= 16 bits
+    struct Reg
+    {   // 8 bits + 16 bits (big endian)
+        enum class Size : uint8_t { none = 0, eightbits = 8, sixteenbits = 16 };
+        static constexpr uint16_t addressNONE {0xffff};
+        uint16_t address {addressNONE};
+        Size size {Size::eightbits};
+        // this ctor transform a single number into a 8-bit register and it MAINTAINS BACKWARDS COMPATIBILITY w/ old API which used REG as a uint8_t
+        constexpr Reg(uint16_t a, Size s = Size::eightbits) { address = a; size = s; }
+        constexpr Reg() = default;
+    };
+   
+          
     struct Config
     {   
-        std::uint32_t speed {400000}; 
-        constexpr Config(std::uint32_t s) : speed(s) {}        
-        constexpr Config() : speed(400000) {}
+        std::uint32_t speed {embot::core::tointegral(Speed::fast400)};       
+        constexpr Config() = default;
+        constexpr Config(std::uint32_t s) : speed(s) {}  
+        constexpr Config(Speed sp) : speed(embot::core::tointegral(sp)) {}
     };
     
     struct Descriptor
     {
-        embot::hw::I2C     bus;
-        Config  config;
-        constexpr Descriptor() : bus(embot::hw::I2C::none), config(400000) {}
+        embot::hw::I2C bus {embot::hw::I2C::none};
+        Config config {Speed::fast400};
+        constexpr Descriptor() = default;
         constexpr Descriptor(embot::hw::I2C b, std::uint32_t s) : bus(b), config(s) {}
     };
 
@@ -64,38 +74,102 @@ namespace embot { namespace hw { namespace i2c {
     
     result_t init(embot::hw::I2C b, const Config &config);
     
-    // if a transaction is ongoing the bus cannot be used.
-    bool isbusy(embot::hw::I2C b);
-    // we also have a version w/ timeout. use it carefully!
+    
+    // read() and write() operate on a register of the chip.
+    // transmit() and receive() operate on the chip without specifying a given register
+    
+    
+    // BLOCKING mode.
+    // in such a mode, the functions start operations and wait until completion or until a timeout has expired.
+    // the timeout must always be specified. for example 3*embot::core::time1millisec, 500*embot::core::time1microsec, etc...
+    
+    // BLOCKING BUS ACTIVITY CHECK
+    // it tells if the specified i2c bus is busy with some operation. if busy the bus cannot be used.
+    // returns true only if the bus gets free by the specified timeout. it gives back in remaining the time = timeout - time spent inside.  
+    // this function is internally used by functions ping(), read(), write(), transmit() and receive(). they wait until the bus is free before 
+    // they get ownership of the bus for their tx/rx operations.
     bool isbusy(embot::hw::I2C b, embot::core::relTime timeout, embot::core::relTime &remaining);
     
-    // check is the device is present.
-    // it internally calls isbusy(timeout, remaining)
-    bool ping(embot::hw::I2C b, ADR adr, embot::core::relTime timeout = 3*embot::core::time1millisec);
+    // PING of a device
+    // check is a device is present on a given bus b and at a given address adr. this function waits up to a timeout 
+    // whose typical value is 3*embot::core::time1millisec
+    // before any activity this functions waits until isbusy(b, timeout, remaining) returns false.
+    bool ping(embot::hw::I2C b, ADR adr, embot::core::relTime timeout);
     
-    // blocking byte-transmission to ADR: it just sends the bytes inside content to a given i2c address and waits for completion for a maximum timeout
-    result_t transmit(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout = 3*embot::core::time1millisec);
-        
-    // not blocking read from REG. we read from register reg a total of destination.capacity bytes
-    // at the end of transaction, data is copied into destination.pointer and oncompletion.callback() is called (if non nullptr). 
-    result_t read(embot::hw::I2C b, ADR adr, REG reg, embot::core::Data &destination, const embot::core::Callback &oncompletion);
     
-    // blocking read from REG. we read from register reg a total of destination.size bytes and we wait until a timeout. 
-    // if result is resOK, destination.pointer contains the data; if resNOKtimeout, the timeout expired. if resNOK the operation was not even started
-    // the functions internally waits until not busy for the timeout ... however, please check isbusy() outside. 
-    result_t read(embot::hw::I2C b, ADR adr, REG reg, embot::core::Data &destination, embot::core::relTime timeout);
-    result_t read16(embot::hw::I2C b, ADR adr, REG16 reg16, embot::core::Data &destination, embot::core::relTime timeout);
-        
-    // not blocking write to REG. we write in register reg the content.size byte pointed by content.pointer.
-    // when the write is done, the function oncompletion.callback() is called to alert the user.
-    result_t write(embot::hw::I2C b, ADR adr, REG reg, const embot::core::Data &content, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
+    // BLOCKING CORE BYTE TX.
+    // it is the most general transmission function.
+    // it ensure to call directly the direct low level functions (not DMA). it sets inside the bus busy and then free again 
+    // it accepts zero address and empty content (in such a case sends just the address)
+    result_t tx(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout);    
     
-    // blocking write to REG. we write in register reg the content.size byte pointed by content.pointer and we wait until a timeout.
-    // if result is resOK, the operation is successful. if resNOKtimeout, the timeout expired. if resNOK the operation was not even started
-    // the functions internally waits until not busy for the timeout ... however, please check isbusy() outside.
-    result_t write(embot::hw::I2C b, ADR adr, REG reg, const embot::core::Data &content, embot::core::relTime timeout);  
-    result_t write16(embot::hw::I2C b, ADR adr, REG16 reg16, const embot::core::Data &content, embot::core::relTime timeout);     
+    // BLOCKING READ from a register. 
+    // it reads starting from register reg a total of destination.capacity bytes and waits until a timeout. 
+    // operation is OK only if read() returns resOK. In this case destination.pointer contains the data; 
+    // operation fails if read() returns resNOKtimeout (the timeout has expired) or resNOK (the operation was not even started)
+    // before any activity this functions waits until isbusy() returns false. any such wait consumes the specified timeout. 
+    result_t read(embot::hw::I2C b, ADR adr, Reg reg, embot::core::Data &destination, embot::core::relTime timeout);
+    
+    // BLOCKING WRITE to a register. 
+    // it writes starting from register reg a total of content.size bytes pointed by content.pointer and waits until a timeout.
+    // operation is OK only if write() returns resOK. In this case the bytes pointed by content.pointer are guaranteed to be written to register.
+    // operation fails if write() returns resNOKtimeout (the timeout has expired) or resNOK (the operation was not even started).
+    // before any activity this functions waits until isbusy(b, timeout, remaining) returns false.
+    result_t write(embot::hw::I2C b, ADR adr, Reg reg, const embot::core::Data &content, embot::core::relTime timeout);
+            
+    // BLOCKING BYTE RECEIVE. 
+    // it receives the bytes pointed by destination.pointer for a total of destination.capacity from a given i2c::ADR adr and waits until a timeout.
+    // operation is OK only if receive() returns resOK. In this case the bytes pointed by destination.pointer are those transmitted by the device.
+    // operation fails if receive() returns resNOKtimeout (the timeout has expired) or resNOK (the operation was not even started).
+    // before any activity this functions waits until isbusy(b, timeout, remaining) returns false.
+    result_t receive(embot::hw::I2C b, ADR adr, embot::core::Data &destination, embot::core::relTime timeout);    
+    
+    // BLOCKING BYTE TRANSMIT. 
+    // its send the bytes pointed by content.pointer for a total of content.capacity to a given i2c::ADR adr and waits until a timeout.
+    // operation is OK only if transmit() returns resOK. In this case the bytes pointed by content.pointer are guaranteed to be transmitted.
+    // operation fails if transmit() returns resNOKtimeout (the timeout has expired) or resNOK (the operation was not even started).
+    // before any activity this functions waits until isbusy(b, timeout, remaining) returns false.
+    result_t transmit(embot::hw::I2C b, ADR adr, const embot::core::Data &content, embot::core::relTime timeout);    
+    
+                   
+    // NON-BLOCKING mode.
+    // in such a mode, the functions returns control to the calling thread in the shortest possible time.
+    // if the bus is busy they return without doing any activity. if not busy they set the bus busy, start hardware operations,  
+    // dont wait for completion and return control to the calling thread. 
+    // the calling thread can now operate in two modes:
+    // 1. wait until isbusy() returns false (because the hardware sets the bus free at completion)
+    // 2. can continue its execution and be alerted by the specified callback that the operation is completed.
+    
+    // NON-BLOCKING BUS ACTIVITY CHECK.
+    // it immediatly returns true if the bus is busy or false if the bus is available.
+    // this function is internally used by functions read() and write() which immediately returns w/out doing anything if the bus is busy.  
+    bool isbusy(embot::hw::I2C b);
+    
+    // NON-BLOCKING READ from a register. 
+    // if the bus is not busy it starts the reading operation of a total of destination.capacity bytes starting from register reg and returns. 
+    // at completion of the reading operation the hardware copies the received data inside destination.pointer and ensure the execution of 
+    // the specified callback which can be used to alert a thread. 
+    // this funtions returns resOK if the hardware can succesfully start its operations and resNOK in any failure case.
+    result_t read(embot::hw::I2C b, ADR adr, Reg reg, embot::core::Data &destination, const embot::core::Callback &oncompletion);
+    
+    // NON-BLOCKING WRITE to register. 
+    // if the bus is not busy it starts the writing operation of a total of content.capacity bytes pointed by content.pointer starting from
+    // register reg and returns.
+    // at completion of the writing operation the hardware ensures the execution of the specified callback which can be used to alert a thread. 
+    // this funtions returns resOK if the hardware can succesfully start its operations and resNOK in any failure case.
+    result_t write(embot::hw::I2C b, ADR adr, Reg reg, const embot::core::Data &content, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
+    
 
+    // NON-BLOCKING BYTE RECEIVE. 
+    // if the bus is not busy it starts the receiving operation of a total of destination.capacity bytes and returns. 
+    // at completion of the reading operation the hardware copies the received data inside destination.pointer and ensure the execution of 
+    // the specified callback which can be used to alert a thread. 
+    // this funtions returns resOK if the hardware can succesfully start its operations and resNOK in any failure case.
+    result_t receive(embot::hw::I2C b, ADR adr, embot::core::Data &destination, const embot::core::Callback &oncompletion);  
+    
+    // NON-BLOCKING BYTE TRANSMIT.
+    result_t transmit(I2C b, ADR adr, const embot::core::Data &content, const embot::core::Callback &oncompletion);
+    
 }}} // namespace embot { namespace hw { namespace i2c {
     
     

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_si7051.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_si7051.cpp
@@ -146,7 +146,7 @@ namespace embot { namespace hw { namespace si7051 {
                 
         // init i2c ..
         embot::hw::i2c::init(config.i2cdes.bus, config.i2cdes.config);
-        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::si7051::getBSP().getPROP(s)->i2caddress))
+        if(false == embot::hw::i2c::ping(config.i2cdes.bus, embot::hw::bsp::si7051::getBSP().getPROP(s)->i2caddress, 3*embot::core::time1millisec))
         {
             return resNOK;
         }

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_tlv493d.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_tlv493d.cpp
@@ -205,7 +205,7 @@ namespace embot { namespace hw { namespace tlv493d {
     
 
     // this device works with no register addressing.
-    static const embot::hw::i2c::REG registerToRead = embot::hw::i2c::regNONE;
+    // static const embot::hw::i2c::Reg registerToRead {embot::hw::i2c::Reg::addrNONE, embot::hw::i2c::Reg::Size::eightbits};
     
     static PrivateData s_privatedata;
 
@@ -317,7 +317,8 @@ namespace embot { namespace hw { namespace tlv493d {
         // ok, now i trigger i2c.
         embot::core::Callback cbk(sharedCBK, &s_privatedata.acquisition[index]);
         embot::core::Data data = embot::core::Data(&s_privatedata.acquisition[index].registermap.readmemory[0], sizeof(s_privatedata.acquisition[index].registermap.readmemory));
-        embot::hw::i2c::read(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], embot::hw::i2c::regNONE, data, cbk);
+        //embot::hw::i2c::read(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], registerToRead, data, cbk);
+        embot::hw::i2c::receive(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], data, cbk);
                 
         return resOK;
     }
@@ -465,20 +466,22 @@ namespace embot { namespace hw { namespace tlv493d {
         s_sensor_reset(h);
            
         // 1.a make sure the chip has a good address in the bus         
-        if(false == embot::hw::i2c::ping(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index]))
+        if(false == embot::hw::i2c::ping(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], 3*embot::core::time1millisec))
         {
             return resNOK;
         }
                        
         // 2. read the registers
         data.load(s_privatedata.acquisition[index].registermap.readmemory, s_privatedata.acquisition[index].registermap.readsize); 
-        r = embot::hw::i2c::read(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], embot::hw::i2c::regNONE, data, embot::core::time1second);
+        //r = embot::hw::i2c::read(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], registerToRead, data, embot::core::time1second);
+        r = embot::hw::i2c::receive(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], data, embot::core::time1second);
         r = r;
         
         // 3. impose a mode.
         s_privatedata.acquisition[index].registermap.setWRITE({}); // defconfig
         data.load(s_privatedata.acquisition[index].registermap.writememory, s_privatedata.acquisition[index].registermap.writesize); 
-        r = embot::hw::i2c::write(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], embot::hw::i2c::regNONE, data, embot::core::time1second);
+        //r = embot::hw::i2c::write(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], registerToRead, data, embot::core::time1second);
+        r = embot::hw::i2c::transmit(s_privatedata.config[index].i2cdes.bus, s_privatedata.i2caddress[index], data, embot::core::time1second);
         
         // wait a bit
         embot::hw::sys::delay(10*embot::core::time1millisec);
@@ -496,7 +499,7 @@ namespace embot { namespace hw { namespace tlv493d {
         
         embot::core::Data dummy;
         dummy.clear();
-        volatile result_t r1 = embot::hw::i2c::transmit(s_privatedata.config[index].i2cdes.bus, 0x00, dummy, 3*embot::core::time1millisec);        
+        volatile result_t r1 = embot::hw::i2c::tx(s_privatedata.config[index].i2cdes.bus, 0x00, dummy, 3*embot::core::time1millisec);             
         r1 = r1;
         // extra 3 ms.
         embot::hw::sys::delay(3*embot::core::time1millisec);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_types.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_types.h
@@ -53,7 +53,9 @@ namespace embot { namespace hw {
     
     enum class TLV493D : std::uint8_t { one = 0, two = 1, none = 31, maxnumberof = 2 };
     
-    enum class ADS122C04 : std::uint8_t { one, none = 31, maxnumberof = 1 };
+    enum class ADS122C04 : std::uint8_t { one = 0, none = 31, maxnumberof = 1 };
+    
+    enum class AD7147 : std::uint8_t { one = 0, two = 1, none = 31, maxnumberof = 2 };
     
     
     struct GPIO


### PR DESCRIPTION
This PR introduces an extension of the `embot::hw::i2c` driver so that it can manage chips with registers mapped in both 8 bits space and 16 bit space.

This feature is required to manage the driver of the CDC chip AD7147 used to manage the skin patches
