### PR TITLE
ETH boards: reception of POL_AS_CMD__GET_FULL_SCALES message is managed with eo_strain_AcceptCANframe()

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSTRAIN.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheSTRAIN.h
@@ -54,14 +54,6 @@ extern "C" {
 typedef struct EOtheSTRAIN_hid EOtheSTRAIN;
 
 
-typedef enum 
-{
-    processForce    = 0,    // keep it 0 so that we index teh array in position 0*3 = 0
-    processTorque   = 1,    // keep it 1 so taht we index teh array in position 1*3 = 3
-    processDebugForce = 2,
-    processDebugTorque = 3
-} strainProcessMode_t;
-
 //typedef eOresult_t (*eOstrain_onendofoperation_fun_t) (EOtheSTRAIN* p, eObool_t operationisok);
    
 // - declaration of extern public variables, ...deprecated: better using use _get/_set instead ------------------------
@@ -93,9 +85,17 @@ extern eOresult_t eo_strain_Tick(EOtheSTRAIN *p);
 
 extern eOresult_t eo_strain_Stop(EOtheSTRAIN *p);
 
-// it enables/disables transmission of the strain board. _Start() just starts the service, not the transmission
-extern eOresult_t eo_strain_Transmission(EOtheSTRAIN *p, eObool_t on);
 
+typedef enum 
+{
+    processForce        = 0,    
+    processTorque       = 1,    
+    processDebugForce   = 2,
+    processDebugTorque  = 3,
+    processFullScale    = 4
+} strainProcessMode_t;
+
+// called by the callbacks of can protocol
 extern eOresult_t eo_strain_AcceptCANframe(EOtheSTRAIN *p, eOcanframe_t *frame, eOcanport_t port, strainProcessMode_t mode);
 
 // we can call them if _Activate() was called. they are used by the callbacks of eth protocol

--- a/emBODY/eBcode/arch-arm/board/pmc/bsp/embot_hw_bsp_pmc.cpp
+++ b/emBODY/eBcode/arch-arm/board/pmc/bsp/embot_hw_bsp_pmc.cpp
@@ -68,7 +68,7 @@ void i2c_address_assignment_to_tlv493d_chips_stm32hal()
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);  
 
-    // power off both J11 and U27 and wait
+    // power off both J13 and U27 and wait
     HAL_GPIO_WritePin(GPIOE, GPIO_PIN_10 | GPIO_PIN_11, GPIO_PIN_RESET);
     HAL_Delay(10);
     
@@ -81,7 +81,7 @@ void i2c_address_assignment_to_tlv493d_chips_stm32hal()
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);    
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_9, GPIO_PIN_RESET);
     HAL_Delay(10);
-    // power up J11 so that it can have address 0x3E
+    // power up J13 so that it can have address 0x3E
     HAL_GPIO_WritePin(GPIOE, GPIO_PIN_10, GPIO_PIN_SET);    
     HAL_Delay(10);  
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol_functions.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol_functions.h
@@ -63,10 +63,6 @@ extern "C" {
 
 // - analog sensors: polling
 
-// this function is weakly defined. it must be redefined to implement the chain of requests from channel 0 up to channel 5
-// with successive action of ... for instance informing robotinterface.
-extern eObool_t eocanprotASpolling_redefinable_alert_reception_of_POL_AS_CMD__GET_FULL_SCALES(uint8_t channel,  uint16_t *data, eOas_strain_t* strain);
-
 extern eOresult_t eocanprotASpolling_former_POL_AS_CMD__SET_TXMODE(eOcanprot_descriptor_t *descriptor, eOcanframe_t *frame);
 
 extern eOresult_t eocanprotASpolling_former_POL_AS_CMD__SET_CANDATARATE(eOcanprot_descriptor_t *descriptor, eOcanframe_t *frame);

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theFAPreader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theFAPreader.cpp
@@ -1063,6 +1063,7 @@ bool embot::app::application::theFAPreader::initialise(const Config &config)
     
     pImpl->numofvalidsensors = 0;
     
+    std::string str {};
     pImpl->globaleventmask = pImpl->config.events.acquire | pImpl->config.events.noreply;
     pImpl->maxTOUT = pImpl->config.acquisitiontimeout;
     for(uint8_t n=0; n<numberofpositions; n++)
@@ -1093,7 +1094,11 @@ bool embot::app::application::theFAPreader::initialise(const Config &config)
                 pImpl->validIDpositions.push_back(n);
                 pImpl->numofvalidsensors++;
                 embot::core::binary::bit::set(pImpl->sensorspresencemask, static_cast<uint8_t>(pImpl->config.sensors[n].id));
-                pImpl->globaleventmask |= (pImpl->config.sensors[n].askdata | pImpl->config.sensors[n].dataready | pImpl->config.sensors[n].noreply);                
+                pImpl->globaleventmask |= (pImpl->config.sensors[n].askdata | pImpl->config.sensors[n].dataready | pImpl->config.sensors[n].noreply);   
+
+                embot::hw::TLV493D id = config.sensors[n].id;            
+                str += to_string(id);
+                str += " ";                
             }
             
         }            
@@ -1119,6 +1124,8 @@ bool embot::app::application::theFAPreader::initialise(const Config &config)
 //        embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();
 //        theleds.get(embot::hw::LED::one).wave(&ledwave);  
 //    }
+                
+    embot::core::print("theFAPreader::initialise() -> found: " + str);
 
 #if defined(CONTINUOUS_ACQUISITION)
     embot::core::print("theFAPreader::initialise() -> starting acquisition @ " + std::to_string(pImpl->periodAcquisition/1000) + " ms");


### PR DESCRIPTION
The POL_AS_CMD__GET_FULL_SCALES message is managed by object `EOtheSTRAIN ` with `eo_strain_AcceptCANframe()`.

The code is the same as before, it is just moved into a different file and a different function.

The benefit in here is that the action upon reception of the message is managed entirely inside the relevant object which behaves as an agent.  

With this PR all the actions upon reception of messages of classes analog-sensors polling, analog sensors streaming, skin streaming and inertials streaming are all managed by the relevant objects / agents.

Still missing the two motion control classes.

