### PR TITLE
2FOC pwm feedback 5 bits shift bugfix

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
@@ -18,6 +18,7 @@
 //#define UDEF_CURRENT_MAX 4000 // 4 A
 #define UDEF_SPEED_MAX  32767
 #define UDEF_PWM_MAX    25600 // 800*32 = 80%
+#define VOLT_REF_SHIFT 5 // for a PWM resolution of 1000
 
 //
 // Quadrature (incremental) Encoders parameters

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          4
+#define FW_VERSION_BUILD          10
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -136,7 +136,6 @@ _FICD(ICS_PGD3 & JTAGEN_OFF); // & COE_ON ); //BKBUG_OFF
 //#define CALIBRATION
 
 #define BOARD_CAN_ADDR_DEFAULT 0xE
-#define VOLT_REF_SHIFT 5 // for a PWM resolution of 1000
 #define PWM_50_DUTY_CYC (LOOPINTCY/2)
 
 #define isDriveEnabled() bDriveEnabled

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
@@ -56,6 +56,7 @@ extern volatile int dataA;
 extern volatile int dataB;
 extern volatile int dataC;
 extern volatile int dataD;
+extern volatile char IKs;
 
 extern volatile tMotorConfig MotorConfig;
 
@@ -79,7 +80,7 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
     
     //payload.w[1] = POSCNT;
 
-    payload.w[1] = (VqRef>>5);
+    payload.w[1] = (VqRef>>(IKs-VOLT_REF_SHIFT));
 
     //payload.b[2] = 0;
     //payload.b[3] = 0;


### PR DESCRIPTION
This PR fixes the 2FOC pwm feedback bug, that caused a 32x factor in the pwm feedback sent by the 2FOC to the EMS board, related to issue https://github.com/icub-tech-iit/task-force-miscellanea/issues/69