### PR TITLE
HardFault_Handler() collects full MPU context

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/abslayer/ipal_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/abslayer/ipal_cfg.c
@@ -179,6 +179,7 @@ static void s_ipal_cfg_on_fatal_error(ipal_fatalerror_t errorcode, const char * 
     des->handlertype = fatalerror_handler_ipal;
     des->handlererrorcode = errorcode;
     des->param = NULL;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else
     #warning DONTUSE_EOtheFatalError is defined, are you sure?

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/abslayer/osal_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/abslayer/osal_cfg.c
@@ -119,6 +119,7 @@ static void s_osal_cfg_on_fatal_error(void* task, osal_fatalerror_t errorcode, c
     des->handlertype = fatalerror_handler_osal;
     des->handlererrorcode = errorcode;
     des->param = task;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else 
     #warning DONTUSE_EOtheFatalError is defined, are you sure?

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          42
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          43
 
 //  </h>version
 
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2021
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          37
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
@@ -71,6 +71,7 @@ static void s_save_hardfault(fatal_error_descriptor_t *des);
 static void s_info_hardfault(EOtheFatalError *p);
 static void s_save_mpustate(fatal_error_descriptor_t *des);
 static void s_info_mpustate(EOtheFatalError *p);
+static void s_set_divide_by_zero_trap(void);
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of static variables
@@ -107,6 +108,8 @@ extern EOtheFatalError* eo_fatalerror_Initialise(void)
     {
         return(p);
     }
+    
+    s_set_divide_by_zero_trap();
     
 //    eo_errman_Trace(eo_errman_GetHandle(), "eo_fatalerror_Initialise() starts", s_eobj_ownname); 
        
@@ -161,7 +164,23 @@ extern void eo_fatalerror_AtStartup(EOtheFatalError *p)
                 s_info_mpustate(p);
             }
         }                        
-    }            
+    } 
+
+// test code for dive by zero    
+//    volatile uint32_t value = 0;
+//    volatile uint32_t tmp = 10;
+//    tmp = tmp / value;  
+//   
+//    value = value;
+  
+// test code for access to non existing memory    
+//    volatile unsigned int* pp;
+//    volatile unsigned int n;
+//    pp = (unsigned int*)0xCCCCCCCC;
+//    n = *pp;
+//    
+//    n = n;
+
     
 }
 
@@ -495,6 +514,12 @@ static void s_info_standard(EOtheFatalError *p)
             tid
     );
     eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);    
+}
+
+static void s_set_divide_by_zero_trap(void)
+{
+    volatile uint32_t *pCCR = (volatile uint32_t *) 0xE000ED14;
+    (*pCCR) |= 0x00000010;
 }
 
 static void s_save_hardfault(fatal_error_descriptor_t *des)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
@@ -69,6 +69,8 @@ static void s_info_standard(EOtheFatalError *p);
 
 static void s_save_hardfault(fatal_error_descriptor_t *des);
 static void s_info_hardfault(EOtheFatalError *p);
+static void s_save_mpustate(fatal_error_descriptor_t *des);
+static void s_info_mpustate(EOtheFatalError *p);
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition (and initialisation) of static variables
@@ -78,7 +80,7 @@ static EOtheFatalError s_eo_thefatalerror =
 {
     .initted            = eobool_false,
     .threadcount        = 0,
-    .descriptor         = {0},
+    .descriptor         = {0, 0, 0, 0, NULL, NULL},
     .tobewritten        = {0},
     .detectedfatalerror = {0},
     .errdes             = {0},
@@ -86,7 +88,8 @@ static EOtheFatalError s_eo_thefatalerror =
     {
         {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""},
         {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}, {0, ""}
-    }
+    },
+    .mpustate = {{0, {0, 0, 0}, 0}, {0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0}}
 };
 
 static const char s_eobj_ownname[] = "EOtheFatalError";
@@ -150,10 +153,12 @@ extern void eo_fatalerror_AtStartup(EOtheFatalError *p)
             if(fatalerror_handler_hw_HardFault == p->detectedfatalerror.message.handlertype)
             {
                s_info_hardfault(p); 
+               s_info_mpustate(p);
             }
             else
             {
                 s_info_standard(p);
+                s_info_mpustate(p);
             }
         }                        
     }            
@@ -177,10 +182,12 @@ extern void eo_fatalerror_Restart(EOtheFatalError *p, fatal_error_descriptor_t *
     if(fatalerror_handler_hw_HardFault == des->handlertype)
     {
         s_save_hardfault(des);
+        s_save_mpustate(des);
     }
     else
     {
         s_save_standard(des);
+        s_save_mpustate(des);
     }
 
     
@@ -575,6 +582,126 @@ static void s_info_hardfault(EOtheFatalError *p)
     );            
     eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);    
 }
+
+static void s_save_mpustate(fatal_error_descriptor_t *des)
+{
+    volatile fatal_error_mpustate_cm4_t *pHFmore = (volatile fatal_error_mpustate_cm4_t*) 0x10000000;
+    volatile uint32_t * hardfault_args = (volatile uint32_t *) des->mpucontext;
+
+    pHFmore->header.signature = fatal_error_signature;
+    pHFmore->header.dummy[0] = 0;
+    pHFmore->header.dummy[1] = 1;
+    pHFmore->header.dummy[2] = 2;
+    pHFmore->header.tbd0 = 0;
+    
+    if(NULL == hardfault_args)
+    {
+        pHFmore->context.r0 = pHFmore->context.r1 = pHFmore->context.r2 = pHFmore->context.r3 = 
+        pHFmore->context.r12 = pHFmore->context.lr = pHFmore->context.pc = pHFmore->context.psr = 0;
+    }
+    else 
+    {        
+        pHFmore->context.r0 = hardfault_args[0];
+        pHFmore->context.r1 = hardfault_args[1];
+        pHFmore->context.r2 = hardfault_args[2];
+        pHFmore->context.r3 = hardfault_args[3];        
+        pHFmore->context.r12 = hardfault_args[4];
+        pHFmore->context.lr = hardfault_args[5];
+        pHFmore->context.pc = hardfault_args[6];
+        pHFmore->context.psr = hardfault_args[7];
+    }
+    
+    pHFmore->sysregs.ICSR = (*((volatile uint32_t *)(0xE000ED04)));
+    pHFmore->sysregs.SHCSR = (*((volatile uint32_t *)(0xE000ED24)));
+    pHFmore->sysregs.CFSR = (*((volatile uint32_t *)(0xE000ED28)));
+    pHFmore->sysregs.HFSR = (*((volatile uint32_t *)(0xE000ED2C)));
+    pHFmore->sysregs.DFSR = (*((volatile uint32_t *)(0xE000ED30)));   
+    pHFmore->sysregs.MMFAR = (*((volatile uint32_t *)(0xE000ED34)));
+    pHFmore->sysregs.BFAR = (*((volatile uint32_t *)(0xE000ED38)));
+    pHFmore->sysregs.AFSR = (*((volatile uint32_t *)(0xE000ED3C)));
+}
+
+static void s_info_mpustate(EOtheFatalError *p)
+{
+    // it is of the correct size. i use it to send a diagnostic message
+    uint16_t par16 = 0;
+    uint64_t par64 = p->detectedfatalerror.params.par64;     
+
+    volatile fatal_error_mpustate_cm4_t *pHFmore = (volatile fatal_error_mpustate_cm4_t*) 0x10000000;    
+
+    p->errdes.code             = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag00);
+    p->errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+    p->errdes.sourceaddress    = 0;
+    p->errdes.par16            = par16;
+    p->errdes.par64            = par64;
+    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, "MORE INFO", s_eobj_ownname, &p->errdes);
+
+    // further information is in here
+    char str[64] = {0};
+        
+    if(fatal_error_signature != pHFmore->header.signature)
+    {
+        snprintf(str, sizeof(str), "mpu state invalid sign = 0x%08x",
+            pHFmore->header.signature
+        );
+        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);        
+    }
+    else
+    {
+        // caveat the string can be at most 48 characters 
+        
+        // System control registers. 
+        
+        snprintf(str, sizeof(str), "ICSR = 0x%08x SHCSR = 0x%08x", 
+            pHFmore->sysregs.ICSR, pHFmore->sysregs.SHCSR
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+    
+        snprintf(str, sizeof(str), "CFSR = 0x%08x HFSR = 0x%08x", 
+            pHFmore->sysregs.CFSR, pHFmore->sysregs.HFSR
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+
+        snprintf(str, sizeof(str), "DFSR = 0x%08x MMFAR = 0x%08x", 
+            pHFmore->sysregs.DFSR, pHFmore->sysregs.MMFAR
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+ 
+        snprintf(str, sizeof(str), "BFAR = 0x%08x AFSR = 0x%08x", 
+            pHFmore->sysregs.BFAR, pHFmore->sysregs.AFSR
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+           
+        // execution registers
+
+        snprintf(str, sizeof(str), "r0 = 0x%08x r1 = 0x%08x", 
+            pHFmore->context.r0, pHFmore->context.r1
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+    
+        snprintf(str, sizeof(str), "r2 = 0x%08x r3 = 0x%08x", 
+            pHFmore->context.r2, pHFmore->context.r3
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+
+        snprintf(str, sizeof(str), "r12 = 0x%08x lr = 0x%08x", 
+            pHFmore->context.r12, pHFmore->context.lr
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+ 
+        snprintf(str, sizeof(str), "pc = 0x%08x psr = 0x%08x", 
+            pHFmore->context.pc, pHFmore->context.psr
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes);   
+        
+    }
+    
+    // and now i reset memory bank area
+    memset((fatal_error_mpustate_cm4_t *)pHFmore, 0, sizeof(fatal_error_mpustate_cm4_t));
+    
+}
+
 
 
 // error tests

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.h
@@ -56,7 +56,8 @@ typedef struct
     uint8_t handlererrorcode;   
     uint8_t forfutureuse0;
     uint8_t forfutureuse1;  
-    void *param;     
+    void *param; 
+    void *mpucontext;     
 } fatal_error_descriptor_t;
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError_hid.h
@@ -51,6 +51,45 @@ typedef struct
     uint8_t notusable;
 } fatal_error_message_t; EO_VERIFYsizeof(fatal_error_message_t, 16)
 
+typedef struct
+{ 
+    volatile uint8_t signature;         // it must be fatal_error_signature
+    volatile uint8_t dummy[3]; 
+    volatile uint32_t tbd0;   
+} fatal_error_mpustate_head_t; // 8 
+
+typedef struct
+{
+    volatile uint32_t r0;
+    volatile uint32_t r1;
+    volatile uint32_t r2;
+    volatile uint32_t r3;
+    volatile uint32_t r12;
+    volatile uint32_t lr;
+    volatile uint32_t pc;
+    volatile uint32_t psr;        
+} fatal_error_mpucontext_cm4_t;
+
+// https://developer.arm.com/documentation/100166/0001/System-Control/System-control-registers
+typedef struct
+{
+    volatile uint32_t ICSR;  // 0xE000ED04
+    volatile uint32_t SHCSR; // 0xE000ED24
+    volatile uint32_t CFSR;  // 0xE000ED28
+    volatile uint32_t HFSR;  // 0xE000ED2C
+    volatile uint32_t DFSR;  // 0xE000ED30
+    volatile uint32_t MMFAR; // 0xE000ED34
+    volatile uint32_t BFAR;  // 0xE000ED38
+    volatile uint32_t AFSR;  // 0xE000ED3C        
+} fatal_error_sysregs_cm4_t;
+
+
+typedef struct
+{ 
+    fatal_error_mpustate_head_t header; 
+    fatal_error_mpucontext_cm4_t context;
+    fatal_error_sysregs_cm4_t sysregs;
+} fatal_error_mpustate_cm4_t; // 8 + 8*4 + 8*4 = 72
 
 typedef struct
 {
@@ -85,6 +124,7 @@ struct EOtheFatalError_hid
     fatal_error_t               detectedfatalerror;
     eOerrmanDescriptor_t        errdes;
     threadinfo_t                threads[maxthreads];
+    fatal_error_mpustate_cm4_t  mpustate;    
 }; 
 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/abslayer/hal_core_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/abslayer/hal_core_cfg.c
@@ -95,6 +95,7 @@ static void s_hal_core_cfg_on_fatalerror(hal_fatalerror_t errorcode, const char 
     des->handlertype = fatalerror_handler_hal;
     des->handlererrorcode = errorcode;
     des->param = NULL;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else    
     #warning DONTUSE_EOtheFatalError is defined, are you sure?    
@@ -164,6 +165,18 @@ static void myheap_delete(void* mem)
 
 #if !defined(DONTUSE_EOtheFatalError)
 
+void hw_handler_hf(fatal_error_handler_t feh, uint32_t *arg)
+{
+    fatal_error_descriptor_t *des = eo_fatalerror_GetDescriptor(eo_fatalerror_GetHandle());
+    des->handlertype = feh;
+    des->handlererrorcode = 100;
+    des->forfutureuse0 = 0x12;
+    des->forfutureuse1 = 0x23;
+    des->param = NULL;
+    des->mpucontext = arg;
+    eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
+}
+
 void hw_handler(fatal_error_handler_t feh)
 {
     fatal_error_descriptor_t *des = eo_fatalerror_GetDescriptor(eo_fatalerror_GetHandle());
@@ -172,6 +185,7 @@ void hw_handler(fatal_error_handler_t feh)
     des->forfutureuse0 = 0x12;
     des->forfutureuse1 = 0x23;
     des->param = NULL;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 }
 
@@ -180,10 +194,10 @@ void NMI_Handler(void)
     hw_handler(fatalerror_handler_hw_NMI);
 }
 
-void HardFault_Handler(void)
-{
-    hw_handler(fatalerror_handler_hw_HardFault);
-}
+//void HardFault_Handler(void)
+//{
+//    hw_handler(fatalerror_handler_hw_HardFault);
+//}
 
 void MemManage_Handler(void)
 {
@@ -213,6 +227,30 @@ void Default_Handler(void)
 void RTC_Alarm_IRQHandler(void)
 {
     hw_handler(fatalerror_handler_hw_Default);
+}
+
+void McuHardFault_HandlerC(uint32_t *hardfault_args)
+{
+    hw_handler_hf(fatalerror_handler_hw_HardFault, hardfault_args);
+}
+
+void HardFault_Handler(void) __attribute__((naked));
+void HardFault_Handler(void)
+{
+  __asm volatile (
+    ".syntax unified              \n"  /* needed for the 'adds r1,#2' below */
+    " movs r0,#4                  \n"  /* load bit mask into R0 */
+    " mov r1, lr                  \n"  /* load link register into R1 */
+    " tst r0, r1                  \n"  /* compare with bitmask */
+    " beq _MSP                    \n"  /* if bitmask is set: stack pointer is in PSP. Otherwise in MSP */
+    " mrs r0, psp                 \n"  /* otherwise: stack pointer is in PSP */
+    " b _GetPC                    \n"  /* go to part which loads the PC */
+  "_MSP:                          \n"  /* stack pointer is in MSP register */
+    " mrs r0, msp                 \n"  /* load stack pointer into R0 */
+  "_GetPC:                        \n"  /* find out where the hard fault happened */
+    " ldr r1,[r0,#24]             \n"  /* load program counter into R1. R1 contains address of the next instruction where the hard fault happened */
+    " b McuHardFault_HandlerC   \n"    /* decode more information. R0 contains pointer to stack frame */
+  );
 }
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/abslayer/ipal_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/abslayer/ipal_cfg.c
@@ -180,6 +180,7 @@ static void s_ipal_cfg_on_fatal_error(ipal_fatalerror_t errorcode, const char * 
     des->handlertype = fatalerror_handler_ipal;
     des->handlererrorcode = errorcode;
     des->param = NULL;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else
     #warning DONTUSE_EOtheFatalError is defined, are you sure?

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/abslayer/osal_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/abslayer/osal_cfg.c
@@ -118,6 +118,7 @@ static void s_osal_cfg_on_fatal_error(void* task, osal_fatalerror_t errorcode, c
     des->handlertype = fatalerror_handler_osal;
     des->handlererrorcode = errorcode;
     des->param = task;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else 
     #warning DONTUSE_EOtheFatalError is defined, are you sure?    

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,20 +75,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          26
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          27
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2021
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          48
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          46
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/ipal_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/ipal_cfg.c
@@ -179,6 +179,7 @@ static void s_ipal_cfg_on_fatal_error(ipal_fatalerror_t errorcode, const char * 
     des->handlertype = fatalerror_handler_ipal;
     des->handlererrorcode = errorcode;
     des->param = NULL;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else
     #warning DONTUSE_EOtheFatalError is defined, are you sure?

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/osal_cfg.c
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/osal_cfg.c
@@ -118,6 +118,7 @@ static void s_osal_cfg_on_fatal_error(void* task, osal_fatalerror_t errorcode, c
     des->handlertype = fatalerror_handler_osal;
     des->handlererrorcode = errorcode;
     des->param = task;
+    des->mpucontext = NULL;
     eo_fatalerror_Restart(eo_fatalerror_GetHandle(), des);
 #else 
     #warning DONTUSE_EOtheFatalError is defined, are you sure?    

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -85,7 +85,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          36
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          37
 
 
 //  </h>version
@@ -94,13 +94,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2021
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          44
 
 //  </h>build date
 


### PR DESCRIPTION
With this PR we have the `HardFault_Handler()` collect and save in non volatile RAM the full context of the MPU, so that at the restart the board sends this information over diagnostic messages.

This behaviour applies to ems, mc4plus and mc2plus.

There is an associated PR for the binaries in  https://github.com/robotology/icub-firmware-build/pull/35

**Behaviour of the improved diagnostics**

The `HardFault_Handler()` now sends improved information which contains:
- execution registers at the moment of the exception such as PC (program counter) and others which help understand which instruction caused the fault
- system registers such as CFSR and others which tell more about the cause of the fault. 

Here is an example of what the board sends when we induce a HF by some sample code which access not existing RAM.

```C++
extern void eo_fatalerror_AtStartup(EOtheFatalError *p)
{
...
    volatile unsigned int* pp;
    volatile unsigned int n;
    pp = (unsigned int*)0xCCCCCCCC;
    n = *pp;
``` 
**Listing**. Offending code


```bash
[INFO] (EOtheServices tsk2 @S5:m632:u625)-> {0x3b, p16 0x0000, p64 0x0000000000000000, dev 0, adr 0}: SYS: the board is bootstrapping.
[ERROR] (EOtheFatalError tsk2 @S5:m634:u218)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = RESTARTED after FATAL error
[ERROR] (EOtheFatalError tsk2 @S5:m634:u344)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = @ 5636 ms
[ERROR] (EOtheFatalError tsk2 @S5:m634:u469)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = handler hw_HardFault, code 0x0
[ERROR] (EOtheFatalError tsk2 @S5:m634:u596)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = type see TBL
[ERROR] (EOtheFatalError tsk2 @S5:m634:u723)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = IRQHan HardFault Thread tINIT
[ERROR] (EOtheFatalError tsk2 @S5:m634:u852)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = ipsr 3, tid 2
[ERROR] (EOtheFatalError tsk2 @S5:m634:u973)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = CFSR 0x8200
[ERROR] (EOtheFatalError tsk2 @S5:m635:u89)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = MORE INFO
[ERROR] (EOtheFatalError tsk2 @S5:m635:u216)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = ICSR = 0x00000803 SHCSR = 0x00000000
[ERROR] (EOtheFatalError tsk2 @S5:m635:u354)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = CFSR = 0x00008200 HFSR = 0x40000000
[ERROR] (EOtheFatalError tsk2 @S5:m635:u492)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = DFSR = 0x00000000 MMFAR = 0xcccccccc
[ERROR] (EOtheFatalError tsk2 @S5:m635:u629)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = BFAR = 0xcccccccc AFSR = 0x00000000
[ERROR] (EOtheFatalError tsk2 @S5:m635:u765)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = r0 = 0xcccccccc r1 = 0x00000000
[ERROR] (EOtheFatalError tsk2 @S5:m635:u899)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = r2 = 0x00000000 r3 = 0x00000000
[ERROR] (EOtheFatalError tsk2 @S5:m636:u36)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = r12 = 0x00000000 lr = 0x08048ab9
[ERROR] (EOtheFatalError tsk2 @S5:m636:u171)-> {0x4000000 p16 0x0000, p64 0x0203000600001604, dev 0, adr 0}: DEBUG: tag00. INFO = pc = 0x0802f87a psr = 0x41000000
```
**Listing**. Diagnostics messages

The interpretation of the diagnostic messages is not trivial. We need to refer to the ARM Cortex M4 documentation (see [here](https://developer.arm.com/documentation/ddi0439/b/System-Control/Register-summary)) and we also need the .map file of the running application for mapping the hex addresses of the program counter for instance to the assembly and C code. We very likely will also need to re-run the very same project on the debugger.  As a fact, post mortem diagnosis w/out a debugger is very complicate.

As an example for the above situation:
- with the .map we can locate the pc = 0x0802f87a to the offending function. in this case it is inside  `eo_fatalerror_AtStartup()` as expected
 
 ![image](https://user-images.githubusercontent.com/7148284/133744989-d33af531-b031-4153-9c27-b7fd076b4b48.png)

- however, only w/ the debugger running we can find the offending instruction inside the C function
  ![image](https://user-images.githubusercontent.com/7148284/133745218-7c78be9f-1670-4f68-93d0-da5ec69cd71c.png)

- by looking at the system registers we can for instance see that address `0xcccccccc` is the one giving problems.

**Tests**
The code was tested on an ems on a dedicated testbench where we caused several HF faults such as divide by zero, access to not-existing addresses but also others such as missing memory for RTOS.

The binaries of the mc4plus have been validated also with tests on icub3 (see [here](https://github.com/robotology/icub-firmware-build/pull/35#issuecomment-923939066)), hence we can merge the PR

**Note**
This PR addresses the problem in https://github.com/robotology/icub-firmware/issues/174

  