### PR TITLE
ETH boards: all services now have _AcceptCANframe() to manage incoming CAN frames

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials2.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials2.c
@@ -151,7 +151,7 @@
         return eores_NOK_generic;
     }
     
-    extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOas_inertial_type_t type, eOcanframe_t *frame, eOcanport_t port)
+    extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOcanframe_t *frame, eOcanport_t port, eOas_inertial_type_t type)
     {
         return eores_NOK_generic;
     }
@@ -948,7 +948,7 @@ extern eOresult_t eo_inertials2_Config(EOtheInertials2 *p, eOas_inertial_config_
 }
 
 
-extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOas_inertial_type_t type, eOcanframe_t *frame, eOcanport_t port)
+extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOcanframe_t *frame, eOcanport_t port, eOas_inertial_type_t type)
 {
     if(NULL == p)
     {

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials2.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials2.h
@@ -91,7 +91,7 @@ extern eOresult_t eo_inertials2_Transmission(EOtheInertials2 *p, eObool_t on);
 
 // we can call them if _Activate() was called. they are used by the callbacks of eth protocol
 extern eOresult_t eo_inertials2_Config(EOtheInertials2 *p, eOas_inertial_config_t* config);
-extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOas_inertial_type_t type, eOcanframe_t *frame, eOcanport_t port);
+extern eOresult_t eo_inertials2_AcceptCANframe(EOtheInertials2 *p, eOcanframe_t *frame, eOcanport_t port, eOas_inertial_type_t type);
 
 
 /** @}            

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
@@ -150,7 +150,7 @@
         return eores_NOK_generic;
     }
     
-    extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOas_inertial3_type_t type, eOcanframe_t *frame, eOcanport_t port)
+    extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOcanframe_t *frame, eOcanport_t port, eOas_inertial3_type_t type)
     {
         return eores_NOK_generic;
     }
@@ -1060,7 +1060,7 @@ extern eOresult_t eo_inertials3_Config(EOtheInertials3 *p, eOas_inertial3_config
 }
 
 
-extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOas_inertial3_type_t type, eOcanframe_t *frame, eOcanport_t port)
+extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOcanframe_t *frame, eOcanport_t port, eOas_inertial3_type_t type)
 {
     if(NULL == p)
     {

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.h
@@ -91,7 +91,7 @@ extern eOresult_t eo_inertials3_Transmission(EOtheInertials3 *p, eObool_t on);
 
 // we can call them if _Activate() was called. they are used by the callbacks of eth protocol
 extern eOresult_t eo_inertials3_Config(EOtheInertials3 *p, eOas_inertial3_config_t* config);
-extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOas_inertial3_type_t type, eOcanframe_t *frame, eOcanport_t port);
+extern eOresult_t eo_inertials3_AcceptCANframe(EOtheInertials3 *p, eOcanframe_t *frame, eOcanport_t port, eOas_inertial3_type_t type);
 
 
 /** @}            

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMAIS.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMAIS.h
@@ -55,9 +55,11 @@ extern "C" {
 typedef struct EOtheMAIS_hid EOtheMAIS;
 
 
-//typedef eOresult_t (*eOmais_onendofoperation_fun_t) (EOtheMAIS* p, eObool_t operationisok);
-
-
+typedef enum 
+{
+    processHES0TO6      = 0,    
+    processHES7TO14     = 1     
+} maisProcessMode_t;
    
 // - declaration of extern public variables, ...deprecated: better using use _get/_set instead ------------------------
 // empty-section
@@ -92,15 +94,14 @@ extern uint8_t eo_mais_GetNumberOfOwners(EOtheMAIS *p); // start() increments ow
 // it enables/disables transmission of the mais board. _Start() just starts the service, not the transmission
 extern eOresult_t eo_mais_Transmission(EOtheMAIS *p, eObool_t on);
 
-
+extern eOresult_t eo_mais_AcceptCANframe(EOtheMAIS *p, eOcanframe_t *frame, eOcanport_t port, maisProcessMode_t mode);
 
 // we can call them if _Activate() was called. they are used by the callbacks of eth protocol if robotInterface uses a mais device.
 extern eOresult_t eo_mais_Set(EOtheMAIS *p, eOas_mais_config_t* maiscfg);
 extern eOresult_t eo_mais_SetMode(EOtheMAIS *p, eOas_maismode_t mode);
+extern eObool_t eo_mais_isAlive(EOtheMAIS *p); // checks if the mais regularly transmits
 extern eOresult_t eo_mais_SetDataRate(EOtheMAIS *p, uint8_t datarate);
 extern eOresult_t eo_mais_SetResolution(EOtheMAIS *p, eOas_maisresolution_t resolution);
-extern eOresult_t eo_mais_notifymeOnNewReceivedData(EOtheMAIS *p);
-extern eObool_t eo_mais_isAlive(EOtheMAIS *p);
 
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMC4boards.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMC4boards.c
@@ -96,7 +96,10 @@
         return eores_NOK_generic;
     }
 
-
+    extern eOresult_t eo_mc4boards_AcceptCANframe(EOtheMC4boards *p, eOcanframe_t *frame, eOcanport_t port, eOmc4boards_canframe_t cftype)
+    {
+        return eores_NOK_generic;
+    }
 
     extern eOresult_t eo_mc4boards_Convert_encoderfactor_Set(EOtheMC4boards *p, uint8_t joint, eOmc4boards_conv_encoder_factor_t factor)
     {
@@ -582,6 +585,11 @@ extern eOresult_t eo_mc4boards_Config(EOtheMC4boards *p)
     return(eores_OK);       
 }
 
+extern eOresult_t eo_mc4boards_AcceptCANframe(EOtheMC4boards *p, eOcanframe_t *frame, eOcanport_t port, eOmc4boards_canframe_t cftype)
+{
+    return eores_OK;
+}
+    
 
 extern eOresult_t eo_mc4boards_Convert_encoderfactor_Set(EOtheMC4boards *p, uint8_t joint, eOmc4boards_conv_encoder_factor_t factor)
 {

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMC4boards.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMC4boards.h
@@ -95,6 +95,14 @@ extern eOresult_t eo_mc4boards_BroadcastStop(EOtheMC4boards *p);
 
 extern eOresult_t eo_mc4boards_Config(EOtheMC4boards *p);
 
+typedef enum 
+{   // put in here the types of motioncontrol can frames
+
+    eo_mc4_canframe_unknown = 255    
+} eOmc4boards_canframe_t;
+
+extern eOresult_t eo_mc4boards_AcceptCANframe(EOtheMC4boards *p, eOcanframe_t *frame, eOcanport_t port, eOmc4boards_canframe_t cftype);
+
 
 
 extern eOresult_t eo_mc4boards_Convert_encoderfactor_Set(EOtheMC4boards *p, uint8_t joint, eOmc4boards_conv_encoder_factor_t factor);

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -164,6 +164,11 @@
         return eo_motcon_mode_NONE;
     }
     
+    extern eOresult_t eo_motioncontrol_AcceptCANframe(EOtheMotionController *p, eOcanframe_t *frame, eOcanport_t port, eOmotioncontroller_canframe_t cftype)
+    {
+        return eores_NOK_generic;
+    }
+    
     
 #elif !defined(EOTHESERVICES_disable_theMotionController)
 
@@ -1285,6 +1290,12 @@ extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p)
     // eo_errman_Trace(eo_errman_GetHandle(), "eo_motioncontrol_Stop()", s_eobj_ownname);
     
     return(eores_OK);    
+}
+
+
+extern eOresult_t eo_motioncontrol_AcceptCANframe(EOtheMotionController *p, eOcanframe_t *frame, eOcanport_t port, eOmotioncontroller_canframe_t cftype)
+{
+    return eores_OK;
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.h
@@ -98,7 +98,13 @@ extern eOresult_t eo_motioncontrol_Tick(EOtheMotionController *p);
 
 extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p);
 
+typedef enum 
+{   // put in here the types of motioncontrol can frames
 
+    eo_motcon_canframe_unknown = 255    
+} eOmotioncontroller_canframe_t;
+
+extern eOresult_t eo_motioncontrol_AcceptCANframe(EOtheMotionController *p, eOcanframe_t *frame, eOcanport_t port, eOmotioncontroller_canframe_t cftype);
 
 
 /** @}            

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSTRAIN.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSTRAIN.h
@@ -54,6 +54,13 @@ extern "C" {
 typedef struct EOtheSTRAIN_hid EOtheSTRAIN;
 
 
+typedef enum 
+{
+    processForce    = 0,    // keep it 0 so that we index teh array in position 0*3 = 0
+    processTorque   = 1,    // keep it 1 so taht we index teh array in position 1*3 = 3
+    processDebugForce = 2,
+    processDebugTorque = 3
+} strainProcessMode_t;
 
 //typedef eOresult_t (*eOstrain_onendofoperation_fun_t) (EOtheSTRAIN* p, eObool_t operationisok);
    
@@ -89,6 +96,7 @@ extern eOresult_t eo_strain_Stop(EOtheSTRAIN *p);
 // it enables/disables transmission of the strain board. _Start() just starts the service, not the transmission
 extern eOresult_t eo_strain_Transmission(EOtheSTRAIN *p, eObool_t on);
 
+extern eOresult_t eo_strain_AcceptCANframe(EOtheSTRAIN *p, eOcanframe_t *frame, eOcanport_t port, strainProcessMode_t mode);
 
 // we can call them if _Activate() was called. they are used by the callbacks of eth protocol
 extern eOresult_t eo_strain_GetFullScale(EOtheSTRAIN *p, eOservice_onendofoperation_fun_t overrideonfullscaleready);
@@ -97,7 +105,6 @@ extern eOresult_t eo_strain_SetMode(EOtheSTRAIN *p, eOas_strainmode_t mode);
 extern eOresult_t eo_strain_SetDataRate(EOtheSTRAIN *p, uint8_t datarate);
 extern uint8_t eo_strain_GetDataRate(EOtheSTRAIN *p);
 
-extern eOresult_t eo_strain_notifymeOnNewReceivedData(EOtheSTRAIN *p);
 
 
 /** @}            

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheServices_hid.h
@@ -59,6 +59,7 @@ extern "C" {
 
 // so far, i write them in here. later on we think of a board file or else...
 #if 0
+
 //#define EOTHESERVICES_disable_theInertials2
 //#define EOTHESERVICES_disable_theInertials3
 //#define EOTHESERVICES_disable_theTemperatures
@@ -67,15 +68,13 @@ extern "C" {
 //#define EOTHESERVICES_disable_theSKIN
 //#define EOTHESERVICES_disable_thePSC
 //#define EOTHESERVICES_disable_theMC4boards
-#define EOTHESERVICES_disable_theMotionController
-#define EOTHESERVICES_disable_theEncoderReader
-#define EOTHESERVICES_disable_CurrentsWatchdog
-#define EOTHESERVICES_disable_theMAIS
-#define EOTHESERVICES_disable_thePSC
+//#define EOTHESERVICES_disable_theMotionController
+//#define EOTHESERVICES_disable_theEncoderReader
+//#define EOTHESERVICES_disable_CurrentsWatchdog
 
-#if defined(EOTHESERVICES_disable_theInertials2) && defined(EOTHESERVICES_disable_theInertials3)
-    #define EOTHESERVICES_disable_theMEMs
-#endif
+//#if defined(EOTHESERVICES_disable_theInertials2) && defined(EOTHESERVICES_disable_theInertials3)
+//    #define EOTHESERVICES_disable_theMEMs
+//#endif
 
 #endif
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotASperiodic.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotASperiodic.c
@@ -68,32 +68,13 @@
 // - typedef with internal scope
 // --------------------------------------------------------------------------------------------------------------------
 
-typedef enum 
-{
-    processForce    = 0,    // keep it 0 so that we index teh array in position 0*3 = 0
-    processTorque   = 1     // keep it 1 so taht we index teh array in position 1*3 = 3
-} strainProcessMode_t;
-
-
-typedef enum 
-{
-    processHES0TO6      = 0,    
-    processHES7TO14     = 1     
-} maisProcessMode_t;
 
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of static functions
 // --------------------------------------------------------------------------------------------------------------------
 
-static void* s_eocanprotASperiodic_get_entity(eOprotEndpoint_t endpoint, eOprot_entity_t entity, eOcanframe_t *frame, eOcanport_t port, uint8_t *index);
-
-static eOresult_t s_eocanprotASperiodic_parser_process_forcetorque(eOcanframe_t *frame, eOcanport_t port, strainProcessMode_t mode);
-
-static eOresult_t s_eocanprotASperiodic_parser_process_maisvalue(eOcanframe_t *frame, eOcanport_t port, maisProcessMode_t mode);
-
 static void s_former_PER_AS_prepare_frame(eOcanprot_descriptor_t *descriptor, eOcanframe_t *frame, uint8_t len, uint8_t type);
 
-static void s_eocanprotASperiodic_strain_saturation_handler(eOcanframe_t *frame, eOcanport_t port, strainProcessMode_t mode);
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of static variables
@@ -123,36 +104,14 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__POS(eOcanframe_t *frame
 extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__UNCALIBFORCE_VECTOR_DEBUGMODE(eOcanframe_t *frame, eOcanport_t port)
 {
     // this can frame is from strain only ... i dont do the check that the board must be a strain
-    // i retrieve the strain entity related to the frame    
-    eOas_strain_t *strain = NULL;
-    eOprotIndex_t index = EOK_uint08dummy;
-    
-    if(NULL == (strain = (eOas_strain_t*) s_eocanprotASperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_strain, frame, port, &index)))
-    {
-        return(eores_OK);  
-    }    
-    
-    // copy into status... it should be done using the EOarray ....
-    // memcpy(&(strain->status.uncalibratedvalues.data[0]), &frame->data[0], 6);   
-    eo_array_Assign((EOarray*)(&strain->status.uncalibratedvalues), 0, &(frame->data[0]), 3);
+    eo_strain_AcceptCANframe(eo_strain_GetHandle(), frame, port, processDebugForce);
     return(eores_OK);    
 }
 
 extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__UNCALIBTORQUE_VECTOR_DEBUGMODE(eOcanframe_t *frame, eOcanport_t port)
 {
     // this can frame is from strain only ... i dont do the check that the board must be a strain
-    // i retrieve the strain entity related to the frame    
-    eOas_strain_t *strain = NULL;
-    eOprotIndex_t index = EOK_uint08dummy;
-    
-    if(NULL == (strain = (eOas_strain_t*) s_eocanprotASperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_strain, frame, port, &index)))
-    {
-        return(eores_OK);  
-    }    
-    
-    // copy into status... it should be done using the EOarray ....
-    // memcpy(&(status->uncalibratedvalues.data[6]), &frame->data[0], 6); 
-    eo_array_Assign((EOarray*)(&strain->status.uncalibratedvalues), 3, &(frame->data[0]), 3);
+    eo_strain_AcceptCANframe(eo_strain_GetHandle(), frame, port, processDebugTorque);
     return(eores_OK);    
 }
 
@@ -168,7 +127,7 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__FORCE_VECTOR(eOcanframe
 {
     // this can frame is from strain only ... i dont do the check that the board must be a strain
     // process force
-    s_eocanprotASperiodic_parser_process_forcetorque(frame, port, processForce);
+    eo_strain_AcceptCANframe(eo_strain_GetHandle(), frame, port, processForce);
     return(eores_OK);
 }
 
@@ -185,7 +144,7 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__TORQUE_VECTOR(eOcanfram
 {
     // this can frame is from strain only ... i dont do the check that the board must be a strain
     // process torque
-    s_eocanprotASperiodic_parser_process_forcetorque(frame, port, processTorque);
+    eo_strain_AcceptCANframe(eo_strain_GetHandle(), frame, port, processTorque);
     return(eores_OK);
 }
 
@@ -194,7 +153,7 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__HES0TO6(eOcanframe_t *f
 {
     // this can frame is from mais only ... i dont do the check that the board must be a mais
     // process values
-    s_eocanprotASperiodic_parser_process_maisvalue(frame, port, processHES0TO6);
+    eo_mais_AcceptCANframe(eo_mais_GetHandle(), frame, port, processHES0TO6);
     return(eores_OK);    
 }
 
@@ -203,7 +162,7 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__HES7TO14(eOcanframe_t *
 {
     // this can frame is from mais only ... i dont do the check that the board must be a mais
     // process values
-    s_eocanprotASperiodic_parser_process_maisvalue(frame, port, processHES7TO14);
+    eo_mais_AcceptCANframe(eo_mais_GetHandle(), frame, port, processHES7TO14);
     return(eores_OK);    
 }
 
@@ -215,13 +174,9 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__THERMOMETER_MEASURE(eOc
         return(eores_OK);
     }    
 
-    eo_temperatures_AcceptCANframe(eo_temperatures_GetHandle(), eoas_temperature_t1, frame, port);
-    
+    eo_temperatures_AcceptCANframe(eo_temperatures_GetHandle(), eoas_temperature_t1, frame, port);    
     return(eores_OK);    
 }
-
-
-
 
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -235,6 +190,22 @@ extern eOresult_t eocanprotASperiodic_parser_PER_AS_MSG__THERMOMETER_MEASURE(eOc
 // - definition of static functions 
 // --------------------------------------------------------------------------------------------------------------------
 
+
+static void s_former_PER_AS_prepare_frame(eOcanprot_descriptor_t *descriptor, eOcanframe_t *frame, uint8_t len, uint8_t type)
+{   // for periodic the descriptor->address contains ... the origin
+    uint8_t origin = descriptor->loc.addr;
+    frame->id           = EOCANPROT_CREATE_CANID_PERIODIC(eocanprot_msgclass_periodicAnalogSensor, origin, type);
+    frame->id_type      = eocanframeID_std11bits;
+    frame->frame_type   = eocanframetype_data; 
+    frame->size         = len;
+}
+
+// marco.accame on 23 nov 2020. 
+// this function retrieves the entity from the can frame and it works fine. but we dont use it in here because we use
+// the _AcceptCANframe() methods of the related objects. 
+// nevertheless i would like to keep it even if under a #if 0 
+//     //if(NULL == (strain = (eOas_strain_t*) s_eocanprotASperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_strain, frame, port, &index)))
+#if 0
 static void* s_eocanprotASperiodic_get_entity(eOprotEndpoint_t endpoint, eOprot_entity_t entity, eOcanframe_t *frame, eOcanport_t port, uint8_t *index)
 {
     void * ret = NULL;
@@ -263,241 +234,8 @@ static void* s_eocanprotASperiodic_get_entity(eOprotEndpoint_t endpoint, eOprot_
     return(ret);   
 }
 
-
-static eOresult_t s_eocanprotASperiodic_parser_process_forcetorque(eOcanframe_t *frame, eOcanport_t port, strainProcessMode_t mode)
-{
-    // this can frame is from strain only ... i dont do the check that the board must be a strain
-    // i retrieve the strain entity related to the frame    
-    eOas_strain_t *strain = NULL;
-    eOprotIndex_t index = EOK_uint08dummy;
-    
-    if(NULL == (strain = (eOas_strain_t*) s_eocanprotASperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_strain, frame, port, &index)))
-    {
-        return(eores_OK);  
-    }    
-    
-    eObool_t update_watchdog = eobool_false;
-    
-    // set incoming force values
-    switch(strain->config.mode)
-    {
-        case eoas_strainmode_txcalibrateddatacontinuously:
-        case eoas_strainmode_txalldatacontinuously:
-        {
-            eo_array_Assign((EOarray*)(&strain->status.calibratedvalues), 3*mode, &(frame->data[0]), 3);
-            update_watchdog = eobool_true;
-        } break;
-
-        case eoas_strainmode_txuncalibrateddatacontinuously:
-        {
-            eo_array_Assign((EOarray*)(&strain->status.uncalibratedvalues), 3*mode, &(frame->data[0]), 3);
-            update_watchdog = eobool_true;
-        } break;
-        
-        case eoas_strainmode_acquirebutdonttx:
-        {
-            // i dont do anything in here. but i dont return nok. because it may be that we must empty a rx buffer of canframes rx just before
-            // that we have silenced the strain.
-        } break;
-        
-        default:
-        {
-            //i must never be here
-            //#warning -> TODO: add diagnostics about unknown mode as in s_eo_icubCanProto_mb_send_runtime_error_diagnostics()
-        }
-    }
-    
-    if(update_watchdog)
-    {
-        eo_strain_notifymeOnNewReceivedData(eo_strain_GetHandle());
-    }
-        
-    
-    //check saturation
-//#define SIMPLE_SATURATION_DIAGNOSTIC
-#if defined (SIMPLE_SATURATION_DIAGNOSTIC)
-    static uint16_t count_message = 0;
-    if (frame->size == 7)
-    {
-        //check 7th byte, which should include the saturation bit
-        if (frame->data[6] != 0x00)
-        //send dedicated diagnostics
-        {
-            if ((count_message == 0) || (count_message == 300)) //if it's the first time or every 300ms, if it's continuosly saturating
-            {              
-                eOerrmanDescriptor_t errdes = {0};
-                errdes.sourcedevice         = (eOcanport1 == port) ? (eo_errman_sourcedevice_canbus1) : (eo_errman_sourcedevice_canbus2);
-                errdes.sourceaddress        = EOCANPROT_FRAME_GET_SOURCE(frame);                
-                errdes.code                 = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_strain_saturation);
-                errdes.par16                = frame->size;
-                errdes.par64                = eo_common_canframe_data2u64((eOcanframe_t*)frame);
-                eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
-            }
-            
-            if (count_message == 300)
-                count_message = 0;
-            
-            count_message++;
-        }
-    }
-    else
-    {
-       count_message = 0; 
-    }
-#else
-//    static uint16_t counter = 0;
-//    counter++;
-//    
-//    if (counter > 2000) // stays for 1 second...
-//        counter = 0;
-   
-    s_eocanprotASperiodic_strain_saturation_handler(frame, port, mode);
 #endif
-    
-    return(eores_OK);
-}
 
-static eOresult_t s_eocanprotASperiodic_parser_process_maisvalue(eOcanframe_t *frame, eOcanport_t port, maisProcessMode_t mode)
-{
-    // this can frame is from strain only ... i dont do the check that the board must be a strain
-    // i retrieve the strain entity related to the frame    
-    eOas_mais_t *mais = NULL;
-    eOprotIndex_t index = EOK_uint08dummy;
-    
-    if(NULL == (mais = (eOas_mais_t*) s_eocanprotASperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_mais, frame, port, &index)))
-    {
-        return(eores_OK);  
-    }  
-
-    EOarray* array = (EOarray*)&mais->status.the15values;
-    if(processHES0TO6 == mode)
-    {
-        eo_array_Assign(array, 0, &(frame->data[0]), 7); // 7 bytes of frame->data starting from array position 0 (0, 1, .. , 6)
-    }
-    else //if(processHES7TO14 == mode)
-    {
-        eo_array_Assign(array, 7, &(frame->data[0]), 8); // 8 bytes of frame->data starting from array position 7 (7, 8, .. , 14)
-    }
-        
-    eo_mais_notifymeOnNewReceivedData(eo_mais_GetHandle());
-    
-    return(eores_OK);       
-}
-
-static void s_former_PER_AS_prepare_frame(eOcanprot_descriptor_t *descriptor, eOcanframe_t *frame, uint8_t len, uint8_t type)
-{   // for periodic the descriptor->address contains ... the origin
-    uint8_t origin = descriptor->loc.addr;
-    frame->id           = EOCANPROT_CREATE_CANID_PERIODIC(eocanprot_msgclass_periodicAnalogSensor, origin, type);
-    frame->id_type      = eocanframeID_std11bits;
-    frame->frame_type   = eocanframetype_data; 
-    frame->size         = len;
-}
-
-static void s_eocanprotASperiodic_strain_saturation_handler(eOcanframe_t *frame, eOcanport_t port, strainProcessMode_t mode)
-{
-    static uint16_t upper_saturations[6] = {0};
-    static uint16_t lower_saturations[6] = {0};
-    
-    static uint32_t counter = 0;
-    
-    counter ++;
-    
-    uint8_t strainTXrate = eo_strain_GetDataRate(eo_strain_GetHandle()); // in ms. get it from strain object ....
-    uint32_t numberofmessagesin1second = 2000*strainTXrate; // strai sends 2 msgs (1 for force and 1 for torque) every strainTXrate milli.
-    
-    //there's saturation
-    if (frame->size == 7)
-    {
-        uint8_t info = frame->data[6]; //byte containing info about saturation
-    
-        if (info != 0)
-        {
-            switch (mode)
-            {
-                case processForce:
-                {
-                    icubCanProto_strain_forceSaturationInfo_t* force_info = (icubCanProto_strain_forceSaturationInfo_t*) &info; 
-                    
-                    if (force_info->saturationInChannel_0 == saturationLOW)
-                        lower_saturations[0]++;
-                    else if (force_info->saturationInChannel_0 == saturationHIGH)
-                        upper_saturations[0]++;
-            
-                    if (force_info->saturationInChannel_1 == saturationLOW)
-                        lower_saturations[1]++;
-                    else if (force_info->saturationInChannel_1 == saturationHIGH)
-                        upper_saturations[1]++;
-                   
-                    if (force_info->saturationInChannel_2 == saturationLOW)
-                         lower_saturations[2]++;
-                    else if (force_info->saturationInChannel_2 == saturationHIGH)
-                         upper_saturations[2]++;            
-                } break;                 
-                case processTorque:
-                {
-                    icubCanProto_strain_torqueSaturationInfo_t* torque_info = (icubCanProto_strain_torqueSaturationInfo_t*) &info;
-                 
-                    if (torque_info->saturationInChannel_3 == saturationLOW)
-                        lower_saturations[3]++;
-                    else if (torque_info->saturationInChannel_3 == saturationHIGH)
-                        upper_saturations[3]++;
-                    
-                    if (torque_info->saturationInChannel_4 == saturationLOW)
-                        lower_saturations[4]++;
-                    else if (torque_info->saturationInChannel_4 == saturationHIGH)
-                        upper_saturations[4]++;
-                    
-                    if (torque_info->saturationInChannel_5 == saturationLOW)
-                        lower_saturations[5]++;
-                    else if (torque_info->saturationInChannel_5 == saturationHIGH)
-                        upper_saturations[5]++;
-                } break;                
-                
-            }
-        }
-        else
-        {
-            // send diag message about malformed message
-            // uncomment if you need it for debugging
-            /*
-            eOerrmanDescriptor_t errdes = {0};
-            errdes.sourcedevice         = (eOcanport1 == port) ? (eo_errman_sourcedevice_canbus1) : (eo_errman_sourcedevice_canbus2);
-            errdes.sourceaddress        = EOCANPROT_FRAME_GET_SOURCE(frame);                
-            errdes.code                 = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag01);
-            errdes.par16                = 0;
-            errdes.par64                = 0;
-            eo_errman_Error(eo_errman_GetHandle(), eo_errortype_debug, "strain saturation byte 7 (if sent) should be different from 0!", NULL, &errdes);
-            */
-        }    
-    
-    }
-    
- 
-    if((numberofmessagesin1second > 0) && (counter >= numberofmessagesin1second))
-    {   // ok, 1 second has expired (or better: so many messages have arrived for 1 second). 
-            
-        // reset counter    
-        counter = 0;
-            
-        // send saturation message for every channel, if any
-        for(uint8_t i = 0; i < 6; i++)
-        {
-            eOerrmanDescriptor_t errdes = {0};
-            if (upper_saturations[i] != 0 || lower_saturations[i] != 0)
-            {
-                errdes.sourcedevice         = (eOcanport1 == port) ? (eo_errman_sourcedevice_canbus1) : (eo_errman_sourcedevice_canbus2);
-                errdes.sourceaddress        = EOCANPROT_FRAME_GET_SOURCE(frame);                
-                errdes.code                 = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_strain_saturation);
-                errdes.par16                = i; //channel involved
-                errdes.par64                = (uint64_t) (upper_saturations[i]) << 32 | (uint64_t) lower_saturations[i]; //LSW->lower_sat, MSW->upper_sat
-                eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
-                
-                upper_saturations[i] = 0;
-                lower_saturations[i] = 0;
-            }
-         }                     
-    }
-}
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
@@ -73,9 +73,6 @@
 // - declaration of static functions
 // --------------------------------------------------------------------------------------------------------------------
 
-//static void* s_eocanprotISperiodic_get_entity(eOprotEndpoint_t endpoint, eOprot_entity_t entity, eOcanframe_t *frame, eOcanport_t port, uint8_t *index);
-
-
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of static variables
@@ -105,26 +102,9 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_GYROSCOPE(eOcan
         return(eores_OK);
     }
     
-    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), eoas_inertial_gyros_mtb_ext, frame, port);
+    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_gyros_mtb_ext);
     
     return(eores_OK);
-    
-//    // this can frame is from mtb only ... i dont do the check that the board must be a mbt
-//    // i retrieve the inertial entity related to the frame    
-//    eOas_inertial_t *inertial = NULL;
-//    eOprotIndex_t index = EOK_uint08dummy;
-//    
-//    if(NULL == (inertial = s_eocanprotISperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_inertial, frame, port, &index)))
-//    {
-//        return(eores_OK);  
-//    }    
-//    
-//    inertial->status.gyroscope.x = (int16_t)((frame->data[1]<<8) + frame->data[0]);
-//    inertial->status.gyroscope.y = (int16_t)((frame->data[3]<<8) + frame->data[2]);
-//    inertial->status.gyroscope.z = (int16_t)((frame->data[5]<<8) + frame->data[4]);
-//    inertial->status.gyroscope.ffu = 1; // i set it true.
-//
-//    return(eores_OK);    
 }
 
 extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_ACCELEROMETER(eOcanframe_t *frame, eOcanport_t port)
@@ -135,81 +115,11 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_ACCELEROMETER(e
         return(eores_OK);
     }
     
-    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), eoas_inertial_accel_mtb_int, frame, port);
+    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_accel_mtb_int);
     
-    return(eores_OK);
-    
-//    // this can frame is from mtb only ... i dont do the check that the board must be a mbt
-//    // i retrieve the inertial entity related to the frame    
-//    eOas_inertial_t *inertial = NULL;
-//    eOprotIndex_t index = EOK_uint08dummy;
-//    
-//    if(NULL == (inertial = s_eocanprotISperiodic_get_entity(eoprot_endpoint_analogsensors, eoprot_entity_as_inertial, frame, port, &index)))
-//    {
-//        return(eores_OK);  
-//    }    
-//    
-//    inertial->status.accelerometer.x = (int16_t)((frame->data[1]<<8) + frame->data[0]);
-//    inertial->status.accelerometer.y = (int16_t)((frame->data[3]<<8) + frame->data[2]);
-//    inertial->status.accelerometer.z = (int16_t)((frame->data[5]<<8) + frame->data[4]);
-//    inertial->status.accelerometer.ffu = 1; // i set it true.
-//    
-//    return(eores_OK);
+    return(eores_OK);    
 }
 
-//typedef struct
-//{
-//    uint8_t index;
-//    uint64_t data[16];      
-//    uint64_t delta[16];
-//    uint64_t pr;
-//} pipe_t;
-
-//void pipe_add(pipe_t *p, uint64_t v)
-//{
-//    //static uint64_t pr = 0;
-//    p->data[p->index] = v;   
-//    p->delta[p->index] = v - p->pr;
-//    p->pr = v;
-//    
-//    p->index++;
-//    p->index = p->index % 16;    
-//}
-
-//static pipe_t pipe = {0, {0}, {0}, {0}};
-
-//static pipe_t timepipe = {0, {0}, {0}, {0}};
-
-//void debugPprint(eOcanframe_t *frame)
-//{
-//    static uint32_t prevnozerodataindex = 0;
-//    static uint32_t nozerodataindex = 0;
-//    static uint32_t index = 0;
-//    
-//    
-//    uint64_t msnow = eov_sys_LifeTimeGet(eov_sys_GetHandle());
-//    
-//    pipe_add(&timepipe, msnow/1000);
-//    
-//    if(frame->id == 0x513)
-//    {
-//        uint8_t seq = frame->data[0];
-//        int16_t x = (int16_t)(frame->data[2]) | (int16_t)(frame->data[3]) << 8;
-//        int16_t y = (int16_t)(frame->data[4]) | (int16_t)(frame->data[5]) << 8;
-//        int16_t z = (int16_t)(frame->data[6]) | (int16_t)(frame->data[7]) << 8;
-//        if(x != 0)
-//        {
-//            prevnozerodataindex = nozerodataindex;
-//            nozerodataindex = index; 
-
-//            prevnozerodataindex = prevnozerodataindex;
-//            
-//            pipe_add(&pipe, index);            
-//        }
-//        
-//        index ++;                       
-//    }        
-//}
 
 extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__IMU_TRIPLE(eOcanframe_t *frame, eOcanport_t port)
 {
@@ -217,13 +127,11 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__IMU_TRIPLE(eOcanframe_t
     {
         return(eores_OK);
     }
-    
-//    debugPprint(frame);
-    
+       
     eOas_inertial3_type_t type = eoas_inertial3_canproto_to_imu(frame->data[1]);
     if(eoas_inertial3_unknown != type)
     {
-        eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), type, frame, port);
+        eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, type);
     }
     
     return(eores_OK);
@@ -236,7 +144,7 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__IMU_QUATERNION(eOcanfra
         return(eores_OK);
     }
     
-    eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), eoas_inertial3_imu_qua, frame, port);
+    eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, eoas_inertial3_imu_qua);
 
     return(eores_OK);
 }
@@ -249,7 +157,7 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__IMU_STATUS(eOcanframe_t
     }
     
 
-    eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), eoas_inertial3_imu_status, frame, port);
+    eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, eoas_inertial3_imu_status);
 
     return(eores_OK);
 }
@@ -264,33 +172,7 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__IMU_STATUS(eOcanframe_t
 // --------------------------------------------------------------------------------------------------------------------
 // - definition of static functions 
 // --------------------------------------------------------------------------------------------------------------------
-
-//static void* s_eocanprotISperiodic_get_entity(eOprotEndpoint_t endpoint, eOprot_entity_t entity, eOcanframe_t *frame, eOcanport_t port, uint8_t *index)
-//{
-//    void * ret = NULL;
-//    uint8_t ii = 0;
-//    eObrd_canlocation_t loc = {0};
-//    
-//    loc.port = port;
-//    loc.addr = EOCANPROT_FRAME_GET_SOURCE(frame);    
-//    loc.insideindex = eobrd_caninsideindex_none;
-//    
-//    ii = eo_canmap_GetEntityIndex(eo_canmap_GetHandle(), loc, endpoint, entity);
-//    if(EOK_uint08dummy == ii)
-//    {     
-//        #warning -> TODO: add diagnostics about not found board as in s_eo_icubCanProto_mb_send_runtime_error_diagnostics()
-//        return(NULL);
-//    }
-//    
-//    ret = eoprot_entity_ramof_get(eoprot_board_localboard, endpoint, entity, ii);
-//    
-//    if(NULL != index)
-//    {
-//        *index = ii;        
-//    }  
-
-//    return(ret);   
-//}
+// empty-section
 
 
 


### PR DESCRIPTION
In this PR we continue the refactoring of the ETH services started with https://github.com/robotology/icub-firmware/pull/144. The refactoring is required so that we can more easily change the way some services run on a ETH board. One uses could be to add an alternative `MotionController` service in the boards of the new hand/wrist without changing too much code and in such a way that it could be decided at compile time what to controller to load.

In this refactoring iteration, now all the services have their `_AcceptCANframe(...)` method to accept CAN frames and process them
according to their own needs. The benefit is that the processing is all inside the correct software module and not spread anymore in multiple files.

The following services, though, still have an empty` _AcceptCANframe()` method and the handling of CAN frames inside multiple files: EOtheMC4boards, EOtheMotionController. The fill of `eo_motioncontrol_AcceptCANframe()` and of `eo_mc4boards_AcceptCANframe()` will be done at a later stage.

The changes in the PR are just a refactoring where code handling reception of CAN frames was moved for instance from file `EoCANprotASperiodic.c` to `EOtheMAIS.c`. 
