### PR TITLE
Added support in ETH boards for disabling some services at compile time

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOCurrentsWatchdog.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOCurrentsWatchdog.c
@@ -21,6 +21,7 @@
 // - external dependencies
 // --------------------------------------------------------------------------------------------------------------------
 
+#include "EOtheServices_hid.h"
 #include "EoMotionControl.h"
 #include "EOtheEntities.h"
 #include "EOtheMemoryPool.h"
@@ -43,6 +44,30 @@
 
 #include "EOCurrentsWatchdog_hid.h"
 
+#if defined(EOTHESERVICES_disable_CurrentsWatchdog)
+
+
+    extern EOCurrentsWatchdog* eo_currents_watchdog_Initialise(void)
+    {
+        return NULL;
+    }
+
+    extern EOCurrentsWatchdog* eo_currents_watchdog_GetHandle(void)
+    {
+        return NULL;
+    }
+
+    extern void eo_currents_watchdog_Tick(EOCurrentsWatchdog* p, int16_t voltage, int16_t *currents)
+    {
+    }
+        
+
+    extern eOresult_t eo_currents_watchdog_UpdateCurrentLimits(EOCurrentsWatchdog* p, uint8_t motor)
+    {
+        return eores_NOK_generic;
+    }
+    
+#elif !defined(EOTHESERVICES_disable_CurrentsWatchdog)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -481,6 +506,7 @@ EO_static_inline eObool_t s_eo_currents_watchdog_averageCalc_collectDataIsComple
 
 #endif //REMOVE_TO_AVOID_COMPILATION_WARNING
 
+#endif // #elif !defined(EOTHESERVICES_disable_CurrentsWatchdog)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
@@ -61,6 +61,87 @@
 
 #include "EOtheEncoderReader_hid.h"
 
+#if defined(EOTHESERVICES_disable_theEncoderReader)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheEncoderReader* eo_encoderreader_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheEncoderReader* eo_encoderreader_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+   
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_encoderreader_SendReport(EOtheEncoderReader *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheEncoderReader";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_encoders_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_encoderreader_Verify(EOtheEncoderReader *p, const eOmc_arrayof_4jomodescriptors_t * jomodes, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_mc, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_encoderreader_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_encoderreader_Activate(EOtheEncoderReader *p, const eOmc_arrayof_4jomodescriptors_t * jomodes)
+    {
+        eo_encoderreader_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_encoderreader_Deactivate(EOtheEncoderReader *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_encoderreader_StartReading(EOtheEncoderReader *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eObool_t eo_encoderreader_IsReadingAvailable(EOtheEncoderReader *p)
+    {
+        return eobool_false;
+    }
+  
+    extern eOresult_t eo_encoderreader_Read(EOtheEncoderReader *p, uint8_t position, eOencoderreader_valueInfo_t *primary, eOencoderreader_valueInfo_t *secondary)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_encoderreader_Diagnostics_Tick(EOtheEncoderReader* p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_encoderreader_GetPrimaryEncoder(EOtheEncoderReader *p, uint8_t position, eOmc_encoder_descriptor_t *encoder)
+    {
+         return eores_NOK_generic;        
+    }
+    
+    
+#elif !defined(EOTHESERVICES_disable_theEncoderReader)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -587,6 +668,8 @@ static void s_eo_encoderreader_read_encoders(void* p)
 //    pp = pp/eo_appEncReader_stream_position_numberof;
 //    return((eo_appEncReader_stream_number_t)pp);  
 //}
+
+#endif // #elif !defined(EOTHESERVICES_disable_theEncoderReader)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials2.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials2.c
@@ -59,6 +59,106 @@
 
 #include "EOtheInertials2_hid.h"
 
+#if defined(EOTHESERVICES_disable_theInertials2)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheInertials2* eo_inertials2_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheInertials2* eo_inertials2_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_inertials2_GetServiceState(EOtheInertials2 *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_inertials2_SendReport(EOtheInertials2 *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheInertials2";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_inertials_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_inertials2_Verify(EOtheInertials2 *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_inertials, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_inertials2_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Activate(EOtheInertials2 *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_inertials2_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Deactivate(EOtheInertials2 *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Start(EOtheInertials2 *p)
+    {
+        eo_inertials2_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_SetRegulars(EOtheInertials2 *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_inertials2_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Tick(EOtheInertials2 *p, eObool_t resetstatus)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Stop(EOtheInertials2 *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Transmission(EOtheInertials2 *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials2_Config(EOtheInertials2 *p, eOas_inertial_config_t* config)
+    {
+        eo_inertials2_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOas_inertial_type_t type, eOcanframe_t *frame, eOcanport_t port)
+    {
+        return eores_NOK_generic;
+    }
+
+
+#elif !defined(EOTHESERVICES_disable_theInertials2)
+
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -1491,7 +1591,7 @@ static void s_eo_inertials2_presenceofcanboards_tick(EOtheInertials2 *p)
 }
 
 
-
+#endif // #elif !defined(EOTHESERVICES_disable_theInertials2)
 
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
@@ -52,14 +52,112 @@
 #include "EOtheInertials3.h"
 
 
-
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of extern hidden interface 
 // --------------------------------------------------------------------------------------------------------------------
 
 #include "EOtheInertials3_hid.h"
 
+#if defined(EOTHESERVICES_disable_theInertials3)
 
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheInertials3* eo_inertials3_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheInertials3* eo_inertials3_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_inertials3_GetServiceState(EOtheInertials3 *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_inertials3_SendReport(EOtheInertials3 *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheInertials3";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_inertials3_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_inertials3_Verify(EOtheInertials3 *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_inertials3, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_inertials3_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Activate(EOtheInertials3 *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_inertials3_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Deactivate(EOtheInertials3 *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Start(EOtheInertials3 *p)
+    {
+        eo_inertials3_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_SetRegulars(EOtheInertials3 *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_inertials3_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Tick(EOtheInertials3 *p, eObool_t resetstatus)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Stop(EOtheInertials3 *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Transmission(EOtheInertials3 *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_inertials3_Config(EOtheInertials3 *p, eOas_inertial3_config_t* config)
+    {
+        eo_inertials3_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOas_inertial3_type_t type, eOcanframe_t *frame, eOcanport_t port)
+    {
+        return eores_NOK_generic;
+    }
+
+
+#elif !defined(EOTHESERVICES_disable_theInertials3)
+    
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
 // --------------------------------------------------------------------------------------------------------------------
@@ -1805,7 +1903,7 @@ static void s_eo_inertials3_imu_configure(EOtheInertials3 *p)
 }
 
 
-
+#endif // #elif !defined(EOTHESERVICES_disable_theInertials3)
 
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMAIS.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMAIS.c
@@ -55,6 +55,135 @@
 
 #include "EOtheMAIS_hid.h"
 
+#if defined(EOTHESERVICES_disable_theMAIS)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheMAIS* eo_mais_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheMAIS* eo_mais_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_mais_GetServiceState(EOtheMAIS *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_mais_SendReport(EOtheMAIS *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheMAIS";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_mais_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_mais_Verify(EOtheMAIS *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_mais, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_mais_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Activate(EOtheMAIS *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_mais_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Deactivate(EOtheMAIS *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Start(EOtheMAIS *p)
+    {
+        eo_mais_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_SetRegulars(EOtheMAIS *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_mais_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Tick(EOtheMAIS *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Stop(EOtheMAIS *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Transmission(EOtheMAIS *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mais_Config(EOtheMAIS *p, eOas_inertial3_config_t* config)
+    {
+        eo_mais_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mais_AcceptCANframe(EOtheMAIS *p, eOas_inertial3_type_t type, eOcanframe_t *frame, eOcanport_t port)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mais_Set(EOtheMAIS *p, eOas_mais_config_t* maiscfg)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mais_SetMode(EOtheMAIS *p, eOas_maismode_t mode)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mais_SetDataRate(EOtheMAIS *p, uint8_t datarate)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mais_SetResolution(EOtheMAIS *p, eOas_maisresolution_t resolution)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mais_notifymeOnNewReceivedData(EOtheMAIS *p)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eObool_t eo_mais_isAlive(EOtheMAIS *p)
+    {
+        return eores_NOK_generic;
+    }
+
+
+#elif !defined(EOTHESERVICES_disable_theMAIS)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -1126,6 +1255,10 @@ static void s_eo_mais_send_diagnostic_on_transmissioninterruption(void)
     descriptor.code = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag02);
     eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, "mais timeout", NULL, &descriptor);
 }
+
+#endif // #elif !defined(EOTHESERVICES_disable_theMAIS)
+
+
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMC4boards.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMC4boards.c
@@ -34,7 +34,7 @@
 #include "EOtheCANmapping.h"
 #include "EOtheCANprotocol.h"
 #include "math.h"
-
+#include "EOtheServices_hid.h"
 
 #include "EOMtheEMSappl.h"
 
@@ -52,6 +52,175 @@
 
 #include "EOtheMC4boards_hid.h"
 
+#if defined(EOTHESERVICES_disable_theMC4boards)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheMC4boards* eo_mc4boards_Initialise(const eOmc4boards_config2_t *cfg2) 
+    {   
+        return NULL; 
+    }
+
+    extern eOresult_t eo_mc4boards_LoadShifts(EOtheMC4boards *p, eOmc_mc4shifts_t shifts)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mc4boards_LoadBroadcastFlags(EOtheMC4boards *p, uint16_t flags)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern EOtheMC4boards* eo_mc4boards_GetHandle(void) 
+    {   
+        return NULL; 
+    }
+
+    extern eObool_t eo_mc4boards_AreThere(EOtheMC4boards *p)
+    {
+        return eobool_false;
+    }
+
+    extern eOresult_t eo_mc4boards_BroadcastStart(EOtheMC4boards *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mc4boards_BroadcastStop(EOtheMC4boards *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mc4boards_Config(EOtheMC4boards *p)
+    {
+        return eores_NOK_generic;
+    }
+
+
+
+    extern eOresult_t eo_mc4boards_Convert_encoderfactor_Set(EOtheMC4boards *p, uint8_t joint, eOmc4boards_conv_encoder_factor_t factor)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mc4boards_Convert_encoderoffset_Set(EOtheMC4boards *p, uint8_t joint, eOmc4boards_conv_encoder_offset_t offset)
+    {
+        return eores_NOK_generic;
+    }
+
+
+    extern void eo_mc4boards_Convert_maxJointPos_Set(EOtheMC4boards *p, uint8_t joint, icubCanProto_position_t max)
+    {
+    }
+    
+    extern void eo_mc4boards_Convert_minJointPos_Set(EOtheMC4boards *p, uint8_t joint, icubCanProto_position_t min)
+    {
+    }
+    
+    extern icubCanProto_position_t eo_mc4boards_Convert_maxJointPos_Get(EOtheMC4boards *p, uint8_t joint)
+    {
+        return 0;
+    }
+    
+    extern icubCanProto_position_t eo_mc4boards_Convert_minJointPos_Get(EOtheMC4boards *p, uint8_t joint)
+    {
+        return 0;
+    }
+    
+    extern void eo_mc4boards_Convert_maxMotorPos_Set(EOtheMC4boards *p, uint8_t joint, icubCanProto_position_t max)
+    {
+    }
+    
+    extern void eo_mc4boards_Convert_minMotorPos_Set(EOtheMC4boards *p, uint8_t joint, icubCanProto_position_t min)
+    {
+    }
+    
+    extern icubCanProto_position_t eo_mc4boards_Convert_maxMotorPos_Get(EOtheMC4boards *p, uint8_t joint)
+    {
+        return 0;
+    }
+    
+    extern icubCanProto_position_t eo_mc4boards_Convert_minMotorPos_Get(EOtheMC4boards *p, uint8_t joint)
+    {
+        return 0;
+    }
+    
+    extern eOmeas_position_t eo_mc4boards_Convert_Position_fromCAN(EOtheMC4boards *p, uint8_t joint, icubCanProto_position_t pos)
+    {
+        return 0;
+    }
+    
+    extern icubCanProto_position_t eo_mc4boards_Convert_Position_toCAN(EOtheMC4boards *p, uint8_t joint, eOmeas_position_t pos)
+    {
+        return 0;
+    }
+    
+
+
+    extern icubCanProto_velocity_t eo_mc4boards_Convert_Velocity_toCAN(EOtheMC4boards *p, uint8_t joint, eOmeas_velocity_t vel, eOmc4boards_velocitycontext_t context)
+    {
+        return 0;
+    }
+    
+    extern eOmeas_velocity_t eo_mc4boards_Convert_Velocity_fromCAN(EOtheMC4boards *p, uint8_t joint, icubCanProto_velocity_t vel)
+    {
+        return 0;
+    }
+    
+
+    extern eOmeas_acceleration_t eo_mc4boards_Convert_Acceleration_fromCAN(EOtheMC4boards *p, uint8_t joint, icubCanProto_acceleration_t acc)
+    {
+        return 0;
+    }
+    
+    extern icubCanProto_acceleration_t eo_mc4boards_Convert_Acceleration_toCAN(EOtheMC4boards *p, uint8_t joint, eOmeas_acceleration_t acc)
+    {
+        return 0;
+    }
+    
+
+    extern icubCanProto_acceleration_t eo_mc4boards_Convert_Acceleration_toCAN_abs__NEW(EOtheMC4boards *p, uint8_t joint, eOmeas_acceleration_t acc)
+    {
+        return 0;
+    }
+    
+
+
+    extern icubCanProto_stiffness_t eo_mc4boards_Convert_impedanceStiffness_I2S(EOtheMC4boards *p, uint8_t joint, eOmeas_stiffness_t stiff)
+    {
+        return 0;
+    }
+    
+    extern eOmeas_stiffness_t eo_mc4boards_Convert_impedanceStiffness_S2I(EOtheMC4boards *p, uint8_t joint, icubCanProto_stiffness_t s_stiff)
+    {
+        return 0;
+    }
+    
+
+    extern icubCanProto_damping_t eo_mc4boards_Convert_impedanceDamping_I2S(EOtheMC4boards *p, uint8_t joint, eOmeas_damping_t i_damping)
+    {
+        return 0;
+    }
+    
+    extern eOmeas_damping_t eo_mc4boards_Convert_impedanceDamping_S2I(EOtheMC4boards *p, uint8_t joint, icubCanProto_damping_t s_damping)
+    {
+        return 0;
+    }
+    
+
+    extern icubCanProto_torque_t eo_mc4boards_Convert_torque_I2S(EOtheMC4boards *p, uint8_t joint, eOmeas_torque_t i_torque)
+    {
+        return 0;
+    }
+    
+    extern eOmeas_torque_t eo_mc4boards_Convert_torque_S2I(EOtheMC4boards *p, uint8_t joint, icubCanProto_torque_t s_torque)
+    {
+        return 0;
+    }
+    
+
+
+#elif !defined(EOTHESERVICES_disable_theMC4boards)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -781,6 +950,9 @@ static eObool_t s_eo_mc4boards_foundone(void)
 
     return(found);
 }   
+
+
+#endif // #elif !defined(EOTHESERVICES_disable_theMC4boards)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMEMS.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMEMS.c
@@ -34,6 +34,7 @@
 #include "EOtheSharedHW.h"
 #include "EOaction.h"
 
+#include "EOtheServices_hid.h"
 
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -50,6 +51,52 @@
 
 #include "EOtheMEMS_hid.h"
 
+
+#if defined(EOTHESERVICES_disable_theMEMs)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+
+    extern EOtheMEMS* eo_mems_Initialise(const eOmems_cfg_t *cfg)
+    {
+        return NULL;
+    }
+
+    extern EOtheMEMS* eo_mems_GetHandle(void)
+    {
+        return NULL;
+    }
+
+    extern eObool_t eo_mems_IsSensorSupported(EOtheMEMS *p, eOmems_sensor_t sensor)
+    {
+        return eobool_false;
+    }
+
+    extern eOresult_t eo_mems_Config(EOtheMEMS *p, eOmems_sensor_cfg_t *cfg)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mems_Start(EOtheMEMS *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mems_SetAlert(EOtheMEMS *p, EOMtask *task, eOevent_t event)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_mems_Get(EOtheMEMS *p, eOas_inertial_data_t* data, eOreltime_t timeout, eOmems_sensor_t *sensor, uint16_t* remaining)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_mems_Stop(EOtheMEMS *p)
+    {
+        return eores_NOK_generic;
+    }
+
+#elif !defined(EOTHESERVICES_disable_theMEMs)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -513,7 +560,7 @@ static eObool_t s_eo_mems_deinit_gyro(void)
     return(ok);
 }
 
-
+#endif // #elif !defined(EOTHESERVICES_disable_theMEMs)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -40,7 +40,6 @@
 
 #include "EOMtheEMSappl.h"
 
-//#include "EOmcController.h"
 #include "Controller.h"
 
 #include "hal_sys.h"
@@ -68,6 +67,105 @@
 
 #include "EOtheMotionController_hid.h"
 
+
+#if defined(EOTHESERVICES_disable_theMotionController)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheMotionController* eo_motioncontrol_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheMotionController* eo_motioncontrol_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_motioncontrol_GetServiceState(EOtheMotionController *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_motioncontrol_SendReport(EOtheMotionController *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheMotionController";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_mc_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_motioncontrol_Verify(EOtheMotionController *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_mc, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_motioncontrol_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_Activate(EOtheMotionController *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_motioncontrol_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_Deactivate(EOtheMotionController *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_Start(EOtheMotionController *p)
+    {
+        eo_motioncontrol_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_SetRegulars(EOtheMotionController *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_motioncontrol_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_Tick(EOtheMotionController *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_Transmission(EOtheMotionController *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_motioncontrol_AddRegulars(EOtheMotionController *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOmotioncontroller_mode_t eo_motioncontrol_GetMode(EOtheMotionController *p)
+    {
+        return eo_motcon_mode_NONE;
+    }
+    
+    
+#elif !defined(EOTHESERVICES_disable_theMotionController)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -2003,6 +2101,8 @@ static eOresult_t s_eo_motioncontrol_updatePositionFromEncoder(uint8_t index, eO
     }
     return res;
 }    
+
+#endif // #elif !defined(EOTHESERVICES_disable_theMotionController)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOthePSC.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOthePSC.c
@@ -55,6 +55,105 @@
 
 #include "EOthePSC_hid.h"
 
+#if defined(EOTHESERVICES_disable_thePSC)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOthePSC* eo_psc_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOthePSC* eo_psc_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_psc_GetServiceState(EOthePSC *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_psc_SendReport(EOthePSC *p)
+    {
+        static const char s_eobj_ownname[] = "EOthePSC";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_psc_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_psc_Verify(EOthePSC *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_psc, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_psc_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Activate(EOthePSC *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_psc_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Deactivate(EOthePSC *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Start(EOthePSC *p)
+    {
+        eo_psc_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_SetRegulars(EOthePSC *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_psc_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Tick(EOthePSC *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Stop(EOthePSC *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Transmission(EOthePSC *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_psc_Config(EOthePSC *p, eOas_psc_config_t* config)
+    {
+        eo_psc_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_psc_AcceptCANframe(EOthePSC *p, eOcanframe_t *frame, eOcanport_t port)
+    {
+        return eores_NOK_generic;
+    }
+
+
+#elif !defined(EOTHESERVICES_disable_thePSC)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
@@ -1168,6 +1267,7 @@ static eOresult_t s_eo_psc_OnServiceAlreadyActive(EOthePSC *p, const eOmn_serv_c
     return((eobool_true == verificationOK) ? (eores_OK) : (eores_NOK_generic));      
 }       
         
+#endif // #elif !defined(EOTHESERVICES_disable_thePSC)        
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSKIN.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSKIN.c
@@ -58,6 +58,121 @@
 #include "EOtheSKIN_hid.h"
 
 
+#if defined(EOTHESERVICES_disable_theSKIN)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheSKIN* eo_skin_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheSKIN* eo_skin_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_skin_GetServiceState(EOtheSKIN *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_skin_SendReport(EOtheSKIN *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheSKIN";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_skin_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_skin_Verify(EOtheSKIN *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_skin, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_skin_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Activate(EOtheSKIN *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_skin_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Deactivate(EOtheSKIN *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Start(EOtheSKIN *p)
+    {
+        eo_skin_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_SetRegulars(EOtheSKIN *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_skin_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Tick(EOtheSKIN *p, eObool_t resetstatus)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Stop(EOtheSKIN *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Transmission(EOtheSKIN *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_Config(EOtheSKIN *p, eOas_inertial3_config_t* config)
+    {
+        eo_skin_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_SetMode(EOtheSKIN *p, uint8_t patchindex, eOsk_sigmode_t mode)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_SetBoardsConfig(EOtheSKIN *p, uint8_t patchindex, eOsk_cmd_boardsCfg_t *brdcfg)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_skin_SetTrianglesConfig(EOtheSKIN *p, uint8_t patchindex, eOsk_cmd_trianglesCfg_t *trgcfg)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_skin_AcceptCANframe(EOtheSKIN *p, eOcanframe_t *frame, eOcanport_t port)
+    {
+        return eores_NOK_generic;
+    }
+
+
+#elif !defined(EOTHESERVICES_disable_theSKIN)
+
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
 // --------------------------------------------------------------------------------------------------------------------
@@ -1323,6 +1438,8 @@ static eObool_t s_eo_skin_isID32relevant(uint32_t id32)
     
     return(eobool_false); 
 }
+
+#endif // #elif !defined(EOTHESERVICES_disable_theSKIN)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSTRAIN.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSTRAIN.c
@@ -56,7 +56,130 @@
 
 #include "EOtheSTRAIN_hid.h"
 
+#if defined(EOTHESERVICES_disable_theSTRAIN)
 
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheSTRAIN* eo_strain_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheSTRAIN* eo_strain_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_strain_GetServiceState(EOtheSTRAIN *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_strain_SendReport(EOtheSTRAIN *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheSTRAIN";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_strain_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_strain_Verify(EOtheSTRAIN *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_strain, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_strain_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Activate(EOtheSTRAIN *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_strain_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Deactivate(EOtheSTRAIN *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Start(EOtheSTRAIN *p)
+    {
+        eo_strain_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_SetRegulars(EOtheSTRAIN *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_strain_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Tick(EOtheSTRAIN *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Stop(EOtheSTRAIN *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Transmission(EOtheSTRAIN *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_strain_Config(EOtheSTRAIN *p, eOas_inertial3_config_t* config)
+    {
+        eo_strain_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_strain_GetFullScale(EOtheSTRAIN *p, eOservice_onendofoperation_fun_t overrideonfullscaleready)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_strain_Set(EOtheSTRAIN *p, eOas_strain_config_t *cfg)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_strain_SetMode(EOtheSTRAIN *p, eOas_strainmode_t mode)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_strain_SetDataRate(EOtheSTRAIN *p, uint8_t datarate)
+    {
+        return eores_NOK_generic;
+    }
+    
+    extern uint8_t eo_strain_GetDataRate(EOtheSTRAIN *p)
+    {
+        return 0;
+    }
+
+    extern eOresult_t eo_strain_notifymeOnNewReceivedData(EOtheSTRAIN *p)
+    {
+        return eores_NOK_generic;
+    }
+    
+#elif !defined(EOTHESERVICES_disable_theSTRAIN)
+    
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
 // --------------------------------------------------------------------------------------------------------------------
@@ -1149,6 +1272,9 @@ static void s_eo_strain_send_diagnostic_on_transmissioninterruption(void)
 #endif
 
 }
+
+#endif // #elif !defined(EOTHESERVICES_disable_theSTRAIN)
+
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices.c
@@ -58,6 +58,8 @@
 
 #include "testRTC.h"
 
+#include "EOtheMemoryPool.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of extern public interface
 // --------------------------------------------------------------------------------------------------------------------
@@ -312,7 +314,7 @@ extern eOresult_t eo_services_ProcessCommand(EOtheServices *p, eOmn_service_cmmn
     eOmn_serv_category_t category = (eOmn_serv_category_t)command->category;
     const eOmn_serv_configuration_t *config = &command->parameter.configuration;
     eOmn_serv_arrayof_id32_t *arrayofid32 = &command->parameter.arrayofid32;
-        
+    
     switch(operation)
     {
         case eomn_serv_operation_verifyactivate:
@@ -661,6 +663,17 @@ static void s_eo_services_initialise(EOtheServices *p)
     errdes.par16            = 0x0000;
     errdes.par64            = 0;
     eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, NULL, s_eobj_ownname, &errdes);     
+ 
+#if 0
+    // reading of how much memory we have used so far    
+    volatile uint32_t stop = 0;
+    stop = eo_mempool_SizeOfAllocated(eo_mempool_GetHandle());
+    char strr[128] = {0};
+    snprintf(strr, sizeof(strr), "mempool has used %d bytes", stop);
+    eo_errman_Trace(eo_errman_GetHandle(), strr, s_eobj_ownname);
+    
+    stop = stop;
+#endif    
 }
 
 
@@ -837,6 +850,7 @@ static eOresult_t s_eo_services_process_verifyactivate(EOtheServices *p, eOmn_se
                 errorDescriptor.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_inertials_using_onboard_config);
                 eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, NULL, s_eobj_ownname, &errorDescriptor);                    
             }
+            #warning mettere un risultato ko in modo da avvisare
             eo_inertials2_Verify(eo_inertials2_GetHandle(), config, s_services_callback_afterverify_inertial, eobool_true);            
         } break; 
         

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices_hid.h
@@ -67,6 +67,11 @@ extern "C" {
 //#define EOTHESERVICES_disable_theSKIN
 //#define EOTHESERVICES_disable_thePSC
 //#define EOTHESERVICES_disable_theMC4boards
+#define EOTHESERVICES_disable_theMotionController
+#define EOTHESERVICES_disable_theEncoderReader
+#define EOTHESERVICES_disable_CurrentsWatchdog
+#define EOTHESERVICES_disable_theMAIS
+#define EOTHESERVICES_disable_thePSC
 
 #if defined(EOTHESERVICES_disable_theInertials2) && defined(EOTHESERVICES_disable_theInertials3)
     #define EOTHESERVICES_disable_theMEMs

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices_hid.h
@@ -43,6 +43,37 @@ extern "C" {
 // - declaration of extern public interface ---------------------------------------------------------------------------
 
 #include "EOtheServices.h"
+    
+ 
+
+// - macros which enable/disable the code for the services ------------------------------------------------------------    
+    
+#include "EOtheMotionController.h"
+#include "EOtheSTRAIN.h"
+#include "EOtheMAIS.h"
+#include "EOtheSKIN.h"
+#include "EOtheInertials2.h"
+#include "EOtheInertials3.h"
+#include "EOtheTemperatures.h"
+#include "EOthePSC.h"
+
+// so far, i write them in here. later on we think of a board file or else...
+#if 0
+//#define EOTHESERVICES_disable_theInertials2
+//#define EOTHESERVICES_disable_theInertials3
+//#define EOTHESERVICES_disable_theTemperatures
+//#define EOTHESERVICES_disable_theMAIS
+//#define EOTHESERVICES_disable_theSTRAIN
+//#define EOTHESERVICES_disable_theSKIN
+//#define EOTHESERVICES_disable_thePSC
+//#define EOTHESERVICES_disable_theMC4boards
+
+#if defined(EOTHESERVICES_disable_theInertials2) && defined(EOTHESERVICES_disable_theInertials3)
+    #define EOTHESERVICES_disable_theMEMs
+#endif
+
+#endif
+
 
 
 // - definition of the hidden struct implementing the object ----------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheTemperatures.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheTemperatures.c
@@ -60,6 +60,110 @@
 #include "EOtheTemperatures_hid.h"
 
 
+#if defined(EOTHESERVICES_disable_theTemperatures)
+
+    // provide empty implementation, so that we dont need to change the caller of the API
+    
+    extern EOtheTemperatures* eo_temperatures_Initialise(void) 
+    {   
+        return NULL; 
+    }
+
+    extern EOtheTemperatures* eo_temperatures_GetHandle(void)   
+    { 
+        return NULL; 
+    }
+
+    extern eOmn_serv_state_t eo_temperatures_GetServiceState(EOtheTemperatures *p) 
+    { 
+        return eomn_serv_state_notsupported; 
+    }
+    
+    // in some cases, we need to alert the pc104 that the board does not support this service
+    extern eOresult_t eo_temperatures_SendReport(EOtheTemperatures *p)
+    {
+        static const char s_eobj_ownname[] = "EOtheTemperatures";
+        eOerrmanDescriptor_t errdes = {};
+        errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_temperatures_failed_notsupported);  
+        errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress = 0;
+        errdes.par16 = errdes.par64 = 0;
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+        return eores_OK;
+    }
+
+
+    extern eOresult_t eo_temperatures_Verify(EOtheTemperatures *p, const eOmn_serv_configuration_t * servcfg, eOservice_onendofoperation_fun_t onverify, eObool_t activateafterverify)
+    {
+        // we alert the host that the verification of the service has failed
+        eo_service_hid_SynchServiceState(eo_services_GetHandle(), eomn_serv_category_temperatures, eomn_serv_state_failureofverify);
+        if(NULL != onverify)
+        {
+            onverify(p, eobool_false); 
+        } 
+        
+        // we tell that the reason is that this service is not supported
+        eo_temperatures_SendReport(NULL);
+               
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Activate(EOtheTemperatures *p, const eOmn_serv_configuration_t * servcfg)
+    {
+        eo_temperatures_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Deactivate(EOtheTemperatures *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Start(EOtheTemperatures *p)
+    {
+        eo_temperatures_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_SetRegulars(EOtheTemperatures *p, eOmn_serv_arrayof_id32_t* arrayofid32, uint8_t* numberofthem)
+    {
+        eo_temperatures_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Tick(EOtheTemperatures *p, eObool_t resetstatus)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Stop(EOtheTemperatures *p)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Transmission(EOtheTemperatures *p, eObool_t on)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eOresult_t eo_temperatures_Config(EOtheTemperatures *p, eOas_temperature_config_t* config)
+    {
+        eo_temperatures_SendReport(NULL);
+        return eores_NOK_generic;
+    }
+    
+    extern eOresult_t eo_temperatures_AcceptCANframe(EOtheTemperatures *p, eOas_temperature_type_t type, eOcanframe_t *frame, eOcanport_t port)
+    {
+        return eores_NOK_generic;
+    }
+
+    extern eObool_t eocanprotASperiodic_redefinable_SkipParsingOf_ANY_PERIODIC_THERMOMETER_MSG(eOcanframe_t *frame, eOcanport_t port)
+    {   
+        return(eobool_false);
+    } 
+    
+#elif !defined(EOTHESERVICES_disable_theTemperatures)
+
 // --------------------------------------------------------------------------------------------------------------------
 // - #define with internal scope
 // --------------------------------------------------------------------------------------------------------------------
@@ -1495,7 +1599,7 @@ static void s_eo_temperatures_chip_configure(EOtheTemperatures *p)
 }
 
 
-
+#endif // #elif !defined(EOTHESERVICES_disable_theTemperatures)
 
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/env/eLoader/proj/eLoader.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/env/eLoader/proj/eLoader.uvoptx
@@ -10,7 +10,7 @@
     <aExt>*.s*; *.src; *.a*</aExt>
     <oExt>*.obj</oExt>
     <lExt>*.lib</lExt>
-    <tExt>*.txt; *.h; *.inc</tExt>
+    <tExt>*.txt; *.h; *.inc; *.md</tExt>
     <pExt>*.plm</pExt>
     <CppX>*.cpp</CppX>
     <nMigrate>0</nMigrate>
@@ -101,7 +101,9 @@
         <sRunDeb>0</sRunDeb>
         <sLrtime>0</sLrtime>
         <bEvRecOn>1</bEvRecOn>
-        <nTsel>0</nTsel>
+        <bSchkAxf>0</bSchkAxf>
+        <bTchkAxf>0</bTchkAxf>
+        <nTsel>1</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -112,7 +114,7 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile>.\eventviewer-stm32-cfg.ini</tIfile>
-        <pMon>BIN\UL2CM3.DLL</pMon>
+        <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
         <SetRegEntry>
@@ -123,7 +125,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-O207 -S0 -C0 -FO7  -FN1 -FC1000 -FD20000000 -FF0STM32F4xx_1024 -FL0100000 -FS08000000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM)</Name>
+          <Name>-UAny -O207 -S8 -C0 -P00000000 -N00("") -D00(00000000) -L00(0) -TO65555 -TC168000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIEFFFFFFFF -TIP8 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_1024.FLM -FS08000000 -FL0100000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -216,6 +218,7 @@
       <pMultCmdsp></pMultCmdsp>
       <DebugDescription>
         <Enable>1</Enable>
+        <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
         <DbgClock>10000000</DbgClock>
@@ -303,6 +306,8 @@
         <sRunDeb>0</sRunDeb>
         <sLrtime>0</sLrtime>
         <bEvRecOn>1</bEvRecOn>
+        <bSchkAxf>0</bSchkAxf>
+        <bTchkAxf>0</bTchkAxf>
         <nTsel>0</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
@@ -423,6 +428,7 @@
       <pMultCmdsp></pMultCmdsp>
       <DebugDescription>
         <Enable>1</Enable>
+        <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
         <DbgClock>10000000</DbgClock>
@@ -432,7 +438,7 @@
 
   <Group>
     <GroupName>application</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/env/eLoader/proj/eLoader.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/env/eLoader/proj/eLoader.uvprojx
@@ -10,14 +10,14 @@
       <TargetName>ems4</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060528::V5.06 update 5 (build 528)::ARMCC</pCCUsed>
+      <pCCUsed>5060960::V5.06 update 7 (build 960)::ARMCC</pCCUsed>
       <uAC6>0</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32F407IGHx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32F4xx_DFP.2.12.0</PackID>
-          <PackURL>http://www.keil.com/pack</PackURL>
+          <PackID>Keil.STM32F4xx_DFP.2.15.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x20000) IRAM2(0x10000000,0x10000) IROM(0x08000000,0x100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -184,6 +184,8 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
+            <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -324,6 +326,7 @@
             <uThumb>0</uThumb>
             <uSurpInc>1</uSurpInc>
             <uC99>1</uC99>
+            <uGnu>0</uGnu>
             <useXO>0</useXO>
             <v6Lang>0</v6Lang>
             <v6LangP>0</v6LangP>
@@ -349,7 +352,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>1</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls>--cpreproc</MiscControls>
               <Define></Define>
@@ -477,6 +480,7 @@
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
                 <uC99>2</uC99>
+                <uGnu>2</uGnu>
                 <useXO>2</useXO>
                 <v6Lang>0</v6Lang>
                 <v6LangP>0</v6LangP>
@@ -502,7 +506,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -525,8 +529,8 @@
         <TargetCommonOption>
           <Device>STM32F407IGHx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32F4xx_DFP.2.12.0</PackID>
-          <PackURL>http://www.keil.com/pack</PackURL>
+          <PackID>Keil.STM32F4xx_DFP.2.15.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x20000) IRAM2(0x10000000,0x10000) IROM(0x08000000,0x100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -693,6 +697,8 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
+            <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -833,6 +839,7 @@
             <uThumb>0</uThumb>
             <uSurpInc>1</uSurpInc>
             <uC99>1</uC99>
+            <uGnu>0</uGnu>
             <useXO>0</useXO>
             <v6Lang>0</v6Lang>
             <v6LangP>0</v6LangP>
@@ -858,7 +865,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>1</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls>--cpreproc</MiscControls>
               <Define></Define>
@@ -986,6 +993,7 @@
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
                 <uC99>2</uC99>
+                <uGnu>2</uGnu>
                 <useXO>2</useXO>
                 <v6Lang>0</v6Lang>
                 <v6LangP>0</v6LangP>
@@ -1011,7 +1019,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>

--- a/emBODY/eBcode/arch-arm/board/ems004/env/eUpdater/proj/eom-eupdater-open.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/env/eUpdater/proj/eom-eupdater-open.uvoptx
@@ -10,7 +10,7 @@
     <aExt>*.s*; *.src; *.a*</aExt>
     <oExt>*.obj</oExt>
     <lExt>*.lib</lExt>
-    <tExt>*.txt; *.h; *.inc</tExt>
+    <tExt>*.txt; *.h; *.inc; *.md</tExt>
     <pExt>*.plm</pExt>
     <CppX>*.cpp</CppX>
     <nMigrate>0</nMigrate>
@@ -101,7 +101,9 @@
         <sRunDeb>0</sRunDeb>
         <sLrtime>0</sLrtime>
         <bEvRecOn>1</bEvRecOn>
-        <nTsel>0</nTsel>
+        <bSchkAxf>0</bSchkAxf>
+        <bTchkAxf>0</bTchkAxf>
+        <nTsel>1</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -112,7 +114,7 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile>.\eventviewer-stm32-cfg.ini</tIfile>
-        <pMon>BIN\UL2CM3.DLL</pMon>
+        <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
         <SetRegEntry>
@@ -123,7 +125,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-O207 -S0 -C0 -FO7  -FN1 -FC1000 -FD20000000 -FF0STM32F4xx_1024 -FL0100000 -FS08000000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM)</Name>
+          <Name>-UAny -O207 -S8 -C0 -P00000000 -N00("") -D00(00000000) -L00(0) -TO65555 -TC168000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_1024.FLM -FS08000000 -FL0100000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -162,35 +164,19 @@
           <Type>0</Type>
           <LineNumber>681</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
+          <Address>134254236</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
+          <BreakIfRCount>1</BreakIfRCount>
           <Filename>..\..\..\..\common\env\eUpdater\eOcfg_sm_cangtw.c</Filename>
           <ExecCommand></ExecCommand>
-          <Expression></Expression>
+          <Expression>\\emsUpdater\../../../../common/env/eUpdater/eOcfg_sm_cangtw.c\681</Expression>
         </Bp>
         <Bp>
           <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>182</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\..\..\..\common\env\eUpdater\eom-eupdater-main.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
           <Type>0</Type>
           <LineNumber>322</LineNumber>
           <EnabledFlag>1</EnabledFlag>
@@ -206,7 +192,7 @@
           <Expression></Expression>
         </Bp>
         <Bp>
-          <Number>3</Number>
+          <Number>2</Number>
           <Type>0</Type>
           <LineNumber>473</LineNumber>
           <EnabledFlag>1</EnabledFlag>
@@ -283,7 +269,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>1</aSer4>
+        <aSer4>0</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -304,6 +290,7 @@
       <pMultCmdsp></pMultCmdsp>
       <DebugDescription>
         <Enable>1</Enable>
+        <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
         <DbgClock>10000000</DbgClock>
@@ -391,6 +378,8 @@
         <sRunDeb>0</sRunDeb>
         <sLrtime>0</sLrtime>
         <bEvRecOn>1</bEvRecOn>
+        <bSchkAxf>0</bSchkAxf>
+        <bTchkAxf>0</bTchkAxf>
         <nTsel>0</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
@@ -743,6 +732,7 @@
       </SystemViewers>
       <DebugDescription>
         <Enable>1</Enable>
+        <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
         <DbgClock>10000000</DbgClock>
@@ -752,7 +742,7 @@
 
   <Group>
     <GroupName>app</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/env/eUpdater/proj/eom-eupdater-open.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/env/eUpdater/proj/eom-eupdater-open.uvprojx
@@ -10,14 +10,14 @@
       <TargetName>ems4</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060528::V5.06 update 5 (build 528)::ARMCC</pCCUsed>
+      <pCCUsed>5060960::V5.06 update 7 (build 960)::ARMCC</pCCUsed>
       <uAC6>0</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32F407IGHx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32F4xx_DFP.2.12.0</PackID>
-          <PackURL>http://www.keil.com/pack</PackURL>
+          <PackID>Keil.STM32F4xx_DFP.2.15.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x20000) IRAM2(0x10000000,0x10000) IROM(0x08000000,0x100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -184,6 +184,8 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
+            <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -324,6 +326,7 @@
             <uThumb>0</uThumb>
             <uSurpInc>1</uSurpInc>
             <uC99>1</uC99>
+            <uGnu>0</uGnu>
             <useXO>0</useXO>
             <v6Lang>0</v6Lang>
             <v6LangP>0</v6LangP>
@@ -349,7 +352,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>1</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls>--cpreproc</MiscControls>
               <Define></Define>
@@ -761,6 +764,7 @@
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
                 <uC99>2</uC99>
+                <uGnu>2</uGnu>
                 <useXO>2</useXO>
                 <v6Lang>0</v6Lang>
                 <v6LangP>0</v6LangP>
@@ -786,7 +790,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>
@@ -809,8 +813,8 @@
         <TargetCommonOption>
           <Device>STM32F407IGHx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32F4xx_DFP.2.12.0</PackID>
-          <PackURL>http://www.keil.com/pack</PackURL>
+          <PackID>Keil.STM32F4xx_DFP.2.15.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x20000) IRAM2(0x10000000,0x10000) IROM(0x08000000,0x100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -977,6 +981,8 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
+            <RvdsMve>0</RvdsMve>
+            <RvdsCdeCp>0</RvdsCdeCp>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1117,6 +1123,7 @@
             <uThumb>0</uThumb>
             <uSurpInc>1</uSurpInc>
             <uC99>1</uC99>
+            <uGnu>0</uGnu>
             <useXO>0</useXO>
             <v6Lang>0</v6Lang>
             <v6LangP>0</v6LangP>
@@ -1142,7 +1149,7 @@
             <NoWarn>0</NoWarn>
             <uSurpInc>1</uSurpInc>
             <useXO>0</useXO>
-            <uClangAs>0</uClangAs>
+            <ClangAsOpt>4</ClangAsOpt>
             <VariousControls>
               <MiscControls>--cpreproc</MiscControls>
               <Define></Define>
@@ -1554,6 +1561,7 @@
                 <uThumb>2</uThumb>
                 <uSurpInc>2</uSurpInc>
                 <uC99>2</uC99>
+                <uGnu>2</uGnu>
                 <useXO>2</useXO>
                 <v6Lang>0</v6Lang>
                 <v6LangP>0</v6LangP>
@@ -1579,7 +1587,7 @@
                 <NoWarn>2</NoWarn>
                 <uSurpInc>2</uSurpInc>
                 <useXO>2</useXO>
-                <uClangAs>2</uClangAs>
+                <ClangAsOpt>0</ClangAsOpt>
                 <VariousControls>
                   <MiscControls></MiscControls>
                   <Define></Define>


### PR DESCRIPTION
This PR adds the support for for disabling some services at compile time in order to save RAM in some special configurations.

That is done by defining in the projects of ems, mc4plus or mc2plus special macros which changes the standard definition of the public functions and provide a dummy one.

These macros are disabled by default, so they do not change the standard behaviour of the ETH boards.

These macros are

```C++
#if 0
#undef EOTHESERVICES_disable_theInertials2
#undef EOTHESERVICES_disable_theInertials3
#undef EOTHESERVICES_disable_theMEMs
#undef EOTHESERVICES_disable_theTemperatures
#undef EOTHESERVICES_disable_theMAIS
#undef EOTHESERVICES_disable_theSTRAIN
#undef EOTHESERVICES_disable_theSKIN
#undef EOTHESERVICES_disable_thePSC
#undef EOTHESERVICES_disable_theMC4boards
#undef EOTHESERVICES_disable_theMotionController
#undef EOTHESERVICES_disable_theEncoderReader
#undef EOTHESERVICES_disable_CurrentsWatchdog

#if defined(EOTHESERVICES_disable_theInertials2) && defined(EOTHESERVICES_disable_theInertials3)
    #define EOTHESERVICES_disable_theMEMs
#endif

#endif

``` 
They could for instance compile w/ the `-DEOTHESERVICES_disable_theInertials3` option in a demo project where we don need for the `EOtheInertials3` service.

In doing the test, I have also computed an estimate of RAM requirements of some services. I report them in the following tables.


| Service             | Used RAM (bytes) |
| ------------------- | ---------------- |
| `EOtheSKIN`         | 2944             |
| `EOtheInertials3`   | 1248             |
| `EOtheInertials2`   | 896              |
| `EOtheTemperatures` | 456              |
| `EOtheMAIS`         | 200              |
| `EOtheSTRAIN`       | 200              |
| `EOthePSC`          | 176              |
| Total of the above  | 6120             |



| EOtheMotionController                     | Used RAM (bytes)                                             |
| ----------------------------------------- | ------------------------------------------------------------ |
| `EOtheEncoderReader`                      | 112                                                          |
| `EOCurrentsWatchdog`                      | 0, but it is called in runtime  |
| `MController`                             | 5224                                                         |
| `EOtheMotionController` as a wrapper only | 352                                                          |
| `EOtheMAIS`                               | 200                                                          |
| `EOthePSC`                                | 176                                                          |
| Total of the above                        | 6064                                                        |

