### PR TITLE
Low level motor control for board amcbldc

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
@@ -153,72 +153,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>161</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134384170</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\embot\hw\embot_hw_motor.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../../../../embot/hw/embot_hw_motor.cpp\161</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>279</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134377174</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\amcbldc-main.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/amcbldc-main.cpp\279</Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>108</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134375376</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\motorhal\motorhal_config.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/motorhal/motorhal_config.c\108</Expression>
-        </Bp>
-        <Bp>
-          <Number>3</Number>
-          <Type>0</Type>
-          <LineNumber>370</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134407412</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\motorhal\pwm.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/motorhal/pwm.c\370</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -265,7 +200,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
+        <aSer4>1</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -883,7 +818,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1531,7 +1466,7 @@
 
   <Group>
     <GroupName>others::motorhal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
@@ -1390,7 +1390,7 @@
 
   <Group>
     <GroupName>others</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
@@ -135,7 +135,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L175 -Z6 -C0 -M1 -T1</Name>
+          <Name>-L175 -Z7 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -153,7 +153,72 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint/>
+      <Breakpoint>
+        <Bp>
+          <Number>0</Number>
+          <Type>0</Type>
+          <LineNumber>161</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134384170</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\embot\hw\embot_hw_motor.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../../../../embot/hw/embot_hw_motor.cpp\161</Expression>
+        </Bp>
+        <Bp>
+          <Number>1</Number>
+          <Type>0</Type>
+          <LineNumber>279</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134377174</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\amcbldc-main.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/amcbldc-main.cpp\279</Expression>
+        </Bp>
+        <Bp>
+          <Number>2</Number>
+          <Type>0</Type>
+          <LineNumber>108</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134375376</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\motorhal\motorhal_config.c</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/motorhal/motorhal_config.c\108</Expression>
+        </Bp>
+        <Bp>
+          <Number>3</Number>
+          <Type>0</Type>
+          <LineNumber>370</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134407412</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\motorhal\pwm.c</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/motorhal/pwm.c\370</Expression>
+        </Bp>
+      </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -742,7 +807,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -990,6 +1055,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>5</GroupNumber>
+      <FileNumber>23</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\embot\hw\embot_hw_motor.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_motor.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1000,7 +1077,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1020,7 +1097,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1040,7 +1117,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1052,7 +1129,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1064,7 +1141,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1076,7 +1153,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1088,7 +1165,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1100,7 +1177,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1112,7 +1189,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1124,7 +1201,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1136,7 +1213,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>33</FileNumber>
+      <FileNumber>34</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1156,7 +1233,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>34</FileNumber>
+      <FileNumber>35</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1168,7 +1245,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>35</FileNumber>
+      <FileNumber>36</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1180,7 +1257,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>36</FileNumber>
+      <FileNumber>37</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1192,7 +1269,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>37</FileNumber>
+      <FileNumber>38</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1204,7 +1281,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>38</FileNumber>
+      <FileNumber>39</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1216,7 +1293,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>39</FileNumber>
+      <FileNumber>40</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1228,7 +1305,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>40</FileNumber>
+      <FileNumber>41</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1240,7 +1317,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>41</FileNumber>
+      <FileNumber>42</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1252,7 +1329,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>42</FileNumber>
+      <FileNumber>43</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1272,7 +1349,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>43</FileNumber>
+      <FileNumber>44</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1284,7 +1361,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>44</FileNumber>
+      <FileNumber>45</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1296,7 +1373,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>45</FileNumber>
+      <FileNumber>46</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1308,7 +1385,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>46</FileNumber>
+      <FileNumber>47</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1320,7 +1397,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>47</FileNumber>
+      <FileNumber>48</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1332,7 +1409,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>48</FileNumber>
+      <FileNumber>49</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1346,13 +1423,13 @@
 
   <Group>
     <GroupName>embot::app-others</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>49</FileNumber>
+      <FileNumber>50</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1364,7 +1441,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>50</FileNumber>
+      <FileNumber>51</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1384,7 +1461,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>51</FileNumber>
+      <FileNumber>52</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1396,7 +1473,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>52</FileNumber>
+      <FileNumber>53</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1408,7 +1485,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>53</FileNumber>
+      <FileNumber>54</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1422,13 +1499,13 @@
 
   <Group>
     <GroupName>others::foc</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>54</FileNumber>
+      <FileNumber>55</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1440,13 +1517,69 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>55</FileNumber>
+      <FileNumber>56</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Lib\ARM\arm_cortexM4lf_math.lib</PathWithFileName>
       <FilenameWithoutPath>arm_cortexM4lf_math.lib</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>others::motorhal</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>57</FileNumber>
+      <FileType>1</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\motorhal\motorhal_config.c</PathWithFileName>
+      <FilenameWithoutPath>motorhal_config.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>58</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\motorhal\encoder.c</PathWithFileName>
+      <FilenameWithoutPath>encoder.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>59</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\motorhal\pwm.c</PathWithFileName>
+      <FilenameWithoutPath>pwm.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>60</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\motorhal\analog.c</PathWithFileName>
+      <FilenameWithoutPath>analog.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvprojx
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>5</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvprojx
@@ -339,7 +339,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMCBLDC STM32HAL_DRIVER_V120</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\..\eBcode\arch-arm\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\eBcode\arch-arm\libs\midware\eventviewer\api;..\..\..\..\..\..\eBcode\arch-arm\libs\lowlevel\stm32hal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\eBcode\arch-arm\embot\app;..\..\..\..\..\..\eBcode\arch-arm\embot\i2h;..\..\..\..\..\..\eBcode\arch-arm\embot\hw;..\..\..\..\..\..\eBcode\arch-arm\embot\os;..\..\..\..\..\..\eBcode\arch-arm\embot;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\app\dsp;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\bsp;..\src\FOCode\BLDC_FOC_Code\Current_FOC_ert_rtw;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include</IncludePath>
+              <IncludePath>..\..\..\..\..\..\eBcode\arch-arm\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\eBcode\arch-arm\libs\midware\eventviewer\api;..\..\..\..\..\..\eBcode\arch-arm\libs\lowlevel\stm32hal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\eBcode\arch-arm\embot\app;..\..\..\..\..\..\eBcode\arch-arm\embot\i2h;..\..\..\..\..\..\eBcode\arch-arm\embot\hw;..\..\..\..\..\..\eBcode\arch-arm\embot\os;..\..\..\..\..\..\eBcode\arch-arm\embot;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\app\dsp;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\bsp;..\src\FOCode\BLDC_FOC_Code\Current_FOC_ert_rtw;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include;..\src\motorhal</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -531,6 +531,11 @@
               <FileName>embot_hw_types.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\embot\hw\embot_hw_types.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_motor.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\embot\hw\embot_hw_motor.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -787,6 +792,31 @@
               <FileName>arm_cortexM4lf_math.lib</FileName>
               <FileType>4</FileType>
               <FilePath>..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Lib\ARM\arm_cortexM4lf_math.lib</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>others::motorhal</GroupName>
+          <Files>
+            <File>
+              <FileName>motorhal_config.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\src\motorhal\motorhal_config.c</FilePath>
+            </File>
+            <File>
+              <FileName>encoder.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\encoder.c</FilePath>
+            </File>
+            <File>
+              <FileName>pwm.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\pwm.c</FilePath>
+            </File>
+            <File>
+              <FileName>analog.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\analog.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -1390,6 +1420,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\embot\hw\embot_hw_types.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_motor.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\embot\hw\embot_hw_motor.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1645,6 +1680,31 @@
               <FileName>arm_cortexM4lf_math.lib</FileName>
               <FileType>4</FileType>
               <FilePath>..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Lib\ARM\arm_cortexM4lf_math.lib</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>others::motorhal</GroupName>
+          <Files>
+            <File>
+              <FileName>motorhal_config.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\src\motorhal\motorhal_config.c</FilePath>
+            </File>
+            <File>
+              <FileName>encoder.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\encoder.c</FilePath>
+            </File>
+            <File>
+              <FileName>pwm.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\pwm.c</FilePath>
+            </File>
+            <File>
+              <FileName>analog.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\analog.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2248,6 +2308,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\embot\hw\embot_hw_types.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_motor.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\embot\hw\embot_hw_motor.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2503,6 +2568,31 @@
               <FileName>arm_cortexM4lf_math.lib</FileName>
               <FileType>4</FileType>
               <FilePath>..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Lib\ARM\arm_cortexM4lf_math.lib</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>others::motorhal</GroupName>
+          <Files>
+            <File>
+              <FileName>motorhal_config.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\src\motorhal\motorhal_config.c</FilePath>
+            </File>
+            <File>
+              <FileName>encoder.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\encoder.c</FilePath>
+            </File>
+            <File>
+              <FileName>pwm.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\pwm.c</FilePath>
+            </File>
+            <File>
+              <FileName>analog.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\motorhal\analog.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
@@ -252,7 +252,7 @@ void thrCTRL(void* p) { embot::os::Thread *t = reinterpret_cast<embot::os::Threa
 
 constexpr embot::os::Event evt_CTRL_tick {embot::os::bitpos2event(1)};
 embot::os::Timer * tCTRL_tickTimer {nullptr};
-constexpr embot::core::relTime tCTRL_tickperiod {100*embot::core::time1millisec}; 
+constexpr embot::core::relTime tCTRL_tickperiod {1000*embot::core::time1millisec}; 
 
     
 void s_start_CTRL_thread()
@@ -273,11 +273,7 @@ void s_start_CTRL_thread()
 }
 
 void tCTRL_startup(embot::os::Thread *t, void *param)
-{   
-
-    embot::core::print("tCTRL_startup(): init embot::hw::MOTOR::one");
-    embot::hw::motor::init(embot::hw::MOTOR::one, {});
-        
+{           
     embot::core::print("tCTRL_startup(): starts a timer which sends a tick event every " + embot::core::TimeFormatter(tCTRL_tickperiod).to_string());
     
     // start a timer which ticks the thread CTRL
@@ -312,8 +308,8 @@ void tCTRL_onevent(embot::os::Thread *t, embot::os::EventMask eventmask, void *p
 
 
 
-
-constexpr embot::app::scope::SignalType signaltype = embot::app::scope::SignalType::EViewer;
+constexpr embot::app::scope::SignalType signaltype = embot::app::scope::SignalType::Dummy;
+//constexpr embot::app::scope::SignalType signaltype = embot::app::scope::SignalType::EViewer;
 //constexpr embot::app::scope::SignalType signaltype = embot::app::scope::SignalType::Print;
 //constexpr embot::app::scope::SignalType signaltype = embot::app::scope::SignalType::GPIO;
 
@@ -325,7 +321,11 @@ void test_init()
     amcbldc::codetotest::init();
 
     // initialize the tool which measure the duration of the code to test
-    if(embot::app::scope::SignalType::EViewer == signaltype)
+    if(embot::app::scope::SignalType::Dummy == signaltype)
+    {       
+        signal = new embot::app::scope::SignalDummy({});
+    }
+    else if(embot::app::scope::SignalType::EViewer == signaltype)
     {       
         signal = new embot::app::scope::SignalEViewer({amcbldc::codetotest::tick, embot::app::scope::SignalEViewer::Config::LABEL::one});
     }

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
@@ -101,6 +101,7 @@ int main(void)
 
 #include "embot_hw_sys.h"
 
+
 // maybe move API and implementation of the ctrl thread in dedicated files
 void s_start_CTRL_thread();
 
@@ -238,6 +239,9 @@ void test_tick();
 // just to see some GPIO transformations
 #include "embot_hw_gpio_bsp.h"
 
+// i also use motors
+#include "embot_hw_motor.h"
+
 // finally, from here there is the preparation of the t_CTRL thread
 
 embot::os::EventThread *t_CTRL {nullptr};
@@ -269,7 +273,11 @@ void s_start_CTRL_thread()
 }
 
 void tCTRL_startup(embot::os::Thread *t, void *param)
-{    
+{   
+
+    embot::core::print("tCTRL_startup(): init embot::hw::MOTOR::one");
+    embot::hw::motor::init(embot::hw::MOTOR::one, {});
+        
     embot::core::print("tCTRL_startup(): starts a timer which sends a tick event every " + embot::core::TimeFormatter(tCTRL_tickperiod).to_string());
     
     // start a timer which ticks the thread CTRL

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
@@ -252,7 +252,7 @@ void thrCTRL(void* p) { embot::os::Thread *t = reinterpret_cast<embot::os::Threa
 
 constexpr embot::os::Event evt_CTRL_tick {embot::os::bitpos2event(1)};
 embot::os::Timer * tCTRL_tickTimer {nullptr};
-constexpr embot::core::relTime tCTRL_tickperiod {1000*embot::core::time1millisec}; 
+constexpr embot::core::relTime tCTRL_tickperiod {100*embot::core::time1millisec}; 
 
     
 void s_start_CTRL_thread()

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
@@ -66,29 +66,34 @@ namespace amcbldc { namespace codetotest {
         Current_FOC_Obj.step();
         
 #elif defined(TEST_MOTOR)
+
+#undef TEST_MOTOR_BUT_DONTMOVEIT
         
         static embot::hw::motor::Pwm pwm = 0;
         static uint8_t cnt = 0;
         constexpr embot::hw::motor::Pwm step {500};
-        constexpr embot::core::relTime period {2000*embot::core::time1millisec};
+        constexpr embot::core::relTime period {1000*embot::core::time1millisec};
         static embot::core::Time prevcommutation = 0;
         
         embot::core::Time now = embot::core::now();
         
-        embot::hw::motor::Position pos {0};        
-        //embot::hw::motor::getencoder(embot::hw::MOTOR::one, pos); 
-        embot::hw::motor::gethallcounter(embot::hw::MOTOR::one, pos); 
+        embot::hw::motor::Position hall {0};       
+        embot::hw::motor::Position enco {0};            
+        embot::hw::motor::getencoder(embot::hw::MOTOR::one, enco); 
+        embot::hw::motor::gethallcounter(embot::hw::MOTOR::one, hall); 
         constexpr uint8_t npoles = 7;
         constexpr uint8_t nhall = 6;
         constexpr float resolutionhalltick = 360.0 / (npoles*nhall);        
-        float deg = pos*resolutionhalltick;        
+        float deghall = hall*resolutionhalltick;        
         
-        embot::core::print("@ " + embot::core::TimeFormatter(now).to_string() + " amcbldc::codetotest::tick(): hall [cnt, deg] = [" + std::to_string(pos) + ", " + std::to_string(deg) + "]");
+        embot::core::print("@ " + embot::core::TimeFormatter(now).to_string() + ": [encmod4, hallcnt, halldeg] = [" + std::to_string(enco) + ", " + std::to_string(hall) + ", " + std::to_string(deghall) + "]");
 
+#if defined(TEST_MOTOR_BUT_DONTMOVEIT)
+#else        
         if((now - prevcommutation) >= period)
         {
             prevcommutation = now;
-            embot::core::print("@ " + embot::core::TimeFormatter(now).to_string() + " amcbldc::codetotest::tick(): embot::hw::motor::setpwm(embot::hw::MOTOR::one, " + std::to_string(pwm) + ")");
+            embot::core::print("@ " + embot::core::TimeFormatter(now).to_string() + ": embot::hw::motor::setpwm(embot::hw::MOTOR::one, " + std::to_string(pwm) + ")");
             
             embot::hw::motor::setpwm(embot::hw::MOTOR::one, pwm);
             
@@ -101,6 +106,7 @@ namespace amcbldc { namespace codetotest {
                 default:    {   cnt = 0;    pwm = 0;       } break;
             }
         }
+#endif        
         
 #else        
         static constexpr std::array<embot::core::relTime, 5> usec = 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
@@ -69,19 +69,37 @@ namespace amcbldc { namespace codetotest {
         
         static embot::hw::motor::Pwm pwm = 0;
         static uint8_t cnt = 0;
-        constexpr embot::hw::motor::Pwm step {100};
+        constexpr embot::hw::motor::Pwm step {500};
+        constexpr embot::core::relTime period {2000*embot::core::time1millisec};
+        static embot::core::Time prevcommutation = 0;
         
-        embot::core::print("@ " + embot::core::TimeFormatter(embot::core::now()).to_string() + " amcbldc::codetotest::tick(): embot::hw::motor::setpwm(embot::hw::MOTOR::one, " + std::to_string(pwm) + ")");
+        embot::core::Time now = embot::core::now();
         
-        embot::hw::motor::setpwm(embot::hw::MOTOR::one, pwm);
+        embot::hw::motor::Position pos {0};        
+        //embot::hw::motor::getencoder(embot::hw::MOTOR::one, pos); 
+        embot::hw::motor::gethallcounter(embot::hw::MOTOR::one, pos); 
+        constexpr uint8_t npoles = 7;
+        constexpr uint8_t nhall = 6;
+        constexpr float resolutionhalltick = 360.0 / (npoles*nhall);        
+        float deg = pos*resolutionhalltick;        
         
-        switch(cnt)
+        embot::core::print("@ " + embot::core::TimeFormatter(now).to_string() + " amcbldc::codetotest::tick(): hall [cnt, deg] = [" + std::to_string(pos) + ", " + std::to_string(deg) + "]");
+
+        if((now - prevcommutation) >= period)
         {
-            case 0:     {   cnt = 1;    pwm = step;    } break;
-            case 1:     {   cnt = 2;    pwm = 0;       } break;
-            case 2:     {   cnt = 3;    pwm = -step;   } break;
-            case 4: 
-            default:    {   cnt = 0;    pwm = 0;       } break;
+            prevcommutation = now;
+            embot::core::print("@ " + embot::core::TimeFormatter(now).to_string() + " amcbldc::codetotest::tick(): embot::hw::motor::setpwm(embot::hw::MOTOR::one, " + std::to_string(pwm) + ")");
+            
+            embot::hw::motor::setpwm(embot::hw::MOTOR::one, pwm);
+            
+            switch(cnt)
+            {
+                case 0:     {   cnt = 1;    pwm = step;    } break;
+                case 1:     {   cnt = 2;    pwm = 0;       } break;
+                case 2:     {   cnt = 3;    pwm = -step;   } break;
+                case 4: 
+                default:    {   cnt = 0;    pwm = 0;       } break;
+            }
         }
         
 #else        

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
@@ -22,12 +22,17 @@
 #include "embot_hw_sys.h"
 #include <array>
 
-#define TEST_FOC
+//#define TEST_FOC
+#define TEST_MOTOR
 
 #if defined(TEST_FOC)
 // foc code
 #include "Current_FOC.h"               // Model's header file
 #include "rtwtypes.h"
+
+#elif defined(TEST_MOTOR)
+
+#include "embot_hw_motor.h"
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -47,7 +52,10 @@ namespace amcbldc { namespace codetotest {
     {
 #if defined(TEST_FOC)        
         // Initialize model
-        Current_FOC_Obj.initialize();
+        Current_FOC_Obj.initialize();        
+#elif defined(TEST_MOTOR)
+        embot::core::print("amcbldc::codetotest::init(): initting embot::hw::MOTOR::one");
+        embot::hw::motor::init(embot::hw::MOTOR::one, {});        
 #endif        
     }
         
@@ -56,6 +64,26 @@ namespace amcbldc { namespace codetotest {
 #if defined(TEST_FOC)
         // Step the model
         Current_FOC_Obj.step();
+        
+#elif defined(TEST_MOTOR)
+        
+        static embot::hw::motor::Pwm pwm = 0;
+        static uint8_t cnt = 0;
+        constexpr embot::hw::motor::Pwm step {100};
+        
+        embot::core::print("@ " + embot::core::TimeFormatter(embot::core::now()).to_string() + " amcbldc::codetotest::tick(): embot::hw::motor::setpwm(embot::hw::MOTOR::one, " + std::to_string(pwm) + ")");
+        
+        embot::hw::motor::setpwm(embot::hw::MOTOR::one, pwm);
+        
+        switch(cnt)
+        {
+            case 0:     {   cnt = 1;    pwm = step;    } break;
+            case 1:     {   cnt = 2;    pwm = 0;       } break;
+            case 2:     {   cnt = 3;    pwm = -step;   } break;
+            case 4: 
+            default:    {   cnt = 0;    pwm = 0;       } break;
+        }
+        
 #else        
         static constexpr std::array<embot::core::relTime, 5> usec = 
         {   

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/analog.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/analog.c
@@ -1,0 +1,661 @@
+/*******************************************************************************************************************//**
+ * @file    analog.c
+ * @author  G.Zini
+ * @version 1.0
+ * @date    2021 January, 20
+ * @brief   Analog signals management
+ **********************************************************************************************************************/
+
+// CODE SHAPER
+#if defined(USE_STM32HAL)
+#include "motorhal_config.h"
+#endif
+
+#if defined(USE_STM32HAL)
+// API
+#include "analog.h"
+#endif
+
+/* Includes ***********************************************************************************************************/
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <ctype.h>
+
+#if defined(USE_STM32HAL)
+#include "stm32hal.h"
+
+#include "pwm.h"
+
+#if !defined(HALCONFIG_DONTUSE_FLASH)
+#include "flash.h"
+#endif
+
+#else
+#include "adc.h"
+#include "analog.h"
+#include "console.h"
+#include "flash.h"
+#include "led.h"
+#include "main.h"
+#include "pwm.h"
+#include "utilities.h"
+#include "FreeRTOS.h"
+#endif
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS != 1)
+    #error Flag ADC1 in menu "Project Manager -> Advanced Settings -> Register CallBack" of CubeMx must be ENABLED
+#endif
+
+
+/* Private macros *****************************************************************************************************/
+
+/* Used by the Moving Average Filter */
+#define ANALOG_AVG_FILTER_SHIFT     (7)
+#define ANALOG_AVG_FILTER_LENGTH    (1U<<ANALOG_AVG_FILTER_SHIFT)
+
+/* Calibration parameter stored by the manufacturer 
+ * Given:
+ *  VREF                Current reference voltage
+ *  VREFINT             Current ADC measurement of VREFIN channel
+ *  VREF_CAL            Reference voltage during manufacturer calibration
+ *  VREFINT_CAL         ADC measurement of VREFIN channel during manufacturer calibration
+ *
+ * The following equation holds:
+ *  VREFINT * VREF = VREFINT_CAL * VREF_CAL
+ *
+ * Hence:
+ *  VREF = VREFINT_CAL * VREF_CAL / VREFINT = k_vref / VREFINT;
+ *
+ * The product k_vref = VREFINT_CAL * VREF_CAL is costant hence it can be evaluated in advance, during initialization.
+ * The current VREF voltage can be tracked any time a new VREFINT value is measured
+ */
+#define VREF_CAL    ((double)VREFINT_CAL_VREF * mVolt)
+#define VREFINT_CAL (*VREFINT_CAL_ADDR)
+#define VREF_NOM    (3.300 * Volt)
+#define VREFINT_NOM (1.212 * Volt)
+
+/* Scaling factor */
+#define SCALING_FACTOR  (65536.0/4096.0)
+
+/* Hardware component definitions */
+#define kOhm        (1000.0)
+#define Ohm         (1.000)
+#define mOhm        (0.001)
+#define Volt        (1.000)
+#define mVolt       (0.001)
+#define uVolt       (0.000001)
+#define nVolt       (0.000000001)
+#define Ampere      (1.000)
+#define mAmpere     (0.001)
+
+/* Hardware related constants */
+#define R37			(560.0 * kOhm)
+#define R43			(560.0 * kOhm)
+#define R44			(33.0 * kOhm)
+#define R47			(33.0 * kOhm)
+#define ACS70331_OFFS   (1500.0 * mVolt)
+#define ACS70331_GAIN   (2.5 * Ampere/Volt)
+#define CIN_OFFS    (4096.0 * ACS70331_OFFS/VREF_NOM +0.5)
+#define CIN_GAIN    ((int32_t)(SCALING_FACTOR * ACS70331_GAIN + 0.5))
+#define VIN_GAIN	((uint32_t)(SCALING_FACTOR * (R47+R43)/R47 + 0.5))
+#define VPH_GAIN	((uint32_t)(SCALING_FACTOR * (R44+R37)/R44 + 0.5))
+
+
+/* Private typedefs ***************************************************************************************************/
+
+/*************************************************************************************************************
+ * NOTE: The following data structures comply with the workaround described in section 2.7.7 of the document *
+ * ES0430, rev 6: STM32G471xx/473xx/474xx/483xx/484xx device errata.                                         *
+ * The workaround is mandatory for devices with REV_ID <= 0x2001 (package marking Z)                         *
+ *************************************************************************************************************/
+ 
+/* Data record of ADC1 */
+typedef struct
+{
+  uint16_t vref;  /* Channel 18: Internal voltage reference */
+  uint16_t nul1;
+  uint16_t vph1;  /* Channel_1: Phase 1 voltage */
+  uint16_t nul2;
+  uint16_t vph2;  /* Channel_3: Phase 2 voltage  */
+  uint16_t nul3;
+  uint16_t vph3;  /* Channel_4: Phase 3 voltage  */
+  uint16_t nul4;
+  uint16_t vin;   /* Channel 12: Input voltage */
+  uint16_t nul5;
+  int16_t cin;    /* Channel 14: Input average current */
+  int16_t nul6;
+  uint16_t temp;  /* Channel 16: Internal temperature sensor */
+  uint16_t nul7;
+} ADC1_Record_t;
+
+/* Data record of ADC2 */
+typedef struct
+{
+  int16_t cph1;   /* Channel_3: Phase 1 current */
+  int16_t nul8;
+  int16_t cph2;   /* Channel_4: Phase 2 current  */
+  int16_t nul9;
+  int16_t cph3;   /* Channel_5: Phase 3 current  */
+  int16_t nul10;
+} ADC2_Record_t;
+
+typedef struct
+{
+    int32_t     avg;
+    uint32_t    idx;
+    int32_t     buf[ANALOG_AVG_FILTER_LENGTH];
+} analogAvgFilterTypeDef;
+
+/* Private variables **************************************************************************************************/
+
+/* DMA Buffer of ADC1 and ADC2 */
+static ADC1_Record_t adc1_Buffer;
+static ADC2_Record_t adc2_Buffer[2];
+
+/* VREF constant: VREFINT_CAL * VREFINT_CAL_VREF */
+static uint32_t k_vref = 4096 * VREFINT_NOM / mVolt;
+
+/* Measured VREF in mV. Equal to VCC */
+static uint16_t vref_mV = VREF_NOM / mVolt;
+
+/* Average filters for current measurements */
+static analogAvgFilterTypeDef cinFilter;
+static analogAvgFilterTypeDef cph1Filter;
+static analogAvgFilterTypeDef cph2Filter;
+static analogAvgFilterTypeDef cph3Filter;
+
+/* Public variables ***************************************************************************************************/
+
+
+/* Private functions **************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+static int32_t analogMovingAverage(analogAvgFilterTypeDef *filter, int32_t sample)
+{
+    filter->avg -= filter->buf[filter->idx];
+    filter->avg += (filter->buf[filter->idx] = sample);
+    if (++(filter->idx) >= ANALOG_AVG_FILTER_LENGTH) filter->idx = 0;
+    return filter->avg;
+}
+
+
+/* Callback functions *************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+static void adc1_TransferComplete_cb(ADC_HandleTypeDef *hadc)
+{
+	if (0 != adc1_Buffer.vref) vref_mV = (k_vref + (adc1_Buffer.vref>>1))/adc1_Buffer.vref;
+    else vref_mV = VREF_NOM / mVolt;
+    analogMovingAverage(&cinFilter, adc1_Buffer.cin);
+}
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+static void adc2_HalfTransferComplete_cb(ADC_HandleTypeDef *hadc)
+{
+    pwmSetCurrents_cb(adc2_Buffer[0].cph1, adc2_Buffer[0].cph2, adc2_Buffer[0].cph3);
+    analogMovingAverage(&cph1Filter, adc2_Buffer[0].cph1);
+    analogMovingAverage(&cph2Filter, adc2_Buffer[0].cph2);
+    analogMovingAverage(&cph3Filter, adc2_Buffer[0].cph3);
+}
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+static void adc2_TransferComplete_cb(ADC_HandleTypeDef *hadc)
+{
+    pwmSetCurrents_cb(adc2_Buffer[1].cph1, adc2_Buffer[1].cph2, adc2_Buffer[1].cph3);
+    analogMovingAverage(&cph1Filter, adc2_Buffer[1].cph1);
+    analogMovingAverage(&cph2Filter, adc2_Buffer[1].cph2);
+    analogMovingAverage(&cph3Filter, adc2_Buffer[1].cph3);
+}
+
+
+/* Public functions ***************************************************************************************************/
+
+
+/*******************************************************************************************************************//**
+ * @brief   Measure IPHASE1 current
+ * @param   void
+ * @return  IPHASE1 current in mA [-2500mA .. 2500mA]
+ */
+int32_t analogConvertCurrent(int32_t raw)
+{
+	return CIN_GAIN * vref_mV * raw >> 16u;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Measure VCC voltage in mV. Value must be inside the interval 3200 mV to 3400 mV
+ * @param   void
+ * @return  VCC voltage in mV
+ */
+uint32_t analogVcc(void)
+{
+	return vref_mV;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure VIN voltage
+ * @param   void
+ * @return  VIN voltage in mV [9500mV .. 57000mV]
+ */
+uint32_t analogVin(void)
+{
+    /* Convert value in mV */
+	return VIN_GAIN * vref_mV * adc1_Buffer.vin >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure VPHASE1 voltage
+ * @param   void
+ * @return  VPHASE1 voltage in mV [0 .. 57000mV]
+ */
+uint32_t analogVph1(void)
+{
+	return VPH_GAIN * vref_mV * adc1_Buffer.vph1 >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure VPHASE2 voltage
+ * @param   void
+ * @return  VPHASE2 voltage in mV [0 .. 57000mV]
+ */
+uint32_t analogVph2(void)
+{
+	return VPH_GAIN * vref_mV * adc1_Buffer.vph2 >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure VPHASE3 voltage
+ * @param   void
+ * @return  VPHASE3 voltage in mV [0 .. 57000mV]
+ */
+uint32_t analogVph3(void)
+{
+	return VPH_GAIN * vref_mV * adc1_Buffer.vph3 >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure IIN current
+ * @param   void
+ * @return  IIN current in mA [-2500mA .. 2500mA]
+ */
+int32_t analogCin(void)
+{
+    int32_t raw = cinFilter.avg >> ANALOG_AVG_FILTER_SHIFT;
+	return CIN_GAIN * vref_mV * raw >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure IPHASE1 current
+ * @param   void
+ * @return  IPHASE1 current in mA [-2500mA .. 2500mA]
+ */
+int32_t analogCph1(void)
+{
+    int32_t raw = cph1Filter.avg >> ANALOG_AVG_FILTER_SHIFT;
+	return CIN_GAIN * vref_mV * raw >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure IPHASE2 current
+ * @param   void
+ * @return  IPHASE2 current in mA [-2500mA .. 2500mA]
+ */
+int32_t analogCph2(void)
+{
+    int32_t raw = cph2Filter.avg >> ANALOG_AVG_FILTER_SHIFT;
+	return CIN_GAIN * vref_mV * raw >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Measure IPHASE3 current
+ * @param   void
+ * @return  IPHASE3 current in mA [-2500mA .. 2500mA]
+ */
+int32_t analogCph3(void)
+{
+    int32_t raw = cph3Filter.avg >> ANALOG_AVG_FILTER_SHIFT;
+	return CIN_GAIN * vref_mV * raw >> 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Read the offset value of the Iin sensor
+ * @param   void
+ * @return  Offset current in mA
+ */
+int32_t analogGetOffsetIin( void )
+{
+    return LL_ADC_GetOffsetLevel(ADC1, LL_ADC_OFFSET_4);
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Write the offset value of the Iin sensor
+ * @param   Offset current in mA
+ * @return  Previous value of Offset current in mA
+ */
+int32_t analogSetOffsetIin(int32_t offs)
+{
+	int32_t prev = LL_ADC_GetOffsetLevel(ADC1, LL_ADC_OFFSET_4);
+    LL_ADC_SetOffset(ADC1, LL_ADC_OFFSET_4, LL_ADC_CHANNEL_14, offs);
+	return prev;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Read the offset value of the Phase 1 sensor
+ * @param   void
+ * @return  Offset current in mA
+ */
+int32_t analogGetOffsetIph1( void )
+{
+    return LL_ADC_GetOffsetLevel(ADC2, LL_ADC_OFFSET_1);
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Write the offset value of the Phase 1 sensor
+ * @param   Offset current in mA
+ * @return  Previous value of Offset current in mA
+ */
+int32_t analogSetOffsetIph1(int32_t offs)
+{
+	int32_t prev = LL_ADC_GetOffsetLevel(ADC2, LL_ADC_OFFSET_1);
+    LL_ADC_SetOffset(ADC2, LL_ADC_OFFSET_1, ADC_CHANNEL_3, offs);
+	return prev;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Read the offset value of the Phase 2 sensor
+ * @param   void
+ * @return  Offset current in mA
+ */
+int32_t analogGetOffsetIph2( void )
+{
+    return LL_ADC_GetOffsetLevel(ADC2, LL_ADC_OFFSET_2);
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Write the offset value of the Phase 2 sensor
+ * @param   Offset current in mA
+ * @return  Previous value of Offset current in mA
+ */
+int32_t analogSetOffsetIph2(int32_t offs)
+{
+	int32_t prev = LL_ADC_GetOffsetLevel(ADC2, LL_ADC_OFFSET_2);
+    LL_ADC_SetOffset(ADC2, LL_ADC_OFFSET_2, ADC_CHANNEL_4, offs);
+	return prev;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Read the offset value of the Phase 3 sensor
+ * @param   void
+ * @return  Offset current in mA
+ */
+int32_t analogGetOffsetIph3( void )
+{
+    return LL_ADC_GetOffsetLevel(ADC2, LL_ADC_OFFSET_3);
+}
+
+/*******************************************************************************************************************//**
+ * @brief   Write the offset value of the Phase 3 sensor
+ * @param   Offset current in mA
+ * @return  Previous value of Offset current in mA
+ */
+int32_t analogSetOffsetIph3(int32_t offs)
+{
+	int32_t prev = LL_ADC_GetOffsetLevel(ADC2, LL_ADC_OFFSET_3);
+    LL_ADC_SetOffset(ADC2, LL_ADC_OFFSET_3, ADC_CHANNEL_5, offs);
+	return prev;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+HAL_StatusTypeDef analogInit(void)
+{
+	HAL_StatusTypeDef result = HAL_ERROR;
+
+	/* Check ADC initialization */
+	if ((NULL != hadc1.Instance) && (NULL != hadc2.Instance))
+	{
+		/* Stop any ADC operation */
+		HAL_ADC_Stop_DMA(&hadc1);
+		HAL_ADC_Stop_DMA(&hadc2);
+
+		/* Calibrate ADC1 and ADC2 */
+		if ((HAL_OK == HAL_ADCEx_Calibration_Start(&hadc1, ADC_SINGLE_ENDED)) &&
+		    (HAL_OK == HAL_ADCEx_Calibration_Start(&hadc2, ADC_SINGLE_ENDED)))
+		{
+			/* Calculate the proportionality constant */
+			k_vref = (uint32_t)VREFINT_CAL_VREF * (uint32_t)VREFINT_CAL;
+
+            /* If the board has never been calibrated */
+            if (0 == MainConf.analog.cinOffs)
+            {
+                /* Configure default values */
+                MainConf.analog.cinOffs   = CIN_OFFS;
+                MainConf.analog.cphOffs[0] = CIN_OFFS;
+                MainConf.analog.cphOffs[1] = CIN_OFFS;
+                MainConf.analog.cphOffs[2] = CIN_OFFS;
+            }
+            
+            /* Set the calibration parameters */
+            analogSetOffsetIin(MainConf.analog.cinOffs);
+            analogSetOffsetIph1(MainConf.analog.cphOffs[0]);
+            analogSetOffsetIph2(MainConf.analog.cphOffs[1]);
+            analogSetOffsetIph3(MainConf.analog.cphOffs[2]);
+			
+			/* Clear the input buffers */
+			memset((void *)&adc1_Buffer, 0, sizeof(adc1_Buffer));
+			memset((void *)&adc2_Buffer, 0, sizeof(adc2_Buffer));
+
+			/* Register the interrupt callback function for the DMA Transfer Complete interrupt*/
+			if ((HAL_OK == HAL_ADC_RegisterCallback(&hadc1, HAL_ADC_CONVERSION_COMPLETE_CB_ID, adc1_TransferComplete_cb)) &&
+				(HAL_OK == HAL_ADC_RegisterCallback(&hadc2, HAL_ADC_CONVERSION_HALF_CB_ID, adc2_HalfTransferComplete_cb)) &&
+				(HAL_OK == HAL_ADC_RegisterCallback(&hadc2, HAL_ADC_CONVERSION_COMPLETE_CB_ID, adc2_TransferComplete_cb)))
+			{
+				/* Enable the Transfer Complete interrupts of the DMA */
+				__HAL_DMA_ENABLE_IT(hadc1.DMA_Handle, DMA_IT_TC);
+				__HAL_DMA_ENABLE_IT(hadc2.DMA_Handle, DMA_IT_TC);
+				/* Enable the ADC in DMA mode */
+				if ((HAL_OK == HAL_ADC_Start_DMA(&hadc1, (uint32_t *)&adc1_Buffer, sizeof(adc1_Buffer)/sizeof(uint16_t))) &&
+					(HAL_OK == HAL_ADC_Start_DMA(&hadc2, (uint32_t *)&adc2_Buffer, sizeof(adc2_Buffer)/sizeof(uint16_t))))
+				{
+					/* DMA is running now */
+					result = HAL_OK;
+				}
+			}
+		}
+	}
+	return result;
+}
+
+#if defined(HALCONFIG_DONTUSE_TESTS)
+#else
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+void analogTest(void)
+{
+    char ch;
+    char coBuffer[80];
+    const char *curs;
+    int32_t value;
+
+    coprintf("Analog Test\n"); HAL_Delay(250);
+    coprintf("Vin = %5u mV, Iin = %+5d mA, Vcc = %5u mV\n", analogVin(), analogCin(), analogVcc()); HAL_Delay(250);
+
+    /* Infinite loop */
+    for(;;)
+    {
+        coprintf("0   : Set Iin offset\n"
+                 "1   : Set phase 1 offset\n"
+                 "2   : Set phase 2 offset\n"
+                 "3   : Set phase 3 offset\n"
+                 "D   : Display currents/voltages\n"
+                 "Z   : Autozero phase offsets\n"
+                 "ESC : Exit test\n"
+                 "? "); HAL_Delay(250);
+        ch = coRxChar();
+        if (isprint(ch))
+        {
+            coprintf("%c\n", ch);
+            switch (toupper(ch))
+            {
+                case '0':
+                    while (1)
+                    {
+                        coprintf("\rIin = %+5d mA", analogCin()); HAL_Delay(250);
+                        if (coRxReady())
+                        {
+                            ch = coRxChar();
+                            value = analogGetOffsetIin();
+                            if (ch == '+') --value;
+                            else if (ch == '-') ++value;
+                            else if (ch == '<') value += 10;
+                            else if (ch == '>') value -= 10;
+                            else { coprintf("\n"); break; }
+                            analogSetOffsetIin(value);
+                            MainConf.analog.cinOffs = value;
+                        }
+                    }
+                    break;
+
+                case '1':
+                    while (1)
+                    {
+                        coprintf("\rIph1 = %+5d mA", analogCph1()); HAL_Delay(250);
+                        if (coRxReady())
+                        {
+                            ch = coRxChar();
+                            value = analogGetOffsetIph1();
+                            if (ch == '+') --value;
+                            else if (ch == '-') ++value;
+                            else if (ch == '<') value += 10;
+                            else if (ch == '>') value -= 10;
+                            else { coprintf("\n"); break; }
+                            analogSetOffsetIph1(value);
+                            MainConf.analog.cphOffs[0] = value;
+                        }
+                    }
+                    break;
+
+                case '2':
+                    while (1)
+                    {
+                        coprintf("\rIph2 = %+5d mA", analogCph2()); HAL_Delay(250);
+                        if (coRxReady())
+                        {
+                            ch = coRxChar();
+                            value = analogGetOffsetIph2();
+                            if (ch == '+') --value;
+                            else if (ch == '-') ++value;
+                            else if (ch == '<') value += 10;
+                            else if (ch == '>') value -= 10;
+                            else { coprintf("\n"); break; }
+                            analogSetOffsetIph2(value);
+                            MainConf.analog.cphOffs[1] = value;
+                        }
+                    }
+                    break;
+
+                case '3':
+                    while (1)
+                    {
+                        coprintf("\rIph3 = %+5d mA", analogCph3()); HAL_Delay(250);
+                        if (coRxReady())
+                        {
+                            ch = coRxChar();
+                            value = analogGetOffsetIph3();
+                            if (ch == '+') --value;
+                            else if (ch == '-') ++value;
+                            else if (ch == '<') value += 10;
+                            else if (ch == '>') value -= 10;
+                            else { coprintf("\n"); break; }
+                            analogSetOffsetIph3(value);
+                            MainConf.analog.cphOffs[2] = value;
+                        }
+                    }
+                    break;
+
+                case 'D':
+                    while (1)
+                    {
+                        coprintf("Press RETURN to stop\n");  HAL_Delay(100);
+                        /*       "|xxxxx|xxxxx/+xxxx|xxxxx/+xxxx|xxxxx/+xxxx|xxxxx/+xxxx|"  */
+                        coprintf("| Vcc  |    Vin    | Phase #1  | Phase #2  | Phase #3  |\n");  HAL_Delay(100);
+                        coprintf("|  mV  |   mV/mA   |   mV/mA   |   mV/mA   |   mV/mA   |\n");  HAL_Delay(100);
+                        do
+                        {
+                            coprintf("\r|%5u |", analogVcc()); HAL_Delay(100);
+                            coprintf("%5u/%+-5d|", analogVin(),  analogCin());  HAL_Delay(100);
+                            coprintf("%5u/%+-5d|", analogVph1(), analogCph1()); HAL_Delay(100);
+                            coprintf("%5u/%+-5d|", analogVph2(), analogCph2()); HAL_Delay(100);
+                            coprintf("%5u/%+-5d|", analogVph3(), analogCph3()); HAL_Delay(100);
+                            coprintf("%+-5d", (analogCph1()+analogCph2()+analogCph3())/3); HAL_Delay(100);
+                        } while (!coRxReady());
+                        coprintf("\nPWM? ");
+                        coEditString(coBuffer, sizeof(coBuffer));
+                        coprintf("\n");
+                        curs = &(coBuffer[0]);
+                        ch = skipblank(&curs);
+                        if (isdigit(ch))
+                        {
+//                            if (atosl(&curs, &value) && ('\0' == skipblank(&curs)) && (HAL_OK == pwmSetValue(value)))
+//                            {
+//                                coprintf("Motor PWM = %d\n", value);
+//                                continue;
+//                            }
+                        }
+                        else if ('\0' == ch) break;
+                        coprintf("ERROR: %s\n", curs);
+                    }
+                    pwmSet(0, 0, 0);
+                    break;
+
+                case 'Z':
+                    coprintf("Sorry: not implemented yet\n", ch);
+                    break;
+
+                default:
+                    coprintf("Unknown command: %c\n", ch);
+                    break;
+            }
+        }
+        else if ('\x1B' == ch)
+        {
+            coprintf("\n");
+            coprintf("- Iin offset:     %+d LSB\n", analogGetOffsetIin());
+            coprintf("- Iphase1 offset: %+d LSB\n", analogGetOffsetIph1());
+            coprintf("- Iphase2 offset: %+d LSB\n", analogGetOffsetIph2());
+            coprintf("- Iphase3 offset: %+d LSB\n", analogGetOffsetIph3());
+            coprintf("Exit test\n");
+            return ;
+        }
+    }
+}
+
+#endif // HALCONFIG_DONTUSE_TESTS
+
+/* END OF FILE ********************************************************************************************************/

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/analog.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/analog.h
@@ -1,0 +1,77 @@
+/*******************************************************************************************************************//**
+ * @file    analog.c
+ * @author  G.Zini
+ * @version 1.0
+ * @date    2021 January, 20
+ * @brief   Analog signals management
+ **********************************************************************************************************************/
+
+/* Define to prevent recursive inclusion */
+#ifndef __ANALOG_H
+#define __ANALOG_H
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
+/* Includes ----------------------------------------------------------------------------------------------------------*/
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+#if defined(USE_STM32HAL)
+#include "stm32hal.h"
+#else 
+#include <stdarg.h>        
+#include "stm32g4xx.h"
+#include "adc.h"
+#endif
+        
+/* Exported macro ----------------------------------------------------------------------------------------------------*/
+
+
+/* Exported typedefs -------------------------------------------------------------------------------------------------*/
+
+/* Configuration structure:
+ * FLASH manager must include a member called "analog" in MainConf structure
+ */
+typedef struct
+{
+    uint16_t    cinOffs;
+    uint16_t    cphOffs[3];
+} analogConfTypeDef;
+
+/* Exported variables ------------------------------------------------------------------------------------------------*/
+
+
+/* Exported functions prototypes -------------------------------------------------------------------------------------*/
+
+extern int32_t analogConvertCurrent(int32_t raw);
+extern HAL_StatusTypeDef analogInit(void);
+extern uint32_t analogVcc(void);
+extern uint32_t analogVph1(void);
+extern uint32_t analogVph2(void);
+extern uint32_t analogVph3(void);
+extern uint32_t analogVin(void);
+extern int32_t  analogCin(void);
+extern int32_t  analogCph1(void);
+extern int32_t  analogCph2(void);
+extern int32_t  analogCph3(void);
+extern int32_t  analogGetOffsetIin(void);
+extern int32_t  analogSetOffsetIin(int32_t offs);
+extern int32_t  analogGetOffsetIph1(void);
+extern int32_t  analogSetOffsetIph1(int32_t offs);
+extern int32_t  analogGetOffsetIph2(void);
+extern int32_t  analogSetOffsetIph2(int32_t offs);
+extern int32_t  analogGetOffsetIph3(void);
+extern int32_t  analogSetOffsetIph3(int32_t offs);
+
+extern void analogTest(void);
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif /* __cplusplus */
+#endif /* __ANALOG_H */
+/* END OF FILE ********************************************************************************************************/

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/encoder.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/encoder.c
@@ -1,0 +1,157 @@
+/*******************************************************************************************************************//**
+ * @file    encoder.c
+ * @author  G.Zini
+ * @version 1.0
+ * @date    2021 March, 9
+ * @brief   Incremental Encoder management
+ **********************************************************************************************************************/
+ 
+// CODE SHAPER
+#if defined(USE_STM32HAL)
+#include "motorhal_config.h"
+#endif
+ 
+#if defined(USE_STM32HAL) 
+// API
+#include "encoder.h"
+#endif
+
+/* Includes ***********************************************************************************************************/
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+
+#if defined(USE_STM32HAL)
+#include "stm32hal.h"
+#if !defined(HALCONFIG_DONTUSE_FLASH)
+#include "flash.h"
+#endif
+#else
+#include "FreeRTOS.h"
+#include "encoder.h"
+#include "flash.h"
+#include "main.h"
+#include "utilities.h"
+#include "tim.h"
+#include "stm32g4xx_hal_tim.h"
+#endif
+
+#if (USE_HAL_TIM_REGISTER_CALLBACKS != 1)
+    #error Flag TIM2 in menu "Project Manager -> Advanced Settings -> Register CallBack" of CubeMx must be ENABLED
+#endif
+
+/* Private macros *****************************************************************************************************/
+/* Private variables **************************************************************************************************/
+
+/* Coversion factor from encoder step value to elctrical angle. It is given by:
+ * encoderConvFactor = 65536 * number_of_poles / number_of_encoder_steps
+ */
+static int16_t encoderConvFactor = 112;   
+
+
+/* Callbacks **********************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief
+ * @param
+ * @return
+ */
+void encoderIndexCallback(TIM_HandleTypeDef *htim)
+{
+    /**************
+     * TO BE DONE *
+     **************/
+}
+
+
+/* Exported functions *************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief   Start TIM2 as 32 bits incremental encoders
+ * @param   void
+ * @return  HAL_StatusTypeDef   Operation result
+ */
+HAL_StatusTypeDef encoderInit(void)
+{
+    TIM_Encoder_InitTypeDef sConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIMEx_EncoderIndexConfigTypeDef sEncoderIndexConfig = {0};
+
+    if (0 == MainConf.encoder.mode)
+    {
+        MainConf.encoder.mode   = TIM_ENCODERMODE_TI12;
+        MainConf.encoder.filter = 4;
+        MainConf.encoder.idxpos = TIM_ENCODERINDEX_POSITION_00;
+        MainConf.encoder.nsteps = 4096;
+    }
+
+    /* Forced, for now */
+    encoderConvFactor = 112;   
+    
+    /* Re-configure TIM2 base, IC1 and IC2 */
+    htim2.Instance = TIM2;
+    htim2.Init.Prescaler = 0;
+    htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim2.Init.Period = MainConf.encoder.nsteps - 1;
+    htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    sConfig.EncoderMode = MainConf.encoder.mode;
+    sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
+    sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
+    sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
+    sConfig.IC1Filter = MainConf.encoder.filter;
+    sConfig.IC2Polarity = TIM_ICPOLARITY_RISING;
+    sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
+    sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
+    sConfig.IC2Filter = MainConf.encoder.filter;
+    if (HAL_OK != HAL_TIM_Encoder_Init(&htim2, &sConfig)) return HAL_ERROR;
+
+    /* Force master mode witout slaves */
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_OK != HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig)) return HAL_ERROR;
+
+    /* Configure the INDEX mode */
+    sEncoderIndexConfig.Polarity = TIM_ENCODERINDEX_POLARITY_NONINVERTED;
+    sEncoderIndexConfig.Prescaler = TIM_ENCODERINDEX_PRESCALER_DIV1;
+    sEncoderIndexConfig.Filter = MainConf.encoder.filter;
+    sEncoderIndexConfig.FirstIndexEnable = DISABLE;
+    sEncoderIndexConfig.Position = MainConf.encoder.idxpos;
+    sEncoderIndexConfig.Direction = TIM_ENCODERINDEX_DIRECTION_UP_DOWN;
+    if (HAL_OK != HAL_TIMEx_ConfigEncoderIndex(&htim2, &sEncoderIndexConfig)) return HAL_ERROR;
+
+    /* Register the callback function used to signal the activation of the Index pulse */
+    if (HAL_OK != HAL_TIM_RegisterCallback(&htim2, HAL_TIM_ENCODER_INDEX_CB_ID, encoderIndexCallback)) return HAL_ERROR;
+
+    /* Start timers in encoder mode */
+    if (HAL_OK != HAL_TIM_Encoder_Start(&htim2, TIM_CHANNEL_ALL)) return HAL_ERROR;
+    __HAL_TIM_SET_COUNTER(&htim2, 0);
+    return HAL_OK;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Read encoder value
+ * @param   void
+ * @return  int32_t     Encoder value
+ */
+uint32_t encoderGetCounter(void)
+{
+    return (uint32_t)__HAL_TIM_GET_COUNTER(&htim2);
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Read encoder value and convert to electrical-angle
+ * @param   void
+ * @return  uint16_t    Encoder value
+ */
+uint16_t encoderGetElectricalAngle(void)
+{
+    return (__HAL_TIM_GET_COUNTER(&htim2) * encoderConvFactor) & 0xFFFF;
+}
+
+
+/* END OF FILE ********************************************************************************************************/

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/encoder.h
@@ -1,0 +1,55 @@
+/*******************************************************************************************************************//**
+ * @file    encoder.h
+ * @author  G.Zini
+ * @version 1.0
+ * @date    2021 March, 9
+ * @brief   Incremental Encoder management
+ **********************************************************************************************************************/
+
+/* Define to prevent recursive inclusion */
+#ifndef __ENCODER_H
+#define __ENCODER_H
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* Includes ----------------------------------------------------------------------------------------------------------*/
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <ctype.h>
+        
+#if defined(USE_STM32HAL)
+#include "stm32hal.h"
+#else
+#include <stdarg.h>
+#include "stm32g4xx.h"
+#include "stm32g4xx_hal_tim.h"
+#endif
+
+/* Exported typedefs -------------------------------------------------------------------------------------------------*/
+
+typedef struct
+{
+    uint16_t    mode;
+    uint16_t    filter;
+    uint16_t    idxpos;
+    uint16_t    nsteps;
+} encoderConfTypeDef;
+
+
+/* Exported macro ----------------------------------------------------------------------------------------------------*/
+/* Exported variables ------------------------------------------------------------------------------------------------*/
+/* Exported functions prototypes -------------------------------------------------------------------------------------*/
+
+extern HAL_StatusTypeDef encoderInit(void);
+extern uint32_t encoderGetCounter(void);
+extern uint16_t encoderGetElectricalAngle(void);
+
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif /* __cplusplus */
+#endif /* __ENCODER_H */
+/* END OF FILE ********************************************************************************************************/

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/motorhal_config.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/motorhal_config.c
@@ -1,0 +1,220 @@
+
+/*
+ * Copyright (C) 2021 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+#if 0
+    The files motorhal_config.[h, c] contain macros and code which cuts aways un-necessary dependencies
+    for the files provided by Giorgio Zini for the motor control of the amcbldc. These files are:
+    encoder.[c, h], pwm.[c, h], analog.[c, h]. The dependencies cut away are those which offer
+    generic services such as logging, leds, flash storage.    
+#endif
+
+// CODE SHAPER
+#if defined(USE_STM32HAL)
+#include "motorhal_config.h"
+#endif
+
+#if defined(HALCONFIG_DONTUSE_FLASH)
+
+MainConfTypeDef MainConf = {0};
+
+#else
+#endif // HALCONFIG_DONTUSE_FLASH
+
+
+#if defined(HALCONFIG_ADD_IRQHANDLERS)
+
+#include "stm32hal.h"
+
+/**
+  * @brief This function handles DMA1 channel1 global interrupt.
+  */
+void DMA1_Channel1_IRQHandler(void)
+{
+  /* USER CODE BEGIN DMA1_Channel1_IRQn 0 */
+
+  /* USER CODE END DMA1_Channel1_IRQn 0 */
+  HAL_DMA_IRQHandler(&hdma_adc1);
+  /* USER CODE BEGIN DMA1_Channel1_IRQn 1 */
+
+  /* USER CODE END DMA1_Channel1_IRQn 1 */
+}
+
+/**
+  * @brief This function handles DMA1 channel2 global interrupt.
+  */
+void DMA1_Channel2_IRQHandler(void)
+{
+  /* USER CODE BEGIN DMA1_Channel2_IRQn 0 */
+
+  /* USER CODE END DMA1_Channel2_IRQn 0 */
+  HAL_DMA_IRQHandler(&hdma_adc2);
+  /* USER CODE BEGIN DMA1_Channel2_IRQn 1 */
+
+  /* USER CODE END DMA1_Channel2_IRQn 1 */
+}
+
+/**
+  * @brief This function handles ADC1 and ADC2 global interrupt.
+  */
+void ADC1_2_IRQHandler(void)
+{
+  /* USER CODE BEGIN ADC1_2_IRQn 0 */
+
+  /* USER CODE END ADC1_2_IRQn 0 */
+  HAL_ADC_IRQHandler(&hadc1);
+  HAL_ADC_IRQHandler(&hadc2);
+  /* USER CODE BEGIN ADC1_2_IRQn 1 */
+
+  /* USER CODE END ADC1_2_IRQn 1 */
+}
+
+///**
+//  * @brief This function handles USB low priority interrupt remap.
+//  */
+//void USB_LP_IRQHandler(void)
+//{
+//  /* USER CODE BEGIN USB_LP_IRQn 0 */
+
+//  /* USER CODE END USB_LP_IRQn 0 */
+//  HAL_PCD_IRQHandler(&hpcd_USB_FS);
+//  /* USER CODE BEGIN USB_LP_IRQn 1 */
+
+//  /* USER CODE END USB_LP_IRQn 1 */
+//}
+
+/**
+  * @brief This function handles TIM1 break interrupt and TIM15 global interrupt.
+  */
+void TIM1_BRK_TIM15_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM1_BRK_TIM15_IRQn 0 */
+
+  /* USER CODE END TIM1_BRK_TIM15_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim1);
+  /* USER CODE BEGIN TIM1_BRK_TIM15_IRQn 1 */
+
+  /* USER CODE END TIM1_BRK_TIM15_IRQn 1 */
+}
+
+/**
+  * @brief This function handles TIM1 update interrupt and TIM16 global interrupt.
+  */
+void TIM1_UP_TIM16_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM1_UP_TIM16_IRQn 0 */
+
+  /* USER CODE END TIM1_UP_TIM16_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim1);
+  /* USER CODE BEGIN TIM1_UP_TIM16_IRQn 1 */
+
+  /* USER CODE END TIM1_UP_TIM16_IRQn 1 */
+}
+
+/**
+  * @brief This function handles TIM1 trigger and commutation interrupts and TIM17 global interrupt.
+  */
+void TIM1_TRG_COM_TIM17_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM1_TRG_COM_TIM17_IRQn 0 */
+
+  /* USER CODE END TIM1_TRG_COM_TIM17_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim1);
+  /* USER CODE BEGIN TIM1_TRG_COM_TIM17_IRQn 1 */
+
+  /* USER CODE END TIM1_TRG_COM_TIM17_IRQn 1 */
+}
+
+/**
+  * @brief This function handles TIM1 capture compare interrupt.
+  */
+void TIM1_CC_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM1_CC_IRQn 0 */
+
+  /* USER CODE END TIM1_CC_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim1);
+  /* USER CODE BEGIN TIM1_CC_IRQn 1 */
+
+  /* USER CODE END TIM1_CC_IRQn 1 */
+}
+
+/**
+  * @brief This function handles TIM2 global interrupt.
+  */
+void TIM2_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM2_IRQn 0 */
+
+  /* USER CODE END TIM2_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim2);
+  /* USER CODE BEGIN TIM2_IRQn 1 */
+
+  /* USER CODE END TIM2_IRQn 1 */
+}
+
+/**
+  * @brief This function handles TIM3 global interrupt.
+  */
+void TIM3_IRQHandler(void)
+{
+  /* USER CODE BEGIN TIM3_IRQn 0 */
+
+  /* USER CODE END TIM3_IRQn 0 */
+  HAL_TIM_IRQHandler(&htim3);
+  /* USER CODE BEGIN TIM3_IRQn 1 */
+
+  /* USER CODE END TIM3_IRQn 1 */
+}
+
+/**
+  * @brief This function handles EXTI line[15:10] interrupts.
+  */
+void EXTI15_10_IRQHandler(void)
+{
+  /* USER CODE BEGIN EXTI15_10_IRQn 0 */
+
+  /* USER CODE END EXTI15_10_IRQn 0 */
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_13);
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_14);
+  /* USER CODE BEGIN EXTI15_10_IRQn 1 */
+
+  /* USER CODE END EXTI15_10_IRQn 1 */
+}
+
+///**
+//  * @brief This function handles I2C4 event interrupt / I2C4 wake-up interrupt through EXTI line 42.
+//  */
+//void I2C4_EV_IRQHandler(void)
+//{
+//  /* USER CODE BEGIN I2C4_EV_IRQn 0 */
+
+//  /* USER CODE END I2C4_EV_IRQn 0 */
+//  HAL_I2C_EV_IRQHandler(&hi2c4);
+//  /* USER CODE BEGIN I2C4_EV_IRQn 1 */
+
+//  /* USER CODE END I2C4_EV_IRQn 1 */
+//}
+
+///**
+//  * @brief This function handles I2C4 error interrupt.
+//  */
+//void I2C4_ER_IRQHandler(void)
+//{
+//  /* USER CODE BEGIN I2C4_ER_IRQn 0 */
+
+//  /* USER CODE END I2C4_ER_IRQn 0 */
+//  HAL_I2C_ER_IRQHandler(&hi2c4);
+//  /* USER CODE BEGIN I2C4_ER_IRQn 1 */
+
+//  /* USER CODE END I2C4_ER_IRQn 1 */
+//}
+
+
+#endif
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/motorhal_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/motorhal_config.h
@@ -1,0 +1,67 @@
+
+/*
+ * Copyright (C) 2021 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+#ifndef __HALCONFIG_H
+#define __HALCONFIG_H
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+        
+        
+#if !defined(USE_STM32HAL)   
+#define USE_STM32HAL
+#endif        
+
+#define HALCONFIG_DONTUSE_CONSOLE
+#define HALCONFIG_DONTUSE_FLASH
+#define HALCONFIG_DONTUSE_UTILITIES
+#define HALCONFIG_DONTUSE_LED
+#define HALCONFIG_DONTUSE_TESTS       
+#define HALCONFIG_ADD_IRQHANDLERS   
+
+#if defined(HALCONFIG_DONTUSE_FLASH)
+        
+#include "pwm.h"
+#include "encoder.h"
+#include "analog.h"
+typedef struct
+{
+    pwmConfTypeDef pwm;
+    encoderConfTypeDef encoder;
+    analogConfTypeDef analog;
+} MainConfTypeDef;
+
+extern MainConfTypeDef MainConf;
+
+#endif     
+
+
+#if defined(HALCONFIG_DONTUSE_UTILITIES)
+
+// Get the MSB of an integer. The compiler generates an immediate constant value when the argument is a constant
+// value known at compile time. Use macro msb(x) for not constant values
+// @param   x   Integer constant value
+// @return      Bit number of the left-most not-zero bit of the argument, or -1 when the argument is 0
+#define MSB(x)      ((x)?MSB$64(((uint64_t)(x))):-1)
+#define MSB$64(x)   (x&0xFFFFFFFF00000000LL?(32+MSB$32(x>>32)):MSB$32(x))
+#define MSB$32(x)   (x&0x00000000FFFF0000LL?(16+MSB$16(x>>16)):MSB$16(x))
+#define MSB$16(x)   (x&0x000000000000FF00LL?(8+MSB$8(x>>8)):MSB$8(x))
+#define MSB$8(x)    (x&0x00000000000000F0LL?(4+MSB$4(x>>4)):MSB$4(x))
+#define MSB$4(x)    (x&0x000000000000000CLL?(2+MSB$2(x>>2)):MSB$2(x))
+#define MSB$2(x)    (x&0x0000000000000002LL?1:0)
+
+#endif // HALCONFIG_DONTUSE_UTILITIES
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* __HALCONFIG_H */
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/pwm.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/pwm.c
@@ -1,0 +1,729 @@
+/*******************************************************************************************************************//**
+ * @file    pwm.c
+ * @author  G.Zini
+ * @version 1.0
+ * @date    2021 January, 19
+ * @brief   PWM signals management
+ **********************************************************************************************************************/
+
+ 
+// CODE SHAPER
+#if defined(USE_STM32HAL)
+#include "motorhal_config.h"
+#endif
+
+#if defined(USE_STM32HAL) 
+// API
+#include "pwm.h"
+#endif
+
+/* Includes ***********************************************************************************************************/
+#if defined(USE_STM32HAL)
+#include "stm32hal.h"
+#if !defined(HALCONFIG_DONTUSE_UTILITIES)
+#include "utilities.h"
+#endif
+#if !defined(HALCONFIG_DONTUSE_FLASH)
+#include "flash.h"
+#endif
+#if !defined(HALCONFIG_DONTUSE_CONSOLE)
+ #include "console.h"
+#endif
+#if !defined(HALCONFIG_DONTUSE_LED)
+#include "led.h"
+#endif
+#else
+#include "console.h"
+#include "cordic.h"
+#include "encoder.h"
+#include "flash.h"
+#include "led.h"
+#include "pwm.h"
+#include "tim.h"
+#include "utilities.h"
+#include "FreeRTOS.h"
+#include "main.h"
+#include "stm32g4xx_hal_tim.h"
+#endif
+
+#if (USE_HAL_TIM_REGISTER_CALLBACKS != 1)
+    #error Flag TIM1 in menu "Project Manager -> Advanced Settings -> Register CallBack" of CubeMx must be ENABLED
+#endif
+
+#define USE_HALL_SENSORS    1
+//#define USE_ENCODER_SENSORS 1
+
+
+/* Private macros *****************************************************************************************************/
+
+#define PWM_ENABLE_MASK     (EN1_Pin|EN2_Pin|EN3_Pin)
+
+/* Current in six-step mode */
+#define HALL_CURRENT_PHASE1 (0)
+#define HALL_CURRENT_PHASE2 (1)
+#define HALL_CURRENT_PHASE3 (2)
+
+
+/* Private variables **************************************************************************************************/
+
+/* Current value of the Hall sensors */ 
+static volatile uint8_t  hallStatus = 0;
+static volatile int16_t  pwmStatus = 0;
+static volatile int32_t  hallCounter = 0;
+static volatile uint16_t hallAngle = 0;
+static volatile int16_t hallCurrentPhase = 0;
+static volatile int16_t hallCurrent = 0;
+
+#if defined(USE_STM32HAL) && defined(__cplusplus)
+constexpr uint16_t hallAngleTable[] =
+{
+    /* ABC  (°)  */
+    /* LLL ERROR */ 0,
+    /* LLH  300  */ static_cast<uint16_t>(300.0 * 65536.0 / 360.0 + 0.5), /* 54613 */
+    /* LHL  180  */ static_cast<uint16_t>(180.0 * 65536.0 / 360.0 + 0.5), /* 32768 */
+    /* LHH  240  */ static_cast<uint16_t>(240.0 * 65536.0 / 360.0 + 0.5), /* 43690 */
+    /* HLL   60  */ static_cast<uint16_t>( 60.0 * 65536.0 / 360.0 + 0.5), /* 10923 */
+    /* HLH    0  */ static_cast<uint16_t>(  0.0 * 65536.0 / 360.0 + 0.5), /*     0 */
+    /* HHL  120  */ static_cast<uint16_t>(120.0 * 65536.0 / 360.0 + 0.5), /* 21845 */
+    /* HHH ERROR */ static_cast<uint16_t>(0)
+};
+#else
+static const uint16_t hallAngleTable[] =
+{
+    /* ABC  (°)  */
+    /* LLL ERROR */ 0,
+    /* LLH  300  */ 300.0 * 65536.0 / 360.0 + 0.5, /* 54613 */
+    /* LHL  180  */ 180.0 * 65536.0 / 360.0 + 0.5, /* 32768 */
+    /* LHH  240  */ 240.0 * 65536.0 / 360.0 + 0.5, /* 43690 */
+    /* HLL   60  */  60.0 * 65536.0 / 360.0 + 0.5, /* 10923 */
+    /* HLH    0  */   0.0 * 65536.0 / 360.0 + 0.5, /*     0 */
+    /* HHL  120  */ 120.0 * 65536.0 / 360.0 + 0.5, /* 21845 */
+    /* HHH ERROR */ 0
+};
+#endif
+
+/* Public variables ***************************************************************************************************/
+/* Private functions **************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief   Read the current Hall sensor status and configure signals EN1, EN2, EN3, PHASE1, PHASE2, PHASE3 as for a
+ *          CW or CCW torque
+ * @param   pwm     Set the new PWM value. A positive value generate a CW torque, whereas a negative value generate a
+ *                  CCW torque. Absolute value must be lower than MAX_PWM
+ * @return  void
+ *
+ * This function configures the signals as in the following table
+ *
+ * |                   ||         CW           ||        CCW           |
+ * | HALL1 HALL2 HALL3 || PHASE1 PHASE2 PHASE3 || PHASE1 PHASE2 PHASE3 |
+ * |-------------------++----------------------++----------------------|
+ * |   1     0     1   ||  PWM    LOW    HIZ   ||  LOW    PWM    HIZ   |
+ * |   1     0     0   ||  PWM    HIZ    LOW   ||  LOW    HIZ    PWM   |
+ * |   1     1     0   ||  HIZ    PWM    LOW   ||  HIZ    LOW    PWM   |
+ * |   0     1     0   ||  LOW    PWM    HIZ   ||  PWM    LOW    HIZ   |
+ * |   0     1     1   ||  LOW    HIZ    PWM   ||  PWM    HIZ    LOW   |
+ * |   0     0     1   ||  HIZ    LOW    PWM   ||  HIZ    PWM    LOW   |
+ * |-------------------||----------------------||----------------------|
+ * |   0     0     0   ||  HIZ    HIZ    HIZ   ||  HIZ    HIZ    HIZ   | ERROR
+ * |   1     1     1   ||  HIZ    HIZ    HIZ   ||  HIZ    HIZ    HIZ   | ERROR
+ *
+ * where:
+ *      HIZ means that PHASEx is in high impedanace state (ENx = 0, PWMx = 0)
+ *      LOW means that PHASEx is in LOW state (ENx = 1, PWMx = 0)
+ *      PWM means that PHASEx is modulated with the pwm value (ENx = 1, PWMx = pwm)
+ */
+static void hallSetPWM(int16_t pwm)
+{
+#ifdef USE_HALL_SENSORS
+    /* Remeber previous value */
+    uint8_t hall = hallStatus;
+#endif
+    
+    /* Read current value of HALL1, HALL2 and HALL3 signals in bits 2..0 */
+    hallStatus = (((HALL1_GPIO_Port->IDR & HALL1_Pin) >> MSB(HALL1_Pin)) << 2)
+               | (((HALL2_GPIO_Port->IDR & HALL2_Pin) >> MSB(HALL2_Pin)) << 1)
+               | (((HALL3_GPIO_Port->IDR & HALL3_Pin) >> MSB(HALL3_Pin)) << 0);
+
+#ifdef USE_HALL_SENSORS
+    /* Current hall sensors status */
+    switch (hallStatus)
+    {
+        case 0x05:
+            /* PHASE1=pwm, PHASE2=-pwm, PHASE3=hiz */
+            EN1_GPIO_Port->BSRR = EN1_Pin | EN2_Pin | (EN3_Pin<<16) ;
+            /* CW rotation */
+            if (pwm >= 0)
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE1;
+            }
+            /* CCW rotation */
+            else
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, -pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE2;
+            }
+            /* Verify previous HALL sensors status */
+            if      (hall == 0x01) ++hallCounter;
+            else if (hall == 0x04) --hallCounter;
+            break;
+
+        case 0x04:
+            /* PHASE1=pwm, PHASE2=hiz, PHASE3=-pwm */
+            EN1_GPIO_Port->BSRR = EN1_Pin | (EN2_Pin<<16) | EN3_Pin ;
+            /* CW rotation */
+            if (pwm >= 0)
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE1;
+            }
+            /* CCW rotation */
+            else
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, -pwm);
+                hallCurrentPhase = HALL_CURRENT_PHASE3;
+            }
+            /* Verify previous HALL sensors status */
+            if      (hall == 0x05) ++hallCounter;
+            else if (hall == 0x06) --hallCounter;
+            break;
+
+        case 0x06:
+            /* PHASE1=hiz, PHASE2=pwm, PHASE3=-pwm */
+            EN1_GPIO_Port->BSRR = (EN1_Pin<<16) | EN2_Pin | EN3_Pin;
+            /* CW rotation */
+            if (pwm >= 0)
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE2;
+            }
+            /* CCW rotation */
+            else
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, -pwm);
+                hallCurrentPhase = HALL_CURRENT_PHASE3;
+            }
+            /* Verify previous HALL sensors status */
+            if      (hall == 0x04) ++hallCounter;
+            else if (hall == 0x02) --hallCounter;
+            break;
+
+        case 0x02:
+            /* PHASE1=-pwm, PHASE2=pwm, PHASE3=hiz */
+            EN1_GPIO_Port->BSRR = EN1_Pin | EN2_Pin | (EN3_Pin<<16) ;
+            /* CW rotation */
+            if (pwm >= 0)
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE2;
+            }
+            /* CCW rotation */
+            else
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, -pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE1;
+            }
+            /* Verify previous HALL sensors status */
+            if      (hall == 0x06) ++hallCounter;
+            else if (hall == 0x03) --hallCounter;
+            break;
+
+        case 0x03:
+            /* PHASE1=-pwm, PHASE2=hiz, PHASE3=pwm */
+            EN1_GPIO_Port->BSRR = EN1_Pin | (EN2_Pin<<16) | EN3_Pin ;
+            /* CW rotation */
+            if (pwm >= 0)
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, pwm);
+                hallCurrentPhase = HALL_CURRENT_PHASE3;
+            }
+            /* CCW rotation */
+            else
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, -pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE1;
+            }
+            /* Verify previous HALL sensors status */
+            if      (hall == 0x02) ++hallCounter;
+            else if (hall == 0x01) --hallCounter;
+            break;
+
+        case 0x01:
+            /* PHASE1=hiz, PHASE2=-pwm, PHASE3=pwm */
+            EN1_GPIO_Port->BSRR = (EN1_Pin<<16) | EN2_Pin | EN3_Pin;
+            /* CW rotation */
+            if (pwm >= 0)
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, pwm);
+                hallCurrentPhase = HALL_CURRENT_PHASE3;
+            }
+            /* CCW rotation */
+            else
+            {
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, -pwm);
+                __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+                hallCurrentPhase = HALL_CURRENT_PHASE2;
+            }
+            /* Verify previous HALL sensors status */
+            if      (hall == 0x03) ++hallCounter;
+            else if (hall == 0x05) --hallCounter;
+            break;
+
+        default:
+            /* ERROR: forbitten combination */
+#if defined(HALCONFIG_DONTUSE_LED) 
+#else 
+        ledSet(LED2, 0);
+#endif        
+            EN1_GPIO_Port->BSRR = ((EN3_Pin|EN2_Pin|EN1_Pin)<<16);
+            __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+            __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+            __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+            pwm = 0;
+            break;
+    }
+#endif
+    
+    /* Update pwm status */
+    pwmStatus = pwm;
+
+    /* Update angle */
+    hallAngle = hallAngleTable[hallStatus];
+}
+
+
+/* Callback functions *************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief   Called by TIM1 when signal nMFAULT is activated by the motor driver.
+ * @param   htim    Pointer to TIM1 handler
+ * @return  void
+ */
+static void pwmMotorFault_cb(TIM_HandleTypeDef *htim)
+{
+    /* Check TIM1 already initialized */
+    if (TIM1 == htim->Instance)
+    {
+        /* Avoid re-entering in the isr */
+        __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_BREAK);
+        /* Disable the driver */
+        EN1_GPIO_Port->BSRR = ((EN3_Pin|EN2_Pin|EN1_Pin)<<16);
+        __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, 0);
+        __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, 0);
+        __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, 0);
+        /* Null output voltage */
+        pwmStatus = 0;
+        /* Advertise the fault */
+#if defined(HALCONFIG_DONTUSE_LED) 
+#else         
+        ledSet(LED2, 0);
+#endif        
+    }
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Called by TIM3 whenever it detects an edge over HALL1, HALL2 and HALL3 signals
+ * @param   htim    Pointer to TIM3 handler
+ * @return  void
+ */
+static void hallStatusChange_cb(TIM_HandleTypeDef *htim)
+{
+    /* Check TIM3 already initialized */
+    if (TIM3 == htim->Instance)
+    {
+        /* Generate the correct PWM configuration following the pwmStatus pattern */
+        hallSetPWM(pwmStatus);
+    }
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Called by DMA associated to ADC2 whenever a new set of phase currents is available
+ * @param   i1, i2, i3  Currents measured in PHASE1, PHASE2 and PHASE3 of the motor
+ * @return  void
+ */
+void pwmSetCurrents_cb(int16_t i1, int16_t i2, int16_t i3)
+{
+    switch (hallCurrentPhase)
+    {
+        case HALL_CURRENT_PHASE1:
+            hallCurrent = i1;
+            break;
+        case HALL_CURRENT_PHASE2:
+            hallCurrent = i2;
+            break;
+        case HALL_CURRENT_PHASE3:
+            hallCurrent = i3;
+            break;
+    }        
+}
+
+
+/* Exported functions *************************************************************************************************/
+
+/*******************************************************************************************************************//**
+ * @brief   Complete the CubeMx TIM1 configuration for the PWM subsystem
+ * @param   void
+ * @return  void
+ */
+HAL_StatusTypeDef pwmInit(void)
+{
+    /* Clear any preceeding fault condition */
+    pwmReset(ENABLE);
+    pwmSleep(DISABLE);
+    HAL_Delay(10);
+    pwmReset(DISABLE);
+    HAL_Delay(10);
+
+    if (0 == (MainConf.pwm.mode & PWM_CONF_MODE_MASK))
+    {
+        MainConf.pwm.mode = PWM_CONF_MODE_HALL;
+        MainConf.pwm.poles = 7;
+    }
+        
+    /* Register the required TIM1 callback functions */
+    HAL_TIM_RegisterCallback(&htim1, HAL_TIM_BREAK_CB_ID, pwmMotorFault_cb);
+    __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_BREAK);
+
+    /* Reset the PWM value */
+    hallSetPWM(pwmStatus);
+
+    /* Start TIM1 as 3-phase PWM generator */
+    if (HAL_OK != HAL_TIM_PWM_Start(&htim1, TIM_CHANNEL_1) ||
+        HAL_OK != HAL_TIM_PWM_Start(&htim1, TIM_CHANNEL_2) ||
+        HAL_OK != HAL_TIM_PWM_Start(&htim1, TIM_CHANNEL_3) ||
+    HAL_OK != HAL_TIM_Base_Start_IT(&htim1))
+    {
+        HAL_TIM_Base_Stop(&htim1);
+        HAL_TIM_PWM_Stop(&htim1, TIM_CHANNEL_1);
+        HAL_TIM_PWM_Stop(&htim1, TIM_CHANNEL_2);
+        HAL_TIM_PWM_Stop(&htim1, TIM_CHANNEL_3);
+        return HAL_ERROR;
+    }
+
+    /* All done */
+    return HAL_OK;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Complete the CubeMx TIM3 configuration for the PWM subsystem
+ * @param   void
+ * @return  void
+ */
+HAL_StatusTypeDef hallInit(void)
+{
+    /* Read value of HALL1, HALL2 and HALL3 signals in bits 2..0 */
+    hallStatus = (((HALL1_GPIO_Port->IDR & HALL1_Pin) >> MSB(HALL1_Pin)) << 2)
+               | (((HALL2_GPIO_Port->IDR & HALL2_Pin) >> MSB(HALL2_Pin)) << 1)
+               | (((HALL3_GPIO_Port->IDR & HALL3_Pin) >> MSB(HALL3_Pin)) << 0);
+
+    /* Init angle */
+    hallAngle = hallAngleTable[hallStatus];
+   
+    /* Start position counter */
+    hallCounter = 0;
+
+    /* Check TIM3 configuration and start it */
+    return ((TIM3 == htim3.Instance) &&
+            (HAL_OK == HAL_TIM_RegisterCallback(&htim3, HAL_TIM_IC_CAPTURE_CB_ID, hallStatusChange_cb)) &&
+            (HAL_OK == HAL_TIM_IC_Start_IT(&htim3, TIM_CHANNEL_1)) &&
+            (HAL_OK == HAL_TIM_IC_Start_IT(&htim3, TIM_CHANNEL_2)) &&
+            (HAL_OK == HAL_TIM_IC_Start_IT(&htim3, TIM_CHANNEL_3)) &&
+            (HAL_OK == HAL_TIM_Base_Start_IT(&htim3)))? HAL_OK : HAL_ERROR;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Read the position counter driven by the Hall sensors
+ * @param   void
+ * @return  int32_t     Current value of the position counter
+ */
+int32_t hallGetCounter(void)
+{
+    return hallCounter;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Set the position counter driven by the Hall sensors
+ * @param   count   New value of the position counter
+ * @return  void
+ */
+void hallSetCounter(int32_t count)
+{
+    hallCounter = count;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Read the angle measured by the Hall sensors
+ * @param   void
+ * @return  uint16_t    Current value of the angle
+ */
+uint16_t hallGetAngle(void)
+{
+    return hallAngle;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Read the last measured status of the Hall sensors
+ * @param   void
+ * @return  uint16_t    bit2 <- HALL_1, bit1 <- HALL_2, bit0 <- HALL_3
+ */
+uint16_t hallGetStatus(void)
+{
+    return hallStatus;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Read the phase current in hall 6-step mode
+ * @param   void
+ * @return  int16_t     Current in mA
+ */
+int16_t hallGetCurrent(void)
+{
+    return hallStatus;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Enter or Exit the SLEEP mode of the motor driver
+ * @param   enable  It can assume one of the following values:
+ *                  ENABLE      Motor driver in SLEEP mode: Power dissipation is limited but PWM is not allowed
+ *                  DISABLE     Motor driver in active mode: PWM generation is allowed.
+ * @return  void
+ */
+void pwmSleep(FunctionalState enable)
+{
+    /* Configure signal nMSLEEP as required */
+    HAL_GPIO_WritePin(nMSLEEP_GPIO_Port, nMSLEEP_Pin, (ENABLE==enable)?GPIO_PIN_RESET:GPIO_PIN_SET);
+}
+    
+
+/*******************************************************************************************************************//**
+ * @brief   Assert or release the nMRESET signal of the driver. It can be used to clear any fault condition
+ * @param   enable  It can assume one of the following values:
+ *                  ENABLE      Assert motor driver RESET
+ *                  DISABLE     Release motor driver RESET
+ * @return  void
+ */
+void pwmReset(FunctionalState enable)
+{
+    HAL_GPIO_WritePin(nMRESET_GPIO_Port, nMRESET_Pin, (ENABLE==enable)?GPIO_PIN_RESET:GPIO_PIN_SET);
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  Function result
+ */
+HAL_StatusTypeDef pwmResetFault(void)
+{
+    pwmSet(0, 0, 0);
+    pwmSleep(ENABLE); HAL_Delay(10);
+    pwmSleep(DISABLE);
+    if (GPIO_PIN_SET == HAL_GPIO_ReadPin(nMFAULT_GPIO_Port, nMFAULT_Pin))
+    {
+#ifdef USE_ENCODER_SENSORS
+        pwmPhaseEnable(PWM_PHASE_ALL);
+#endif
+        __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_BREAK);
+        __HAL_TIM_CLEAR_IT(&htim1, TIM_IT_BREAK);
+        __HAL_TIM_MOE_ENABLE(&htim1); HAL_Delay(10);
+        __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_BREAK);
+#if defined(HALCONFIG_DONTUSE_LED) 
+#else        
+        ledSet(0, LED2);
+#endif        
+        return HAL_OK;
+    }
+#if defined(HALCONFIG_DONTUSE_LED) 
+#else     
+    ledSet(LED2, 0);
+#endif    
+    return HAL_ERROR;
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  void
+ */
+void pwmSet(uint16_t u, uint16_t v, uint16_t w)
+{
+    /* Saturate arguments */
+    if (u > (uint16_t)MAX_PWM) u = MAX_PWM;
+    if (v > (uint16_t)MAX_PWM) v = MAX_PWM;
+    if (w > (uint16_t)MAX_PWM) w = MAX_PWM;
+    /* Update PWM generators */
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, u);
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, v);
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, w);
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Enable the PWM driver outputs
+ * @param   mask    Any combination of the following values
+ *                  PWM_PHASE_U
+ *                  PWM_PHASE_V
+ *                  PWM_PHASE_W
+ * @return  void
+ */
+void pwmPhaseEnable(uint16_t mask)
+{
+    EN1_GPIO_Port->BSRR = ((uint32_t)mask & PWM_PHASE_ALL);
+}
+
+
+/*******************************************************************************************************************//**
+ * @brief   Disable the PWM driver outputs
+ * @param   mask    Any combination of the following values
+ *                  PWM_PHASE_U
+ *                  PWM_PHASE_V
+ *                  PWM_PHASE_W
+ * @return  void
+ */
+void pwmPhaseDisable(uint16_t mask)
+{
+    EN1_GPIO_Port->BSRR = ((uint32_t)mask & PWM_PHASE_ALL) << 16u;
+}
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  Function result
+ */
+HAL_StatusTypeDef pwmSetValue(int32_t pwm)
+{
+    if ((pwm >= -(int32_t)MAX_PWM) && (pwm <= (int32_t)MAX_PWM))
+    {
+#ifdef USE_HALL_SENSORS
+        __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_CC1|TIM_IT_CC2|TIM_IT_CC3);
+        hallSetPWM(pwm);
+        __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_CC1|TIM_IT_CC2|TIM_IT_CC3);
+#endif
+        return HAL_OK;
+    }
+    return HAL_ERROR;
+}
+
+#if defined(HALCONFIG_DONTUSE_TESTS)
+#else
+
+/*******************************************************************************************************************//**
+ * @brief   
+ * @param   
+ * @return  
+ */
+void pwmTest(void)
+{
+    char ch;
+    char coBuffer[80];
+    const char *curs;
+    int32_t pwm;
+
+    coprintf("Motor Test\n");
+    if (GPIO_PIN_RESET == HAL_GPIO_ReadPin(nMFAULT_GPIO_Port, nMFAULT_Pin))
+    {
+        ledSet(LED2, 0);
+        coprintf("ATTENTION: FAULT indication active\n");
+    }
+    else ledSet(0, LED2);
+    for (;;)
+    {
+		coprintf("F - Clear motor FAULT indication\n"
+                 "H - Read HALL and ENCODER status\n"
+                 "P - Set motor PWM\n"
+                 "R - Reset Hall sensor counter\n"
+                 "ESC : Exit test\n"
+                 "? "); HAL_Delay(250);
+        if (isgraph(ch = coRxChar())) coPutChar(ch);
+        coPutChar('\n');
+
+		switch (toupper(ch))
+        {
+            case 'F':
+                if (HAL_OK != pwmResetFault())
+                {
+                    coprintf("ERROR: Cannot clear FAULT indication\n");
+                }
+                break;
+
+            case 'H':
+                while (1)
+                {
+                    coprintf("\rENCODER = %5u, HALL = %+11d, CURRENT=%+5dmA ", 
+                                encoderGetCounter(), hallGetCounter(), analogConvertCurrent(hallCurrent));
+                    HAL_Delay(100);
+                    if (coRxReady())
+                    {
+                        ch = coRxChar();
+                        if (('r'==ch)||('R'==ch)) hallSetCounter(0);
+                        else if ('\x1B'==ch) break;
+                    }
+                }
+                coprintf("\n");
+                break;
+
+            case 'P':
+                coprintf("(%d)? ", pwmStatus);
+                coEditString(coBuffer, sizeof(coBuffer));
+                coprintf("\n");
+                curs = &(coBuffer[0]);
+                if ('\0' != skipblank(&curs))
+                {
+                    if (!atosl(&curs, &pwm) || (HAL_OK != pwmSetValue(pwm)))
+                    {
+                        coprintf("ERROR: %s\n", coBuffer); 
+                    }
+                }
+            break;
+
+            case 'R':
+                hallSetCounter(0);
+                break;
+
+            case '\x1B':
+                coprintf("Exit test\n");
+                return;
+
+            default:
+                coprintf("ERROR: %c\n", ch);
+                break;
+        }
+    }
+}
+
+#endif // HALCONFIG_DONTUSE_TESTS
+
+/* END OF FILE ********************************************************************************************************/

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/pwm.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/motorhal/pwm.h
@@ -1,0 +1,87 @@
+/*******************************************************************************************************************//**
+ * @file    pwm.h
+ * @author  G.Zini
+ * @version 1.0
+ * @date    2021 January, 19
+ * @brief   PWM signals management
+ **********************************************************************************************************************/
+
+/* Define to prevent recursive inclusion */
+#ifndef __PWM_H
+#define __PWM_H
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
+/* Includes ----------------------------------------------------------------------------------------------------------*/
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+#if defined(USE_STM32HAL)
+#include "stm32hal.h"
+#else 
+#include <stdarg.h>        
+#include "analog.h"
+#include "main.h"
+#include "stm32g4xx.h"
+#endif
+
+/* Exported macro ----------------------------------------------------------------------------------------------------*/
+
+#define MAX_PWM		(16383U)
+
+#define PWM_CONF_MODE_HALL      (0x0001UL)
+#define PWM_CONF_MODE_ENCODER   (0x0002UL)
+#define PWM_CONF_MODE_MASK      (PWM_CONF_MODE_HALL|PWM_CONF_MODE_ENCODER)
+
+#define PWM_PHASE_U             (EN1_Pin)
+#define PWM_PHASE_V             (EN2_Pin)
+#define PWM_PHASE_W             (EN3_Pin)
+#define PWM_PHASE_ALL           (EN1_Pin|EN2_Pin|EN3_Pin)
+
+
+/* Exported typedefs -------------------------------------------------------------------------------------------------*/
+
+typedef struct
+{
+    uint32_t    mode;
+    uint32_t    poles;
+} pwmConfTypeDef;
+
+
+/* Exported variables ------------------------------------------------------------------------------------------------*/
+
+
+
+/* Exported functions prototypes -------------------------------------------------------------------------------------*/
+
+extern HAL_StatusTypeDef hallInit(void);
+extern int32_t hallGetCounter(void);
+extern void hallSetCounter(int32_t count);
+extern uint16_t hallGetAngle(void);
+extern uint16_t hallGetStatus(void);
+
+extern HAL_StatusTypeDef pwmInit(void);
+extern void pwmSleep(FunctionalState enable);
+extern void pwmReset(FunctionalState enable);
+extern HAL_StatusTypeDef pwmResetFault(void);
+
+extern void pwmSet(uint16_t u, uint16_t v, uint16_t w);
+extern void pwmPhaseEnable(uint16_t mask);
+extern void pwmPhaseDisable(uint16_t mask);
+
+extern void pwmSetCurrents_cb(int16_t i1, int16_t i2, int16_t i3);
+extern HAL_StatusTypeDef pwmSetValue(int32_t pwm); /* DEPRECATED */
+
+extern void pwmTest(void);
+
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif /* __cplusplus */
+#endif /* __PWM_H */
+/* END OF FILE ********************************************************************************************************/

--- a/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc.cpp
@@ -628,7 +628,59 @@ namespace embot { namespace hw { namespace tlv493d {
 
 // - support map: end of embot::hw::tlv493d
 
+// - support map: begin of embot::hw::motor
 
+#include "embot_hw_motor_bsp.h"
+
+#if !defined(EMBOT_ENABLE_hw_motor)
+
+namespace embot { namespace hw { namespace motor {
+    
+    constexpr BSP thebsp { };
+    void BSP::init(embot::hw::MOTOR h) const {}    
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }
+    
+}}}
+
+#else
+
+namespace embot { namespace hw { namespace motor {
+           
+#if defined(STM32HAL_BOARD_AMCBLDC)
+    
+    
+    constexpr PROP propM1  { 0 };
+    
+    constexpr BSP thebsp {     
+
+        // maskofsupported
+        mask::pos2mask<uint32_t>(MOTOR::one),        
+        // properties
+        {{
+            &propM1
+        }}
+  
+    };
+    
+    void BSP::init(embot::hw::MOTOR h) const {}
+        
+    #else
+        #error embot::hw::motor::thebsp must be defined    
+    #endif
+    
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }
+              
+}}} // namespace embot { namespace hw { namespace motor {
+
+#endif // motor
+
+// - support map: end of embot::hw::motor
 
 
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h
@@ -25,6 +25,7 @@
     #define EMBOT_ENABLE_hw_flash_SINGLEBANK
     #define EMBOT_ENABLE_hw_led
     #define EMBOT_ENABLE_hw_can
+    #define EMBOT_ENABLE_hw_motor
 
     //#define EMBOT_ENABLE_hw_i2c    
     //#define EMBOT_ENABLE_hw_pwm ?

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_scope.h
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_scope.h
@@ -30,7 +30,26 @@ namespace embot { namespace app { namespace scope {
         virtual ~Signal() {};    // cannot delete from interface but only from derived object
     };
     
-    enum class SignalType { Print, EViewer, GPIO };
+    enum class SignalType { Dummy, Print, EViewer, GPIO };
+
+    // this implementation does nothing
+    class SignalDummy: public Signal
+    {
+    public:
+               
+        struct Config
+        {  
+            uint32_t nothing {0};
+            Config() = default;
+            bool isvalid() const { return true; }
+        };
+                    
+        SignalDummy(const Config &cfg) {};
+        virtual ~SignalDummy() {};
+    
+        virtual void on() override {};
+        virtual void off() override {};        
+    };  
     
     // this implementation prints out
     class SignalPrint: public Signal

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -1,0 +1,292 @@
+
+/*
+ * Copyright (C) 2021 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_motor.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_bsp_config.h"
+#include "embot_hw_motor_bsp.h"
+
+#include <cstring>
+#include <vector>
+
+#include "embot_core_binary.h"
+#include "embot_hw_sys.h"
+
+#if defined(USE_STM32HAL)
+    #include "stm32hal.h"
+#else
+    #warning this implementation is only for stm32hal
+#endif
+
+
+#if defined(EMBOT_ENABLE_hw_motor_emulatedMODE)
+
+#warning EMBOT_ENABLE_hw_motor_emulatedMODE is defined, the hw driver of the motor will ... 
+
+//#include "embot_os_theCallbackManager.h"
+//#include "embot_os_Timer.h"
+
+namespace embot { namespace hw { namespace motor {
+
+// we place in here what we need to simulate the motor
+
+}}}
+
+#endif
+
+using namespace embot::hw;
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+std::string embot::hw::motor::to_string(embot::hw::MOTOR id)
+{
+    constexpr std::array<const char *, embot::core::tointegral(embot::hw::MOTOR::maxnumberof)> MOTOR_map =
+    { 
+        "MOTOR::one", "MOTOR::two", "MOTOR::three", "MOTOR::four"
+    };
+    uint8_t pos = embot::core::tointegral(id);
+    return (pos < MOTOR_map.size()) ? MOTOR_map[pos] : "MOTOR::none";    
+}
+
+
+#if !defined(EMBOT_ENABLE_hw_motor)
+
+namespace embot { namespace hw { namespace motor {
+
+    bool supported(MOTOR h) { return false; }
+    bool initialised(MOTOR h) { return false; }
+    result_t init(MOTOR h, const Config &config) { return resNOK; }    
+
+}}} // namespace embot { namespace hw { namespace MOTOR {
+
+
+#else
+
+namespace embot { namespace hw { namespace motor {
+              
+    // initialised mask       
+    static std::uint32_t initialisedmask = 0;
+    
+    bool supported(MOTOR h)
+    {
+        return embot::hw::motor::getBSP().supported(h);
+    }
+    
+    bool initialised(MOTOR h)
+    {
+        return embot::core::binary::bit::check(initialisedmask, embot::core::tointegral(h));
+    }    
+    
+         
+
+    struct TBDef
+    {
+        static constexpr std::uint8_t rxdatasize = 8;
+        MOTOR id;
+        volatile bool done;
+        volatile bool ongoing;
+        volatile Position position;
+        embot::core::Callback userdefCBK;
+        void init(MOTOR _id) { clear(); id = _id; }        
+        void clear() { done = false; ongoing = false; position = 0; userdefCBK.clear(); }         
+    };
+    
+    
+    struct PrivateData
+    {  
+        std::array<Config, embot::core::tointegral(MOTOR::maxnumberof)> config;        
+        std::array<TBDef, embot::core::tointegral(MOTOR::maxnumberof)> tbdef;
+        PrivateData() { }
+    };
+    
+
+    // this device works with no register addressing.
+    // static const embot::hw::i2c::Reg registerToRead {embot::hw::i2c::Reg::addrNONE, embot::hw::i2c::Reg::Size::eightbits};
+    
+    static PrivateData s_privatedata;
+    
+    result_t s_hw_init(MOTOR h);
+    Position s_hw_getencoder(MOTOR h);
+    Position s_hw_gethallcounter(MOTOR h);    
+    result_t s_hw_setpwm(MOTOR h, Pwm v);
+              
+    result_t init(MOTOR h, const Config &config)
+    {
+        if(false == supported(h))
+        {
+            return resNOK;
+        }
+        
+        if(true == initialised(h))
+        {
+            return resOK;
+        }
+        
+        
+        std::uint8_t index = embot::core::tointegral(h);
+               
+        
+#if !defined(EMBOT_ENABLE_hw_motor_emulatedMODE)        
+        // init peripheral
+        embot::hw::motor::getBSP().init(h);                             
+        // else
+#endif 
+        
+        // load config etc
+        s_privatedata.config[index] = config;
+
+#if !defined(EMBOT_ENABLE_hw_motor_emulatedMODE)          
+        // proper init
+        if(resOK != s_hw_init(h))
+        {
+            return resNOK;
+        }            
+#else
+        // we emulate the ...
+//        emulatedMODE_timers4callback[embot::core::tointegral(h)] = new embot::os::Timer;  
+#endif
+
+        embot::core::binary::bit::set(initialisedmask, embot::core::tointegral(h));                
+        return resOK;
+    }
+
+    
+
+    
+    result_t getencoder(MOTOR h, Position &position)
+    {
+        if(false == initialised(h))
+        {
+            return resNOK;
+        } 
+        
+        //std::uint8_t index = embot::core::tointegral(h);
+        //position = s_privatedata.tbdef[index].position;
+        position = s_hw_getencoder(h);
+        
+        return resOK;               
+    }
+    
+    
+    result_t gethallcounter(MOTOR h, Position &position)
+    {
+        if(false == initialised(h))
+        {
+            return resNOK;
+        } 
+        
+        //std::uint8_t index = embot::core::tointegral(h);
+        //position = s_privatedata.tbdef[index].position;
+        position = s_hw_gethallcounter(h);
+        
+        return resOK;               
+    }
+    
+    result_t setpwm(MOTOR h, Pwm v)
+    {
+        return s_hw_setpwm(h, v);
+    }
+    
+// in here is the part for low level hw of the amcbldc
+    
+#if !defined(STM32HAL_BOARD_AMCBLDC)
+    result_t s_hw_init(MOTOR h)
+    {
+        return resNOK; 
+    }
+
+#else
+    
+    #include "encoder.h"
+    #include "pwm.h"
+    #include "analog.h"
+    #include "motorhal_config.h"
+    
+    result_t s_hw_init(MOTOR h)
+    {
+        // step 1: what cube mx does
+        MX_ADC1_Init();
+        MX_ADC2_Init();
+        
+        MX_TIM1_Init();
+        MX_TIM3_Init();
+        MX_TIM2_Init();
+        MX_CORDIC_Init();
+        MX_FMAC_Init();
+        MX_CRC_Init();   
+
+        // step 2: what giorgio zini does
+        memset(&MainConf, 0, sizeof(MainConf));
+        
+        analogInit();
+        encoderInit();
+        pwmInit();
+        hallInit();
+
+        HAL_GPIO_WritePin(VAUXEN_GPIO_Port, VAUXEN_Pin, GPIO_PIN_SET);
+        HAL_Delay(10); 
+
+
+        // ok, we are now ready to use the driver
+        // or not. we should test it
+        
+        return resOK; 
+    }
+    
+    Position s_hw_getencoder(MOTOR h)
+    {
+        return encoderGetCounter();
+    }
+
+    Position s_hw_gethallcounter(MOTOR h)
+    {
+        return hallGetCounter();
+    }
+    
+    result_t s_hw_setpwm(MOTOR h, Pwm v)
+    {        
+        HAL_StatusTypeDef r = pwmSetValue(v);
+        return (HAL_OK == r) ? resOK : resNOK;
+    }
+    
+#endif    
+    
+    
+ 
+}}} // namespace embot { namespace hw { namespace motor {
+
+
+
+
+
+
+#endif //defined(EMBOT_MOTOR_ENABLED)
+
+
+    
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
@@ -1,0 +1,57 @@
+
+
+/*
+ * Copyright (C) 2021 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_HW_MOTOR_H_
+#define __EMBOT_HW_MOTOR_H_
+
+#include "embot_core.h"
+#include "embot_hw.h"
+#include "embot_hw_types.h"
+
+
+namespace embot { namespace hw { namespace motor {
+           
+    struct Config
+    { 
+        uint32_t tbd {0};        
+        constexpr Config() = default;         
+        constexpr Config(uint32_t t) : tbd(t) {} 
+        constexpr bool isvalid() const { return true; }
+    };
+       
+    
+    std::string to_string(embot::hw::MOTOR id);
+            
+    bool supported(embot::hw::MOTOR h);    
+    bool initialised(embot::hw::MOTOR h);    
+    result_t init(embot::hw::MOTOR h, const Config &config);
+        
+ 
+    // whatever else we shall need
+    
+    // Position and Pwm are to be defined yet.
+    using Position = std::int32_t;
+    using Pwm = std::int32_t;
+    
+    result_t getencoder(embot::hw::MOTOR h, Position &position);
+    result_t gethallcounter(embot::hw::MOTOR h, Position &position);
+    
+    result_t setpwm(MOTOR h, Pwm v);
+    
+}}} // namespace embot { namespace hw { namespace motor {
+    
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bsp.h
@@ -1,0 +1,50 @@
+
+/*
+ * Copyright (C) 2021 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_HW_MOTOR_BSP_H_
+#define __EMBOT_HW_MOTOR_BSP_H_
+
+
+#include "embot_core.h"
+#include "embot_hw_types.h"
+#include "embot_hw_bsp.h"
+#include "embot_hw_motor.h"
+
+namespace embot { namespace hw { namespace motor {
+    
+    struct PROP
+    { 
+        uint32_t tbd {0};
+    };
+    
+    struct BSP : public embot::hw::bsp::SUPP
+    {
+        constexpr static std::uint8_t maxnumberof = embot::core::tointegral(embot::hw::MOTOR::maxnumberof);
+        constexpr BSP(std::uint32_t msk, std::array<const PROP*, maxnumberof> pro) : SUPP(msk), properties(pro) {} 
+        constexpr BSP() : SUPP(0), properties({0}) {}
+            
+        std::array<const PROP*, maxnumberof> properties;    
+        constexpr const PROP * getPROP(embot::hw::MOTOR h) const { return supported(h) ? properties[embot::core::tointegral(h)] : nullptr; }
+        void init(embot::hw::MOTOR h) const;
+    };
+    
+    const BSP& getBSP();
+                                     
+        
+}}} // namespace embot { namespace hw { namespace motor { 
+
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_types.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_types.cpp
@@ -141,6 +141,12 @@ static_assert(embot::core::tointegral(embot::hw::AD7147::maxnumberof) < 8*sizeof
 static_assert(embot::core::tointegral(embot::hw::AD7147::maxnumberof) < embot::core::tointegral(embot::hw::AD7147::none), "AD7147::maxnumberof must be higher that AD7147::none, so that we can optimise code");
 
 
+// - check of values for embot::hw::motor
+
+static_assert(embot::core::tointegral(embot::hw::MOTOR::none) < 8*sizeof(embot::hw::bsp::SUPP::supportedmask), "MOTOR::none must be less than 32 to be able to address a std::uint32_t mask");
+static_assert(embot::core::tointegral(embot::hw::MOTOR::maxnumberof) < 8*sizeof(embot::hw::bsp::SUPP::supportedmask), "MOTOR::maxnumberof must be less than 32 to be able to address a std::uint32_t mask");
+static_assert(embot::core::tointegral(embot::hw::MOTOR::maxnumberof) < embot::core::tointegral(embot::hw::MOTOR::none), "MOTOR::maxnumberof must be higher that MOTOR::none, so that we can optimise code");
+
 
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_types.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_types.h
@@ -67,6 +67,8 @@ namespace embot { namespace hw {
     enum class ADS122C04 : std::uint8_t { one = 0, none = 31, maxnumberof = 1 };
     
     enum class AD7147 : std::uint8_t { one = 0, two = 1, none = 31, maxnumberof = 2 };
+    
+    enum class MOTOR : std::uint8_t { one = 0, two = 1, three = 2, four = 3, none = 31, maxnumberof = 4 };
   
   
     // definition of more complex data structures

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.g4.uvoptx
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.g4.uvoptx
@@ -2254,7 +2254,7 @@
 
   <Group>
     <GroupName>board-pmc-v120</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/amcbldc/v120/inc/adc.h
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/amcbldc/v120/inc/adc.h
@@ -29,8 +29,11 @@ extern "C" {
 
 /* USER CODE BEGIN Includes */
 
+
 /* USER CODE END Includes */
 
+extern DMA_HandleTypeDef hdma_adc1;
+extern DMA_HandleTypeDef hdma_adc2;
 extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc2;
 


### PR DESCRIPTION
This PR adds low level motor control for the board `amcbldc`.

The control is done through the APIs of `embot::hw::motor` and so far offers only:
- application of a target PWM w/ a 6-steps control.
- retrieval of hall counter and of incremental encoder value.

The lower level code is targeted for the board amcbld and so far manages only a specific motor.
It used the HAL drivers provided by STMicroelectronics on top of which we have used some further specialization code provided by @GiorgioZini which was properly adapted to run in our applications.

The code was tested inside a specific application which moves the motor through a fixed cycle: counterwise, stop, anticonterwise, stop.

Here is a video of the test.

https://user-images.githubusercontent.com/7148284/125054714-cc32b400-e0a6-11eb-84d4-66d1a5ee64ea.mov


**Video**.  The motor spins.

The code added / changed in the PR does not interfere w/ the code used by other boards and can be safely merged.
  