### PR TITLE
embot_app_application_theIMU: fix euler angle representation

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
@@ -18,7 +18,7 @@ constexpr embot::app::theCANboardInfo::applicationInfo applInfo
     embot::prot::can::versionOfAPPLICATION {20, 4, 5},    
     embot::prot::can::versionOfCANPROTOCOL {20, 0} 
 #else    
-    embot::prot::can::versionOfAPPLICATION {1, 4, 5},    
+    embot::prot::can::versionOfAPPLICATION {1, 4, 6},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0} 
 #endif    
 };

--- a/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
@@ -24,7 +24,7 @@ constexpr uint32_t numMilli = 50;
 
 constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
 { 
-    embot::prot::can::versionOfAPPLICATION {1, 2, 0},    
+    embot::prot::can::versionOfAPPLICATION {1, 2, 1},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0}    
 };
 

--- a/emBODY/eBcode/arch-arm/board/strain2/application/src/main-strain2-application.cpp
+++ b/emBODY/eBcode/arch-arm/board/strain2/application/src/main-strain2-application.cpp
@@ -13,7 +13,7 @@
 
 constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
 { 
-    embot::prot::can::versionOfAPPLICATION {2, 0, 9},    
+    embot::prot::can::versionOfAPPLICATION {2, 0, 10},
     embot::prot::can::versionOfCANPROTOCOL {2, 0}    
 };
 

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
@@ -388,8 +388,12 @@ bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot:
         {
             // generate a eul message with canrevisitedconfig.counter
             info.sensor = embot::prot::can::analog::imuSensor::eul;
-            info.value = imuacquisition.data.eul;
-            
+            // The Bosch euler representation can be either the windows(default) or android, but in YARP
+            // we have a different representation(see https://github.com/robotology/yarp/blob/0481f994c6e03897d038c5f1d1078145646a1772/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h#L302-L348)
+            info.value.x = imuacquisition.data.eul.z;
+            info.value.y = -imuacquisition.data.eul.y;
+            info.value.z = imuacquisition.data.eul.x;
+
             msg.load(info);
             msg.get(frame);
             replies.push_back(frame);               


### PR DESCRIPTION
The Bosch Euler representation can be either the windows(default) or android but in YARP
we have a different representation(see https://github.com/robotology/yarp/blob/0481f994c6e03897d038c5f1d1078145646a1772/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h#L302-L348).

It fixes https://github.com/robotology/icub-main/issues/701

The application version has been increased to 2.0.10

THIS HAS TO BE TESTED BEFORE MERGING.

