### PR TITLE
PMC board: added support for flash pages of 4k

### DIFF
--- a/emBODY/eBcode/arch-arm/board/pmc/bootloader/proj/pmc-bootloader.sct
+++ b/emBODY/eBcode/arch-arm/board/pmc/bootloader/proj/pmc-bootloader.sct
@@ -24,8 +24,8 @@
 ; flash starts from xx and its size is xxx
 ; 80k is: LR_IROM1 0x08000000 0x00014000  {    ; load region size_region
 ; however it was 124K: LR_IROM1 0x08000000 0x0001F000  {    ; load region size_region
-LR_IROM1 0x08000000 0x00013800  {    ; load region size_region
-  ER_IROM1 0x08000000 0x00013800  {  ; load address = execution address
+LR_IROM1 0x08000000 0x0001F000  {    ; load region size_region
+  ER_IROM1 0x08000000 0x0001F000  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/emBODY/eBcode/arch-arm/board/pmc/bsp/embot_hw_bsp_pmc_config.h
+++ b/emBODY/eBcode/arch-arm/board/pmc/bsp/embot_hw_bsp_pmc_config.h
@@ -22,6 +22,7 @@
     #define  EMBOT_ENABLE_hw_bsp_specialize
     #define EMBOT_ENABLE_hw_gpio
     #define EMBOT_ENABLE_hw_flash
+    #define EMBOT_ENABLE_hw_flash_SINGLEBANK
     #define EMBOT_ENABLE_hw_led
     #define EMBOT_ENABLE_hw_can
     #define EMBOT_ENABLE_hw_i2c

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_theBootloader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_theBootloader.cpp
@@ -169,7 +169,7 @@ embot::app::theBootloader::evalRes embot::app::theBootloader::eval()
     embot::os::init({});
              
     static const embot::os::InitThread::Config initconfig { 4*2048, embot::app::theBootloader::Impl::init, nullptr };
-    static const embot::os::IdleThread::Config idleconfig { 512, nullptr, nullptr, embot::app::theBootloader::Impl::onidle };
+    static const embot::os::IdleThread::Config idleconfig { 2*1024, nullptr, nullptr, embot::app::theBootloader::Impl::onidle };
     static const embot::core::Callback onOSerror = { embot::app::theBootloader::Impl::userdefonOSerror, nullptr };
     
     embot::os::theScheduler::Config cfg { 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_FlashStorage.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_FlashStorage.cpp
@@ -47,6 +47,8 @@ struct embot::hw::FlashStorage::Impl
     uint32_t pagesize;
     bool bufferisexternal;
     
+    static constexpr size_t maxSupportedPAGEsize = 2048; // it can be lower than the actual pagesize on FLASH
+    
     Impl(std::uint32_t _pagestart, std::uint32_t _pagesize, std::uint64_t * _buffer = nullptr) 
     {
         pagestart = _pagestart; 
@@ -54,12 +56,12 @@ struct embot::hw::FlashStorage::Impl
         {
              pagestart = embot::hw::flash::getpartition(embot::hw::FLASH::sharedstorage).address;
         }
-        pagenumber = (pagestart - embot::hw::flash::getpartition(embot::hw::FLASH::whole).address) / 2048; 
+        pagenumber = (pagestart - embot::hw::flash::getpartition(embot::hw::FLASH::whole).address) / embot::hw::flash::getpartition(embot::hw::FLASH::whole).pagesize; 
         
         pagesize = _pagesize;
-        if(pagesize > 2048)
+        if(pagesize > maxSupportedPAGEsize)
         {
-            pagesize = 2048;
+            pagesize = maxSupportedPAGEsize;
         }
         if(0 == pagesize)
         {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_flash.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_flash.cpp
@@ -68,6 +68,8 @@ namespace embot { namespace hw { namespace flash {
     
     bool isaddressvalid(std::uint32_t address) { return false; }    
     std::uint32_t address2page(std::uint32_t address) { return 0; }
+    std::uint32_t page2address(std::uint32_t page) { return 0; }
+    std::uint32_t address2offset(std::uint32_t address){ return 0; }
     
     bool erase(std::uint32_t page) { return false; }
     bool erase(std::uint32_t address, std::uint32_t size) { return false; }
@@ -108,7 +110,25 @@ namespace embot { namespace hw { namespace flash {
         
         return ((address - part.address) % part.pagesize);
     }
-
+    
+    std::uint32_t page2address(std::uint32_t page)
+    {
+        const embot::hw::Partition &part = embot::hw::flash::getpartition(embot::hw::FLASH::whole);
+        
+        uint32_t adr = part.pagesize*page;
+        
+        if(false == isaddressvalid(adr))
+        {
+            return 0;
+        }
+        return adr;
+    }
+    
+    std::uint32_t address2offset(std::uint32_t address)
+    {
+        const embot::hw::Partition &part = embot::hw::flash::getpartition(embot::hw::FLASH::whole);
+        return address % part.pagesize;
+    }
     
     bool erase(std::uint32_t page)
     {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_flash.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_flash.h
@@ -34,6 +34,8 @@ namespace embot { namespace hw { namespace flash {
     
     bool isaddressvalid(std::uint32_t address);    
     std::uint32_t address2page(std::uint32_t address); // returns [0, maxNumOfPAGEs). if address not valid, it returns an unreliable number.
+    std::uint32_t page2address(std::uint32_t page);
+    std::uint32_t address2offset(std::uint32_t address);
     
     bool erase(std::uint32_t page);
     bool erase(std::uint32_t address, std::uint32_t size);


### PR DESCRIPTION
This PR adds support for FLASH pages of size 4K to the bootloader and the application of the PMC board.

The modern CAN board, such as the `mtb4` or the `strain2` use FLASH to emulate EEPROM so that they can store CAN address, application version, CAN protocol version and private data. 
They all use a FLASH which is organized in pages of 2K bytes each. There is support to specify a variable inside the `embot::hw::flash` namespace which tells the size of the page, but the functions which manage the FLASH for simplicity have used so far just ... `2048`. 

The first produced batch  of `pmc` boards were programmed with FLASH option bytes which had two banks and page size of 2K. That let them work in the same way as their older sisters.

However, I recently spotted a bug which shows only on the new batch of produced `pmc` boards. The writing to emulated EEPROM did not work.

The reason is due to a different configuration of their FLASH: it had now a single bank and pages of size 4K. This new mode is better (more efficient and more compatible w/ our code) but we need to use the size of the page as a variable.

As a result of that, I have modified some parts of code so that every board can use the proper page size.

For the `pmc` board only I also added some check code inside `bool embot::hw::bsp::specialize()` which executes at startup and performs special operations on the HW.  In here we now detect possible incoherencies between the page size imposed at production and the page size imposed inside our code.

I also moved some FLASH related functions inside namespace `embot::hw::flash` so that we avoid duplications.

I did tests on `pmc` boards of both batches (with pages size of 2K and of 4K) and they all work fine now. The other boards cannot be affected because still keep on using the value 2K as before.

