### PR TITLE
Board amcbldc: control of a motor by CAN messages

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvoptx
@@ -818,7 +818,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1026,7 +1026,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1162,7 +1162,7 @@
 
   <Group>
     <GroupName>embot::prot::can</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/proj/amcbldc-application01.uvprojx
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc-main.cpp
@@ -100,7 +100,7 @@ int main(void)
 
 
 #include "embot_hw_sys.h"
-
+#include "embot_hw_motor.h"
 
 // maybe move API and implementation of the ctrl thread in dedicated files
 void s_start_CTRL_thread();
@@ -155,6 +155,8 @@ void mySYS::userdefInit_Extra(embot::os::EventThread* evthr, void *initparam) co
     embot::app::application::theCANparserMC::Config configparsermc { &themcagent };
     canparsermc.initialise(configparsermc);  
 
+    // init motor
+    embot::hw::motor::init(embot::hw::MOTOR::one, {});
 
     // set priority of the can thread
     evthr->setPriority(embot::os::Priority::high40);

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/amcbldc_codetotest.cpp
@@ -23,7 +23,7 @@
 #include <array>
 
 //#define TEST_FOC
-#define TEST_MOTOR
+//#define TEST_MOTOR
 
 #if defined(TEST_FOC)
 // foc code
@@ -109,18 +109,18 @@ namespace amcbldc { namespace codetotest {
 #endif        
         
 #else        
-        static constexpr std::array<embot::core::relTime, 5> usec = 
-        {   
-            100*embot::core::time1microsec, 
-            200*embot::core::time1microsec, 
-            300*embot::core::time1microsec, 
-            400*embot::core::time1microsec, 
-            500*embot::core::time1microsec
-        }; 
-        static uint8_t index {0};
-        
-        index = (index+1) % usec.size();
-        embot::hw::sys::delay(usec[index]);        
+//        static constexpr std::array<embot::core::relTime, 5> usec = 
+//        {   
+//            100*embot::core::time1microsec, 
+//            200*embot::core::time1microsec, 
+//            300*embot::core::time1microsec, 
+//            400*embot::core::time1microsec, 
+//            500*embot::core::time1microsec
+//        }; 
+//        static uint8_t index {0};
+//        
+//        index = (index+1) % usec.size();
+//        embot::hw::sys::delay(usec[index]);        
 #endif        
     }
     

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/embot_app_application_theMCagent.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application01/src/embot_app_application_theMCagent.h
@@ -33,7 +33,9 @@ namespace embot { namespace app { namespace application {
         bool initialise(const Config &config);   
                 
         // interface to CANagentMC
-        virtual bool get(const embot::prot::can::motor::periodic::Message_EMSTO2FOC_DESIRED_CURRENT::Info &info);
+        virtual bool get(const embot::prot::can::motor::periodic::Message_EMSTO2FOC_DESIRED_CURRENT::Info &info);        
+        virtual bool get(const embot::prot::can::motor::polling::Message_SET_CONTROL_MODE::Info &info);
+        virtual bool get(const embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::Info &info, embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::ReplyInfo &replyinfo);
         
     private:
         theMCagent(); 

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theCANparserMC.h
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theCANparserMC.h
@@ -24,7 +24,9 @@ namespace embot { namespace app { namespace application {
     {
     public:
         // interface
-        virtual bool get(const embot::prot::can::motor::periodic::Message_EMSTO2FOC_DESIRED_CURRENT::Info &info) = 0;        
+        virtual bool get(const embot::prot::can::motor::periodic::Message_EMSTO2FOC_DESIRED_CURRENT::Info &info) = 0;  
+        virtual bool get(const embot::prot::can::motor::polling::Message_SET_CONTROL_MODE::Info &info) = 0;      
+        virtual bool get(const embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::Info &info, embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::ReplyInfo &replyinfo) = 0;
        
     public:
         virtual ~CANagentMC() {};         

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePZMdriver.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePZMdriver.cpp
@@ -71,7 +71,8 @@ struct embot::app::application::thePZMdriver::Impl
     
     std::array<piezoMotorState_t, numberofmotors> _PZMstate {STATE_NOT_INIT, STATE_NOT_INIT, STATE_NOT_INIT};
 
-
+    embot::prot::can::motor::polling::ControlMode cm {embot::prot::can::motor::polling::ControlMode::Idle}; 
+    
     embot::os::Timer *timerDISABLEsetpoint {nullptr};    
 
        
@@ -301,7 +302,28 @@ bool embot::app::application::thePZMdriver::get(const embot::prot::can::motor::p
     return true;    
 }
 
+bool embot::app::application::thePZMdriver::get(const embot::prot::can::motor::polling::Message_SET_CONTROL_MODE::Info &info)
+{   
+//    embot::core::print("received SET_CONTROL_MODE[]: " + embot::prot::can::motor::polling::tostring(info.controlmode) + " for motindex " + embot::prot::can::motor::polling::tostring(info.motorindex));
 
+    pImpl->cm = info.controlmode;
+
+// we dont support it yet.    
+//    if(embot::prot::can::motor::polling::ControlMode::Idle == pImpl->cm)
+//    {
+//        pImpl->pwm = 0;
+//        embot::hw::motor::setpwm(embot::hw::MOTOR::one, 0);
+//    }
+    return true;    
+}
+
+bool embot::app::application::thePZMdriver::get(const embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::Info &info, embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::ReplyInfo &replyinfo)
+{    
+//    embot::core::print("received GET_CONTROL_MODE[]: for motindex " + embot::prot::can::motor::polling::tostring(info.motorindex));
+    replyinfo.motorindex = info.motorindex;
+    replyinfo.controlmode =  pImpl->cm;
+    return true;    
+}
 
 
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePZMdriver.h
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePZMdriver.h
@@ -61,6 +61,8 @@ namespace embot { namespace app { namespace application {
         
         // interface to CANagentMC
         virtual bool get(const embot::prot::can::motor::periodic::Message_EMSTO2FOC_DESIRED_CURRENT::Info &info);
+        virtual bool get(const embot::prot::can::motor::polling::Message_SET_CONTROL_MODE::Info &info);
+        virtual bool get(const embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::Info &info, embot::prot::can::motor::polling::Message_GET_CONTROL_MODE::ReplyInfo &replyinfo);
         
     private:
         thePZMdriver(); 

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_polling.h
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_polling.h
@@ -32,9 +32,11 @@
 namespace embot { namespace prot { namespace can { namespace motor { namespace polling {
     
     // the supported commands    
-    enum class CMD { 
+    enum class CMD : uint8_t { 
         none = 0xfe, 
      
+        GET_CONTROL_MODE = 0x07,
+        SET_CONTROL_MODE = 0x09,
         SET_BOARD_ID = 50, GET_FIRMWARE_VERSION = 91 
     };
     
@@ -57,7 +59,22 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
     
 }}}}} // namespace embot { namespace prot { namespace can { namespace motor { namespace polling {
 
-           
+namespace embot { namespace prot { namespace can { namespace motor { namespace polling {
+   
+    // some required types
+
+    enum class MotIndex : uint8_t { one = 0, two = 1, none = 254 };
+    MotIndex toMotIndex(uint8_t v);
+    uint8_t convert(MotIndex mo);  
+    std::string tostring(MotIndex mo);    
+    
+    enum class ControlMode : uint8_t { Idle = 0x00, Current = 0x06, SpeedVoltage = 0x0A, OpenLoop = 0x50, none = 254 };         
+    ControlMode toControlMode(uint8_t v);
+    uint8_t convert(ControlMode cm); 
+    std::string tostring(ControlMode cm);      
+
+}}}}} // namespace embot { namespace prot { namespace can { namespace motor { namespace polling {
+          
 
 namespace embot { namespace prot { namespace can { namespace motor { namespace polling {
             
@@ -80,6 +97,53 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
             embot::prot::can::shared::Message_SET_ID(Clas::pollingMotorControl, static_cast<std::uint8_t>(CMD::SET_BOARD_ID)) {}
        
     }; 
+    
+    
+    class Message_SET_CONTROL_MODE : public Message
+    {
+        public:
+                                   
+        struct Info
+        { 
+            MotIndex motorindex {MotIndex::one};
+            ControlMode controlmode {ControlMode::Idle};            
+            Info() = default;
+        };
+        
+        Info info {};
+        
+        Message_SET_CONTROL_MODE() = default;
+            
+        bool load(const embot::prot::can::Frame &inframe);
+            
+        bool reply();   // none        
+    };
+    
+    class Message_GET_CONTROL_MODE : public Message
+    {
+        public:
+                                    
+        struct Info
+        { 
+            MotIndex motorindex {MotIndex::one};             
+            Info() = default;
+        };
+        
+        struct ReplyInfo
+        {
+            MotIndex motorindex {MotIndex::one};
+            ControlMode controlmode {ControlMode::Idle};            
+            ReplyInfo() = default;
+        };        
+        
+        Info info {};
+        
+        Message_GET_CONTROL_MODE() = default;
+            
+        bool load(const embot::prot::can::Frame &inframe);
+            
+        bool reply(embot::prot::can::Frame &outframe, const std::uint8_t sender, const ReplyInfo &replyinfo);            
+    };      
 
     
 }}}}} // namespace embot { namespace prot { namespace can { namespace motor { namespace polling {


### PR DESCRIPTION
This PR introduces support for CAN protocol of messages `SET_CONTROL_MODE` and `GET_CONTROL_MODE`.

In application01 of the amcbldc the previous messages and also `EMSTO2FOC_DESIRED_CURRENT` produce the movement of a motor using what we added in a previous PR: https://github.com/robotology/icub-firmware/pull/194

In here is a video which demonstrates the movement.


https://user-images.githubusercontent.com/7148284/125445927-9ade3876-8ea6-4c64-bbef-7e824fed0f16.mov

**Video**. The `amcbldc `board is controlled over CAN w/ messages such as `SET_CONTROL_MODE `and `EMSTO2FOC_DESIRED_CURRENT`.

This PR does not interfere w/ code of other boards and can be safely merged.