### PR TITLE
AMO data to YARP ports

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          40
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          41
 
 //  </h>version
 
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          9
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          59
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMC_fun_ems4rd.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMC_fun_ems4rd.c
@@ -1329,15 +1329,13 @@ extern void eoprot_fun_UPDT_mc_motor_config(const EOnv* nv, const eOropdescripto
         
     if(eo_motcon_mode_foc == mcmode)
     {
-        MController_config_motor(mxx, mconfig);
-
+        eo_motioncontrol_ConfigMotor(eo_motioncontrol_GetHandle(), mxx, mconfig);
         return;           
     }
     else if((eo_motcon_mode_mc4plus == mcmode) || (eo_motcon_mode_mc4plusmais == mcmode) || (eo_motcon_mode_mc2pluspsc == mcmode) || 
            (eo_motcon_mode_mc4plusfaps == mcmode) || (eo_motcon_mode_mc4pluspmc == mcmode))   
     {
-        MController_config_motor(mxx, mconfig);
-        eo_currents_watchdog_UpdateCurrentLimits( eo_currents_watchdog_GetHandle(), mxx);
+        eo_motioncontrol_ConfigMotor(eo_motioncontrol_GetHandle(), mxx, mconfig);
     }
     else if(eo_motcon_mode_mc4 == mcmode)
     {

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.h
@@ -109,6 +109,8 @@ typedef enum
 extern eOresult_t eo_motioncontrol_AcceptCANframe(EOtheMotionController *p, eOcanframe_t *frame, eOcanport_t port, eOmotioncontroller_canframe_t cftype);
 
 
+extern eOresult_t eo_motioncontrol_ConfigMotor(EOtheMotionController *p, uint8_t num, eOmc_motor_config_t *mc);
+
 /** @}            
     end of group eo_EOtheMotionController
  **/

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController_hid.h
@@ -89,6 +89,14 @@ typedef struct
 enum { motioncontrol_maxRegulars = 32 }; // there can be at most 12 jomos. we typically use status of joint and status of motor, thus 24 ... however, i use 32 which is the max value of regulars in a board
 
 
+typedef struct
+{
+    EOtimer *tmr;
+    eOmc_motor_config_t *mc;
+    uint8_t num;    
+} motorDelayer_t;
+
+
 struct EOtheMotionController_hid
 {
     eOservice_core_t                        service;
@@ -98,6 +106,9 @@ struct EOtheMotionController_hid
     uint8_t                                 numofjomos;    
     eOmotioncontroller_objs_t               ctrlobjs;             
     EOarray*                                id32ofregulars;
+    
+    motorDelayer_t                          motor_delayer[eo_motcon_standardJOMOs];
+    eOflags08_t                             motor_delayer_flags;
 }; 
 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          24
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          25
 //  </h>version
 
 //  <h> build date
@@ -84,7 +84,7 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -76,7 +76,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          33
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          34
 
 
 //  </h>version
@@ -87,7 +87,7 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
@@ -103,8 +103,9 @@ typedef struct
 enum { amodiag_numOfJoints = 2 };
 
 typedef struct
-{   // only for an encoder at joint of type AMO and onty for the first two joints j0 and/or j1.
+{   // only for an encoder at joint of type AMO and only for the first two joints j0 and/or j1.
     eObool_t                                enabled;
+    eOmn_serv_diagn_cfg_t                   config;
     eOreltime_t                             minimuminterval[amodiag_numOfJoints];
     hal_spiencoder_position_t               vals[amodiag_numOfJoints]; // raw value of the first and secnds
     uint16_t                                regs[amodiag_numOfJoints]; // first and seconds joint


### PR DESCRIPTION
## Description

This PR belongs to a set of PRs which enable to stream AMO data towards YARP ports for debugging purposes.

It extends the content of a previous PR called [AMO diagnostics](https://github.com/robotology/icub-firmware/pull/187) by allowing an alternative diagnostics path which sends the content of AMO registers and values to YARP ports.

This mode can be configured in runtime by acting on the xml files of the MC service.

In the following is shown how the AMO dat to YARP ports can be configured and what it does.



## How to activate / deactivate the AMO diagnostics



The AMO to YARP ports is disabled by default.

If one wants to activate that, he/she must add the group named `DIAGNOSTICS` in the xml file which describes the MC service on a ETH board, as in the following.



```xml
<group name="SERVICE">

    <param name="type"> eomn_serv_MC_foc </param> 
   
    <group name="PROPERTIES">
    
       <group name="DIAGNOSTICS">
           <param name="mode">     eomn_serv_diagn_mode_MC_AMOyarp     </param>
           <param name="par16">    1000                                </param>
       </group> 
       
        ...
```

**Code list**. The `DIAGNOSTICS` group has two parameters: `mode` equal to `eomn_serv_diagn_mode_MC_AMOyarp`  activates the AMO streaming. The parameters par16 expressed the time in ms of delay of application of motor configuration to the 2foc board. In this case 1 second.



The service can be disable also by using a special mode called `eomn_serv_diagn_mode_NONE` as in the following.

```xml
<group name="SERVICE">

    <param name="type"> eomn_serv_MC_foc </param> 
   
    <group name="PROPERTIES">
    
       <group name="DIAGNOSTICS">
           <param name="mode">     eomn_serv_diagn_mode_NONE           </param>
           <param name="par16">    1000                                </param>
       </group> 
       
        ...
```

**Code list**. The diagnostics is disabled if the group DIAGNOSTICS is not present or if it has  `mode` equal to `eomn_serv_diagn_mode_NONE` .

​            

## What the AMO streaming produces



When the AMO streaming is enabled, the board sends to YARP ports which contains the name of the board and of the relevant joint number as show in the following. The name of the ETH board is the same in `ETH_BOARD.ETH_BOARD_SETTINGS.Name` as specified in the relevant xml file.

```bash
$ yarp read ... /amo/left_leg-eb6-j0_1/j0
[yt, amo, reg, pos] 111111.000000 333333 2048 444444
[yt, amo, reg, pos] 111111.005000 333333 2048 444444
...
```

**Log excerpt**. The YARP port opened for the first joint (j0) of board `left_leg-eb6-j0_1` signals what is described inside brackets:  `YARP time`, `AMO raw value`, `content of registers of the AMO`, `eOmc_joint_status_t::core.measures.meas_position`.





## Use of the delay in activation of the motors



If the AMO streaming is enabled with a given delay of motors, let's say par16 = 1000 which corresponds to `1 second`, the effect is the following:

>  The ETH boards starts to stream the values to `icub-head` which publish them on the relevant port (which must be already opened) and after 1 second it applies the configuration to the motors.
>
> During this time of  1 second the MC device is temporarily stopped, so that the calibrator is not activated until the motor on the ETH board is initted.
>
> The time of delay of motor activation can be up to 65 seconds.



In such a way, we can read values without the effect of the activation of the motor (which may emit EM noise). 




## Requirements of this PR

## Requirements of this PR

To enable the features of this PR we also need similar PRs. They are:
- in [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared/pull/49) which contains the data structures,
-  in  [`icub-firmware`](https://github.com/robotology/icub-firmware/pull/188) we have the code for the ETH boards
- in [`icub-main`](https://github.com/robotology/icub-main/pull/753) which contains code to publish on the YARP port.
- in [`icub-firmware-build`](https://github.com/robotology/icub-firmware-build/pull/30) to give the new binaries for the `ems`, `mc4plus`, `mc2plus`.


So far we omit any PR in `robots-configuration`.



## Executed tests

Tests were extensively done on a dedicated setup but not yet on `iCubGenova09`.
