### PR TITLE
amcbldc: mild cleaning of application02

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application02/proj/amcbldc-application02.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application02/proj/amcbldc-application02.uvoptx
@@ -193,7 +193,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>1</periodic>
-        <aLwin>0</aLwin>
+        <aLwin>1</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -1036,7 +1036,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application02/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application02/src/amcbldc-main.cpp
@@ -206,7 +206,6 @@ void s_shared_start()
 }
 
 #include "embot_hw_sys.h"
-#include "embot_hw_motor.h"
 
 embot::os::EventThread *t_COMM {nullptr};
 embot::os::EventThread *t_CTRL {nullptr};
@@ -415,7 +414,7 @@ void tCTRL_startup(embot::os::Thread *t, void *param)
     
     outctrlframes.reserve(5);
 
-    // init agent of mc
+    // init agent of mc. it also init motor
     embot::app::application::theMCagent2 &themcagent2 = embot::app::application::theMCagent2::getInstance();
     themcagent2.initialise({});
 
@@ -424,8 +423,6 @@ void tCTRL_startup(embot::os::Thread *t, void *param)
     embot::app::application::theCANparserMC::Config configparsermc { &themcagent2 };
     canparsermc.initialise(configparsermc);  
 
-    // init motor
-    embot::hw::motor::init(embot::hw::MOTOR::one, {});
         
 //    embot::core::print("tCTRL_startup(): starts a timer which sends a tick event every " + embot::core::TimeFormatter(tCTRL_tickperiod).to_string());
     
@@ -493,17 +490,17 @@ void tCTRL_onevent(embot::os::Thread *t, embot::os::EventMask eventmask, void *p
 }
 
 
-// interface for the model-based-designed control
+// interface for the model-based-designed control which is inside embot::app::application::theMCagent2
 
 // called just once at startup
 void mbd_mc_init()
 {     
-    // fill it w/ mbd code
+    embot::app::application::theMCagent2::getInstance().initialise({});
 }
 
 // called in asynch mode when a can frame arrives. 
 // it must:
-// - processe the frame, 
+// - process the frame, 
 // - do actions, 
 // - fill in the reply can frames
 void mbd_mc_canparse(const embot::prot::can::Frame &rxframe,
@@ -511,7 +508,6 @@ void mbd_mc_canparse(const embot::prot::can::Frame &rxframe,
 {
     // now we use the c++ parser / agent
     embot::app::application::theCANparserMC::getInstance().process(rxframe, outframes);
-    // fill it w/ mbd code
 }
 
 // called every 1 ms and always after mbd_mc_canparse(). 


### PR DESCRIPTION
As per title.

The cleaning is about moving all high level management of the motor inside the object `theMCagent2`: all calls to `embot::hw::motor` and soon also `MBD generated code`


The demo has been tested worked fine.