### PR TITLE
Updated AMC BLDC Application 03 to use generated code with nonvirtual buses

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/proj/amcbldc-application03.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/proj/amcbldc-application03.uvoptx
@@ -119,18 +119,13 @@
       <TargetDriverDllRegistry>
         <SetRegEntry>
           <Number>0</Number>
-          <Key>ST-LINKIII-KEIL_SWO</Key>
-          <Name>-U004B003B3137510839383538 -O206 -SF10000 -C0 -A0 -I0 -HNlocalhost -HP7184 -P1 -N00("") -D00(00000000) -L00(0) -TO131091 -TC168000000 -TT10000000 -TP21 -TDS800D -TDT0 -TDC1F -TIEFFFFFFFF -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512.FLM)</Name>
+          <Key>ULP2CM3</Key>
+          <Name>-UAny -O206 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65554 -TC10000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIEFFFFFFFF -TIP8 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>UL2CM3</Key>
-          <Name>UL2CM3(-S0 -C0 -P0 ) -FN1 -FC1000 -FD20000000 -FF0STM32G4xx_512 -FL080000 -FS08000000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512.FLM)</Name>
-        </SetRegEntry>
-        <SetRegEntry>
-          <Number>0</Number>
-          <Key>ULP2CM3</Key>
-          <Name>-UAny -O16623 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC160000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512.FLM)</Name>
+          <Name>UL2CM3(-S0 -C0 -P0 )  -FN1 -FC1000 -FD20000000 -FF0STM32G47x-8x_512 -FL080000 -FS08000000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -241,7 +236,7 @@
       <pMultCmdsp></pMultCmdsp>
       <DebugDescription>
         <Enable>1</Enable>
-        <EnableFlashSeq>0</EnableFlashSeq>
+        <EnableFlashSeq>1</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
         <DbgClock>10000000</DbgClock>
@@ -730,7 +725,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -762,7 +757,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1298,7 +1293,7 @@
 
   <Group>
     <GroupName>embot::app-required</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1518,7 +1513,7 @@
 
   <Group>
     <GroupName>mbd</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1738,6 +1733,42 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>77</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\sharedutils\const_params.cpp</PathWithFileName>
+      <FilenameWithoutPath>const_params.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>78</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\sharedutils\mw_cmsis.h</PathWithFileName>
+      <FilenameWithoutPath>mw_cmsis.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>79</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\sharedutils\zero_crossing_types.h</PathWithFileName>
+      <FilenameWithoutPath>zero_crossing_types.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1748,7 +1779,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1760,7 +1791,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>81</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1772,7 +1803,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1784,7 +1815,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1798,13 +1829,13 @@
 
   <Group>
     <GroupName>mbd::can-raw2struct</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1816,7 +1847,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1828,7 +1859,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1840,7 +1871,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1860,7 +1891,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1872,7 +1903,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1884,7 +1915,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1896,7 +1927,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1910,13 +1941,13 @@
 
   <Group>
     <GroupName>mbd::supervisor-tx</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1928,7 +1959,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1940,7 +1971,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1952,7 +1983,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1972,7 +2003,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1984,7 +2015,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1996,7 +2027,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2008,7 +2039,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/proj/amcbldc-application03.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/proj/amcbldc-application03.uvprojx
@@ -16,12 +16,12 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
-          <FlashDriverDll>UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512.FLM))</FlashDriverDll>
+          <FlashDriverDll>UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512 -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM))</FlashDriverDll>
           <DeviceId>0</DeviceId>
           <RegisterFile>$$Device:STM32G474QETx$Drivers\CMSIS\Device\ST\STM32G4xx\Include\stm32g4xx.h</RegisterFile>
           <MemoryEnv></MemoryEnv>
@@ -972,6 +972,21 @@
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\sharedutils\uMultiWordShl.h</FilePath>
             </File>
+            <File>
+              <FileName>const_params.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\const_params.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>mw_cmsis.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\mw_cmsis.h</FilePath>
+            </File>
+            <File>
+              <FileName>zero_crossing_types.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\zero_crossing_types.h</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1183,7 +1198,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2070,6 +2085,21 @@
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\sharedutils\uMultiWordShl.h</FilePath>
             </File>
+            <File>
+              <FileName>const_params.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\const_params.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>mw_cmsis.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\mw_cmsis.h</FilePath>
+            </File>
+            <File>
+              <FileName>zero_crossing_types.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\zero_crossing_types.h</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2281,7 +2311,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -3167,6 +3197,21 @@
               <FileName>uMultiWordShl.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\sharedutils\uMultiWordShl.h</FilePath>
+            </File>
+            <File>
+              <FileName>const_params.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\const_params.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>mw_cmsis.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\mw_cmsis.h</FilePath>
+            </File>
+            <File>
+              <FileName>zero_crossing_types.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\zero_crossing_types.h</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -32,9 +32,9 @@ const uint8_T can_decoder_IN_Home = 1U;
 const uint8_T can_decoder_IN_Home_o = 2U;
 const int32_T event_ev_error_mode_unrecognize = 0;
 
-uint8_T rtP_CAN_ID_AMC = 1U;
 real32_T rtP_CAN_ANGLE_DEG2ICUB = 182.044449F;
-uint16_T rtP_CAN_ID_HOST = 0U;
+uint16_T rtP_CAN_ID_HOST = 0U; 
+uint8_T rtP_CAN_ID_AMC = 1U; 
 
 namespace can_messaging
 {
@@ -69,9 +69,10 @@ namespace can_messaging
   }
 
   // Function for Chart: '<S1>/Decoding Logic'
-  void CAN_Decoder::can_decoder_ERROR_HANDLING(const uint8_T
-    *rtu_pck_rx_available)
+  void CAN_Decoder::can_decoder_ERROR_HANDLING(const BUS_CAN_RX *arg_pck_rx)
   {
+    boolean_T guard1 = false;
+    guard1 = false;
     switch (can_decoder_DW.is_ERROR_HANDLING) {
      case can_decoder_IN_Event_Error:
       can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
@@ -79,50 +80,47 @@ namespace can_messaging
       break;
 
      case can_decoder_IN_Home_o:
-      switch (can_decoder_DW.sfEvent) {
-       case can_d_event_ev_error_pck_not4us:
+      if (can_decoder_DW.sfEvent == can_d_event_ev_error_pck_not4us) {
         can_decoder_B.error_type = CANErrorTypes_Packet_Not4Us;
         can_decoder_DW.ev_errorEventCounter++;
         can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Event_Error;
-        break;
-
-       case ca_event_ev_error_pck_malformed:
+        can_decoder_DW.ev_async = true;
+      } else if (can_decoder_DW.sfEvent == ca_event_ev_error_pck_malformed) {
         can_decoder_B.error_type = CANErrorTypes_Packet_Malformed;
         can_decoder_DW.ev_errorEventCounter++;
         can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Event_Error;
-        break;
-
-       case event_ev_error_mode_unrecognize:
+        can_decoder_DW.ev_async = true;
+      } else if (can_decoder_DW.sfEvent == event_ev_error_mode_unrecognize) {
         can_decoder_B.error_type = CANErrorTypes_Mode_Unrecognized;
         can_decoder_DW.ev_errorEventCounter++;
         can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Event_Error;
-        break;
-
-       default:
-        // Outputs for Atomic SubSystem: '<Root>/CAN_Decoder'
-        // Chart: '<S1>/Decoding Logic'
-        if ((*rtu_pck_rx_available > 0) && (can_decoder_DW.cmd_processed == 0))
-        {
-          can_decoder_B.error_type = CANErrorTypes_Packet_Unrecognized;
-          can_decoder_DW.ev_errorEventCounter++;
-          can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
-          can_decoder_DW.cmd_processed = 0U;
-        } else if (can_decoder_DW.cmd_processed > 1) {
-          can_decoder_B.error_type = CANErrorTypes_Packet_MultiFunctionsDetected;
-          can_decoder_DW.ev_errorEventCounter++;
-          can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
-          can_decoder_DW.cmd_processed = 0U;
-        } else {
-          can_decoder_B.error_type = CANErrorTypes_No_Error;
-          can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
-          can_decoder_DW.cmd_processed = 0U;
-        }
-
-        // End of Chart: '<S1>/Decoding Logic'
-        // End of Outputs for SubSystem: '<Root>/CAN_Decoder'
-        break;
+        can_decoder_DW.ev_async = true;
+      } else if (can_decoder_DW.ev_async) {
+        guard1 = true;
+      } else if ((arg_pck_rx->available > 0) && (can_decoder_DW.cmd_processed ==
+                  0)) {
+        can_decoder_B.error_type = CANErrorTypes_Packet_Unrecognized;
+        can_decoder_DW.ev_async = false;
+        can_decoder_DW.ev_errorEventCounter++;
+        can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
+        can_decoder_DW.cmd_processed = 0U;
+      } else if (can_decoder_DW.cmd_processed > 1) {
+        can_decoder_B.error_type = CANErrorTypes_Packet_MultiFunctionsDetected;
+        can_decoder_DW.ev_async = false;
+        can_decoder_DW.ev_errorEventCounter++;
+        can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
+        can_decoder_DW.cmd_processed = 0U;
+      } else {
+        can_decoder_B.error_type = CANErrorTypes_No_Error;
+        guard1 = true;
       }
       break;
+    }
+
+    if (guard1) {
+      can_decoder_DW.ev_async = false;
+      can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
+      can_decoder_DW.cmd_processed = 0U;
     }
   }
 
@@ -156,17 +154,12 @@ namespace can_messaging
 namespace can_messaging
 {
   // System initialize for referenced model: 'can_decoder'
-  void CAN_Decoder::init(boolean_T *rty_messages_rx_control_mode_mo,
-    MCControlModes *rty_messages_rx_control_mode__g, boolean_T
-    *rty_messages_rx_current_limit_m, int16_T *rty_messages_rx_current_limit_n,
-    uint16_T *rty_messages_rx_current_limit_p, uint16_T
-    *rty_messages_rx_current_limit_o, int16_T *rty_messages_rx_desired_current,
-    boolean_T *rty_events_rx_control_mode, boolean_T
-    *rty_events_rx_current_limit, boolean_T *rty_events_rx_desired_current,
-    boolean_T *rty_errors_rx_event, CANErrorTypes *rty_errors_rx_type)
+  void CAN_Decoder::init(BUS_MESSAGES_RX *arg_messages_rx, BUS_EVENTS_RX
+    *arg_events_rx, BUS_CAN_RX_ERRORS *arg_errors_rx)
   {
     // SystemInitialize for Atomic SubSystem: '<Root>/CAN_Decoder'
     // SystemInitialize for Chart: '<S1>/Decoding Logic'
+    can_decoder_DW.sfEvent = can_decoder_CALL_EVENT;
     can_decoder_B.msg_set_control_mode.motor = false;
     can_decoder_B.msg_set_control_mode.mode = MCControlModes_Idle;
     can_decoder_B.msg_set_current_limit.motor = false;
@@ -174,346 +167,263 @@ namespace can_messaging
     can_decoder_B.msg_set_current_limit.peak = 0U;
     can_decoder_B.msg_set_current_limit.overload = 0U;
     can_decoder_B.msg_desired_current.current = 0;
-    can_decoder_DW.sfEvent = can_decoder_CALL_EVENT;
-
-    // Chart: '<S1>/Decoding Logic'
-    can_decoder_DW.is_active_SET_CONTROL_MODE = 1U;
-    can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
-    can_decoder_DW.is_active_DESIRED_CURRENT = 1U;
-    can_decoder_DW.is_DESIRED_CURRENT = can_decoder_IN_Home;
-    can_decoder_DW.is_active_SET_CURRENT_LIMIT = 1U;
-    can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
-    can_decoder_DW.is_active_ERROR_HANDLING = 1U;
-    can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
 
     // SystemInitialize for BusCreator: '<S1>/Bus Creator1'
-    can_decoder_B.BusCreator1.control_mode = can_decoder_B.ev_set_control_mode;
-    can_decoder_B.BusCreator1.current_limit = can_decoder_B.ev_set_current_limit;
-    can_decoder_B.BusCreator1.desired_current = can_decoder_B.ev_desired_current;
+    arg_events_rx->control_mode = can_decoder_B.ev_set_control_mode;
+    arg_events_rx->current_limit = can_decoder_B.ev_set_current_limit;
+    arg_events_rx->desired_current = can_decoder_B.ev_desired_current;
 
     // SystemInitialize for BusCreator: '<S1>/Bus Creator2'
-    can_decoder_B.BusCreator2.control_mode = can_decoder_B.msg_set_control_mode;
-    can_decoder_B.BusCreator2.current_limit =
-      can_decoder_B.msg_set_current_limit;
-    can_decoder_B.BusCreator2.desired_current =
-      can_decoder_B.msg_desired_current;
+    arg_messages_rx->control_mode = can_decoder_B.msg_set_control_mode;
+    arg_messages_rx->current_limit = can_decoder_B.msg_set_current_limit;
+    arg_messages_rx->desired_current = can_decoder_B.msg_desired_current;
 
     // SystemInitialize for BusCreator: '<S1>/Bus Creator3'
-    can_decoder_B.BusCreator3.event = can_decoder_B.ev_error;
-    can_decoder_B.BusCreator3.type = can_decoder_B.error_type;
+    arg_errors_rx->event = can_decoder_B.ev_error;
+    arg_errors_rx->type = can_decoder_B.error_type;
 
     // End of SystemInitialize for SubSystem: '<Root>/CAN_Decoder'
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/errors_rx'
-    *rty_errors_rx_event = can_decoder_B.BusCreator3.event;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/errors_rx'
-    *rty_errors_rx_type = can_decoder_B.BusCreator3.type;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/events_rx'
-    *rty_events_rx_control_mode = can_decoder_B.BusCreator1.control_mode;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/events_rx'
-    *rty_events_rx_current_limit = can_decoder_B.BusCreator1.current_limit;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/events_rx'
-    *rty_events_rx_desired_current = can_decoder_B.BusCreator1.desired_current;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_control_mode_mo =
-      can_decoder_B.BusCreator2.control_mode.motor;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_control_mode__g =
-      can_decoder_B.BusCreator2.control_mode.mode;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_current_limit_m =
-      can_decoder_B.BusCreator2.current_limit.motor;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_current_limit_n =
-      can_decoder_B.BusCreator2.current_limit.nominal;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_current_limit_p =
-      can_decoder_B.BusCreator2.current_limit.peak;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_current_limit_o =
-      can_decoder_B.BusCreator2.current_limit.overload;
-
-    // SystemInitialize for SignalConversion generated from: '<Root>/messages_rx' 
-    *rty_messages_rx_desired_current =
-      can_decoder_B.BusCreator2.desired_current.current;
   }
 
   // Output and update for referenced model: 'can_decoder'
-  void CAN_Decoder::step(const uint8_T *rtu_pck_rx_available, const
-    CANClassTypes *rtu_pck_rx_packets_ID_CLS, const uint8_T
-    *rtu_pck_rx_packets_ID_SRC, const uint8_T *rtu_pck_rx_packets_ID_DST_TYP,
-    const uint8_T *rtu_pck_rx_packets_PAYLOAD_LEN, const boolean_T
-    *rtu_pck_rx_packets_PAYLOAD_CMD_, const uint8_T
-    *rtu_pck_rx_packets_PAYLOAD_CM_k, const uint8_T
-    rtu_pck_rx_packets_PAYLOAD_ARG[7], boolean_T
-    *rty_messages_rx_control_mode_mo, MCControlModes
-    *rty_messages_rx_control_mode__g, boolean_T *rty_messages_rx_current_limit_m,
-    int16_T *rty_messages_rx_current_limit_n, uint16_T
-    *rty_messages_rx_current_limit_p, uint16_T *rty_messages_rx_current_limit_o,
-    int16_T *rty_messages_rx_desired_current, boolean_T
-    *rty_events_rx_control_mode, boolean_T *rty_events_rx_current_limit,
-    boolean_T *rty_events_rx_desired_current, boolean_T *rty_errors_rx_event,
-    CANErrorTypes *rty_errors_rx_type)
+  void CAN_Decoder::step(const BUS_CAN_RX &arg_pck_rx, BUS_MESSAGES_RX &
+    arg_messages_rx, BUS_EVENTS_RX &arg_events_rx, BUS_CAN_RX_ERRORS &
+    arg_errors_rx)
   {
     real_T tmp;
-    int32_T i;
+    int32_T b_previousEvent;
 
     // Outputs for Atomic SubSystem: '<Root>/CAN_Decoder'
-    // BusCreator generated from: '<S1>/Decoding Logic'
-    can_decoder_B.BusConversion_InsertedFor_Decod.ID.CLS =
-      *rtu_pck_rx_packets_ID_CLS;
-    can_decoder_B.BusConversion_InsertedFor_Decod.ID.SRC =
-      *rtu_pck_rx_packets_ID_SRC;
-    can_decoder_B.BusConversion_InsertedFor_Decod.ID.DST_TYP =
-      *rtu_pck_rx_packets_ID_DST_TYP;
-
-    // BusCreator generated from: '<S1>/Decoding Logic'
-    can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.CMD.M =
-      *rtu_pck_rx_packets_PAYLOAD_CMD_;
-    can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.CMD.OPC =
-      *rtu_pck_rx_packets_PAYLOAD_CM_k;
-
-    // BusCreator generated from: '<S1>/Decoding Logic'
-    can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.LEN =
-      *rtu_pck_rx_packets_PAYLOAD_LEN;
-    for (i = 0; i < 7; i++) {
-      can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[i] =
-        rtu_pck_rx_packets_PAYLOAD_ARG[i];
-    }
-
     // Chart: '<S1>/Decoding Logic' incorporates:
     //   Constant: '<S1>/Constant'
 
     can_decoder_DW.sfEvent = can_decoder_CALL_EVENT;
 
     // This state chart is responsible for decoding incoming CAN packets.
-    if ((can_decoder_DW.is_active_SET_CONTROL_MODE != 0U) &&
-        (can_decoder_DW.is_SET_CONTROL_MODE == 1) && ((*rtu_pck_rx_available > 0)
-         && (can_decoder_B.BusConversion_InsertedFor_Decod.ID.CLS ==
-             CANClassTypes_Motor_Control_Command))) {
-      if (can_decoder_B.BusConversion_InsertedFor_Decod.ID.DST_TYP ==
-          rtP_CAN_ID_AMC) {
-        if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.LEN >= 1) {
-          if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.CMD.OPC ==
-              static_cast<int32_T>(MCOPC_Set_Control_Mode)) {
-            if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.LEN >= 2)
-            {
-              if (can_d_is_controlmode_recognized(static_cast<real_T>
-                   (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[0]))
-                  != 0.0) {
-                can_decoder_B.msg_set_control_mode.motor =
-                  can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.CMD.M;
-                can_decoder_B.msg_set_control_mode.mode =
-                  static_cast<MCControlModes>(can_safe_cast_to_MCControlModes
-                  (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[0]));
-                i = can_decoder_DW.cmd_processed + 1;
-                if (can_decoder_DW.cmd_processed + 1 > 65535) {
-                  i = 65535;
-                }
+    if (can_decoder_DW.is_active_c3_can_decoder == 0U) {
+      can_decoder_DW.is_active_c3_can_decoder = 1U;
+      can_decoder_DW.is_active_SET_CONTROL_MODE = 1U;
+      can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
+      can_decoder_DW.is_active_DESIRED_CURRENT = 1U;
+      can_decoder_DW.is_DESIRED_CURRENT = can_decoder_IN_Home;
+      can_decoder_DW.is_active_SET_CURRENT_LIMIT = 1U;
+      can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
+      can_decoder_DW.is_active_ERROR_HANDLING = 1U;
+      can_decoder_DW.ev_async = false;
+      can_decoder_DW.is_ERROR_HANDLING = can_decoder_IN_Home_o;
+      can_decoder_DW.cmd_processed = 0U;
+    } else {
+      if ((can_decoder_DW.is_active_SET_CONTROL_MODE != 0U) &&
+          (can_decoder_DW.is_SET_CONTROL_MODE == 1) && ((arg_pck_rx.available >
+            0) && (arg_pck_rx.packets.ID.CLS ==
+                   CANClassTypes_Motor_Control_Command))) {
+        if (arg_pck_rx.packets.ID.DST_TYP == rtP_CAN_ID_AMC) {
+          if (arg_pck_rx.packets.PAYLOAD.LEN >= 1) {
+            if (arg_pck_rx.packets.PAYLOAD.CMD.OPC == static_cast<int32_T>
+                (MCOPC_Set_Control_Mode)) {
+              if (arg_pck_rx.packets.PAYLOAD.LEN >= 2) {
+                if (can_d_is_controlmode_recognized(static_cast<real_T>
+                     (arg_pck_rx.packets.PAYLOAD.ARG[0])) != 0.0) {
+                  can_decoder_B.msg_set_control_mode.motor =
+                    arg_pck_rx.packets.PAYLOAD.CMD.M;
+                  can_decoder_B.msg_set_control_mode.mode =
+                    static_cast<MCControlModes>(can_safe_cast_to_MCControlModes
+                    (arg_pck_rx.packets.PAYLOAD.ARG[0]));
+                  b_previousEvent = can_decoder_DW.cmd_processed + 1;
+                  if (can_decoder_DW.cmd_processed + 1 > 65535) {
+                    b_previousEvent = 65535;
+                  }
 
-                can_decoder_DW.cmd_processed = static_cast<uint16_T>(i);
-                can_decoder_DW.ev_set_control_modeEventCounter++;
-                can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
+                  can_decoder_DW.cmd_processed = static_cast<uint16_T>
+                    (b_previousEvent);
+                  can_decoder_DW.ev_set_control_modeEventCounter++;
+                  can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
+                } else {
+                  b_previousEvent = can_decoder_DW.sfEvent;
+                  can_decoder_DW.sfEvent = event_ev_error_mode_unrecognize;
+                  if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
+                    can_decoder_ERROR_HANDLING(&arg_pck_rx);
+                  }
+
+                  can_decoder_DW.sfEvent = b_previousEvent;
+                  can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
+                }
               } else {
-                i = can_decoder_DW.sfEvent;
-                can_decoder_DW.sfEvent = event_ev_error_mode_unrecognize;
+                b_previousEvent = can_decoder_DW.sfEvent;
+                can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
                 if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-                  can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
+                  can_decoder_ERROR_HANDLING(&arg_pck_rx);
                 }
 
-                can_decoder_DW.sfEvent = i;
+                can_decoder_DW.sfEvent = b_previousEvent;
                 can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
               }
             } else {
-              i = can_decoder_DW.sfEvent;
-              can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
-              if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-                can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
-              }
-
-              can_decoder_DW.sfEvent = i;
               can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
             }
           } else {
+            b_previousEvent = can_decoder_DW.sfEvent;
+            can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
+            if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
+              can_decoder_ERROR_HANDLING(&arg_pck_rx);
+            }
+
+            can_decoder_DW.sfEvent = b_previousEvent;
             can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
           }
         } else {
-          i = can_decoder_DW.sfEvent;
-          can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
+          b_previousEvent = can_decoder_DW.sfEvent;
+          can_decoder_DW.sfEvent = can_d_event_ev_error_pck_not4us;
           if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-            can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
+            can_decoder_ERROR_HANDLING(&arg_pck_rx);
           }
 
-          can_decoder_DW.sfEvent = i;
+          can_decoder_DW.sfEvent = b_previousEvent;
           can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
         }
-      } else {
-        i = can_decoder_DW.sfEvent;
-        can_decoder_DW.sfEvent = can_d_event_ev_error_pck_not4us;
-        if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-          can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
-        }
-
-        can_decoder_DW.sfEvent = i;
-        can_decoder_DW.is_SET_CONTROL_MODE = can_decoder_IN_Home;
       }
-    }
 
-    if ((can_decoder_DW.is_active_DESIRED_CURRENT != 0U) &&
-        (can_decoder_DW.is_DESIRED_CURRENT == 1) && ((*rtu_pck_rx_available > 0)
-         && (can_decoder_B.BusConversion_InsertedFor_Decod.ID.CLS ==
-             CANClassTypes_Motor_Control_Streaming) &&
-         (can_de_safe_cast_to_MCStreaming
-          (can_decoder_B.BusConversion_InsertedFor_Decod.ID.DST_TYP) ==
-          static_cast<int32_T>(MCStreaming_Desired_Current)))) {
-      if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.LEN == 8) {
-        tmp = can_decoder_merge_2bytes(static_cast<real_T>
-          (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[5]),
-          static_cast<real_T>
-          (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[6]));
-        if (tmp < 32768.0) {
-          if (tmp >= -32768.0) {
-            can_decoder_B.msg_desired_current.current = static_cast<int16_T>(tmp);
-          } else {
-            can_decoder_B.msg_desired_current.current = MIN_int16_T;
-          }
-        } else {
-          can_decoder_B.msg_desired_current.current = MAX_int16_T;
-        }
-
-        i = can_decoder_DW.cmd_processed + 1;
-        if (can_decoder_DW.cmd_processed + 1 > 65535) {
-          i = 65535;
-        }
-
-        can_decoder_DW.cmd_processed = static_cast<uint16_T>(i);
-        can_decoder_DW.ev_desired_currentEventCounter++;
-        can_decoder_DW.is_DESIRED_CURRENT = can_decoder_IN_Home;
-      } else {
-        i = can_decoder_DW.sfEvent;
-        can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
-        if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-          can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
-        }
-
-        can_decoder_DW.sfEvent = i;
-        can_decoder_DW.is_DESIRED_CURRENT = can_decoder_IN_Home;
-      }
-    }
-
-    if ((can_decoder_DW.is_active_SET_CURRENT_LIMIT != 0U) &&
-        (can_decoder_DW.is_SET_CURRENT_LIMIT == 1) && ((*rtu_pck_rx_available >
-          0) && (can_decoder_B.BusConversion_InsertedFor_Decod.ID.CLS ==
-                 CANClassTypes_Motor_Control_Command))) {
-      if (can_decoder_B.BusConversion_InsertedFor_Decod.ID.DST_TYP ==
-          rtP_CAN_ID_AMC) {
-        if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.LEN >= 1) {
-          if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.CMD.OPC ==
-              static_cast<int32_T>(MCOPC_Set_Current_Limit)) {
-            if (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.LEN == 8)
-            {
-              can_decoder_B.msg_set_current_limit.motor =
-                can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.CMD.M;
-              tmp = can_decoder_merge_2bytes(static_cast<real_T>
-                (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[1]),
-                static_cast<real_T>
-                (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[2]));
-              if (tmp < 32768.0) {
-                if (tmp >= -32768.0) {
-                  can_decoder_B.msg_set_current_limit.nominal =
-                    static_cast<int16_T>(tmp);
-                } else {
-                  can_decoder_B.msg_set_current_limit.nominal = MIN_int16_T;
-                }
-              } else {
-                can_decoder_B.msg_set_current_limit.nominal = MAX_int16_T;
-              }
-
-              tmp = can_decoder_merge_2bytes(static_cast<real_T>
-                (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[3]),
-                static_cast<real_T>
-                (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[4]));
-              if (tmp < 65536.0) {
-                if (tmp >= 0.0) {
-                  can_decoder_B.msg_set_current_limit.peak =
-                    static_cast<uint16_T>(tmp);
-                } else {
-                  can_decoder_B.msg_set_current_limit.peak = 0U;
-                }
-              } else {
-                can_decoder_B.msg_set_current_limit.peak = MAX_uint16_T;
-              }
-
-              tmp = can_decoder_merge_2bytes(static_cast<real_T>
-                (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[5]),
-                static_cast<real_T>
-                (can_decoder_B.BusConversion_InsertedFor_Decod.PAYLOAD.ARG[6]));
-              if (tmp < 65536.0) {
-                if (tmp >= 0.0) {
-                  can_decoder_B.msg_set_current_limit.overload =
-                    static_cast<uint16_T>(tmp);
-                } else {
-                  can_decoder_B.msg_set_current_limit.overload = 0U;
-                }
-              } else {
-                can_decoder_B.msg_set_current_limit.overload = MAX_uint16_T;
-              }
-
-              i = can_decoder_DW.cmd_processed + 1;
-              if (can_decoder_DW.cmd_processed + 1 > 65535) {
-                i = 65535;
-              }
-
-              can_decoder_DW.cmd_processed = static_cast<uint16_T>(i);
-              can_decoder_DW.ev_set_current_limitEventCounte++;
-              can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
+      if ((can_decoder_DW.is_active_DESIRED_CURRENT != 0U) &&
+          (can_decoder_DW.is_DESIRED_CURRENT == 1) && ((arg_pck_rx.available > 0)
+           && (arg_pck_rx.packets.ID.CLS ==
+               CANClassTypes_Motor_Control_Streaming) &&
+           (can_de_safe_cast_to_MCStreaming(arg_pck_rx.packets.ID.DST_TYP) ==
+            static_cast<int32_T>(MCStreaming_Desired_Current)))) {
+        if (arg_pck_rx.packets.PAYLOAD.LEN == 8) {
+          tmp = can_decoder_merge_2bytes(static_cast<real_T>
+            (arg_pck_rx.packets.PAYLOAD.ARG[5]), static_cast<real_T>
+            (arg_pck_rx.packets.PAYLOAD.ARG[6]));
+          if (tmp < 32768.0) {
+            if (tmp >= -32768.0) {
+              can_decoder_B.msg_desired_current.current = static_cast<int16_T>
+                (tmp);
             } else {
-              i = can_decoder_DW.sfEvent;
-              can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
-              if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-                can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
-              }
+              can_decoder_B.msg_desired_current.current = MIN_int16_T;
+            }
+          } else {
+            can_decoder_B.msg_desired_current.current = MAX_int16_T;
+          }
 
-              can_decoder_DW.sfEvent = i;
+          b_previousEvent = can_decoder_DW.cmd_processed + 1;
+          if (can_decoder_DW.cmd_processed + 1 > 65535) {
+            b_previousEvent = 65535;
+          }
+
+          can_decoder_DW.cmd_processed = static_cast<uint16_T>(b_previousEvent);
+          can_decoder_DW.ev_desired_currentEventCounter++;
+          can_decoder_DW.is_DESIRED_CURRENT = can_decoder_IN_Home;
+        } else {
+          b_previousEvent = can_decoder_DW.sfEvent;
+          can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
+          if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
+            can_decoder_ERROR_HANDLING(&arg_pck_rx);
+          }
+
+          can_decoder_DW.sfEvent = b_previousEvent;
+          can_decoder_DW.is_DESIRED_CURRENT = can_decoder_IN_Home;
+        }
+      }
+
+      if ((can_decoder_DW.is_active_SET_CURRENT_LIMIT != 0U) &&
+          (can_decoder_DW.is_SET_CURRENT_LIMIT == 1) && ((arg_pck_rx.available >
+            0) && (arg_pck_rx.packets.ID.CLS ==
+                   CANClassTypes_Motor_Control_Command))) {
+        if (arg_pck_rx.packets.ID.DST_TYP == rtP_CAN_ID_AMC) {
+          if (arg_pck_rx.packets.PAYLOAD.LEN >= 1) {
+            if (arg_pck_rx.packets.PAYLOAD.CMD.OPC == static_cast<int32_T>
+                (MCOPC_Set_Current_Limit)) {
+              if (arg_pck_rx.packets.PAYLOAD.LEN == 8) {
+                can_decoder_B.msg_set_current_limit.motor =
+                  arg_pck_rx.packets.PAYLOAD.CMD.M;
+                tmp = can_decoder_merge_2bytes(static_cast<real_T>
+                  (arg_pck_rx.packets.PAYLOAD.ARG[1]), static_cast<real_T>
+                  (arg_pck_rx.packets.PAYLOAD.ARG[2]));
+                if (tmp < 32768.0) {
+                  if (tmp >= -32768.0) {
+                    can_decoder_B.msg_set_current_limit.nominal =
+                      static_cast<int16_T>(tmp);
+                  } else {
+                    can_decoder_B.msg_set_current_limit.nominal = MIN_int16_T;
+                  }
+                } else {
+                  can_decoder_B.msg_set_current_limit.nominal = MAX_int16_T;
+                }
+
+                tmp = can_decoder_merge_2bytes(static_cast<real_T>
+                  (arg_pck_rx.packets.PAYLOAD.ARG[3]), static_cast<real_T>
+                  (arg_pck_rx.packets.PAYLOAD.ARG[4]));
+                if (tmp < 65536.0) {
+                  if (tmp >= 0.0) {
+                    can_decoder_B.msg_set_current_limit.peak =
+                      static_cast<uint16_T>(tmp);
+                  } else {
+                    can_decoder_B.msg_set_current_limit.peak = 0U;
+                  }
+                } else {
+                  can_decoder_B.msg_set_current_limit.peak = MAX_uint16_T;
+                }
+
+                tmp = can_decoder_merge_2bytes(static_cast<real_T>
+                  (arg_pck_rx.packets.PAYLOAD.ARG[5]), static_cast<real_T>
+                  (arg_pck_rx.packets.PAYLOAD.ARG[6]));
+                if (tmp < 65536.0) {
+                  if (tmp >= 0.0) {
+                    can_decoder_B.msg_set_current_limit.overload = static_cast<
+                      uint16_T>(tmp);
+                  } else {
+                    can_decoder_B.msg_set_current_limit.overload = 0U;
+                  }
+                } else {
+                  can_decoder_B.msg_set_current_limit.overload = MAX_uint16_T;
+                }
+
+                b_previousEvent = can_decoder_DW.cmd_processed + 1;
+                if (can_decoder_DW.cmd_processed + 1 > 65535) {
+                  b_previousEvent = 65535;
+                }
+
+                can_decoder_DW.cmd_processed = static_cast<uint16_T>
+                  (b_previousEvent);
+                can_decoder_DW.ev_set_current_limitEventCounte++;
+                can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
+              } else {
+                b_previousEvent = can_decoder_DW.sfEvent;
+                can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
+                if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
+                  can_decoder_ERROR_HANDLING(&arg_pck_rx);
+                }
+
+                can_decoder_DW.sfEvent = b_previousEvent;
+                can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
+              }
+            } else {
               can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
             }
           } else {
+            b_previousEvent = can_decoder_DW.sfEvent;
+            can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
+            if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
+              can_decoder_ERROR_HANDLING(&arg_pck_rx);
+            }
+
+            can_decoder_DW.sfEvent = b_previousEvent;
             can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
           }
         } else {
-          i = can_decoder_DW.sfEvent;
-          can_decoder_DW.sfEvent = ca_event_ev_error_pck_malformed;
+          b_previousEvent = can_decoder_DW.sfEvent;
+          can_decoder_DW.sfEvent = can_d_event_ev_error_pck_not4us;
           if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-            can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
+            can_decoder_ERROR_HANDLING(&arg_pck_rx);
           }
 
-          can_decoder_DW.sfEvent = i;
+          can_decoder_DW.sfEvent = b_previousEvent;
           can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
         }
-      } else {
-        i = can_decoder_DW.sfEvent;
-        can_decoder_DW.sfEvent = can_d_event_ev_error_pck_not4us;
-        if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-          can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
-        }
-
-        can_decoder_DW.sfEvent = i;
-        can_decoder_DW.is_SET_CURRENT_LIMIT = can_decoder_IN_Home;
       }
-    }
 
-    if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
-      can_decoder_ERROR_HANDLING(rtu_pck_rx_available);
+      if (can_decoder_DW.is_active_ERROR_HANDLING != 0U) {
+        can_decoder_ERROR_HANDLING(&arg_pck_rx);
+      }
     }
 
     if (can_decoder_DW.ev_set_control_modeEventCounter > 0U) {
@@ -539,65 +449,20 @@ namespace can_messaging
     // End of Chart: '<S1>/Decoding Logic'
 
     // BusCreator: '<S1>/Bus Creator1'
-    can_decoder_B.BusCreator1.control_mode = can_decoder_B.ev_set_control_mode;
-    can_decoder_B.BusCreator1.current_limit = can_decoder_B.ev_set_current_limit;
-    can_decoder_B.BusCreator1.desired_current = can_decoder_B.ev_desired_current;
+    arg_events_rx.control_mode = can_decoder_B.ev_set_control_mode;
+    arg_events_rx.current_limit = can_decoder_B.ev_set_current_limit;
+    arg_events_rx.desired_current = can_decoder_B.ev_desired_current;
 
     // BusCreator: '<S1>/Bus Creator2'
-    can_decoder_B.BusCreator2.control_mode = can_decoder_B.msg_set_control_mode;
-    can_decoder_B.BusCreator2.current_limit =
-      can_decoder_B.msg_set_current_limit;
-    can_decoder_B.BusCreator2.desired_current =
-      can_decoder_B.msg_desired_current;
+    arg_messages_rx.control_mode = can_decoder_B.msg_set_control_mode;
+    arg_messages_rx.current_limit = can_decoder_B.msg_set_current_limit;
+    arg_messages_rx.desired_current = can_decoder_B.msg_desired_current;
 
     // BusCreator: '<S1>/Bus Creator3'
-    can_decoder_B.BusCreator3.event = can_decoder_B.ev_error;
-    can_decoder_B.BusCreator3.type = can_decoder_B.error_type;
+    arg_errors_rx.event = can_decoder_B.ev_error;
+    arg_errors_rx.type = can_decoder_B.error_type;
 
     // End of Outputs for SubSystem: '<Root>/CAN_Decoder'
-
-    // SignalConversion generated from: '<Root>/errors_rx'
-    *rty_errors_rx_event = can_decoder_B.BusCreator3.event;
-
-    // SignalConversion generated from: '<Root>/errors_rx'
-    *rty_errors_rx_type = can_decoder_B.BusCreator3.type;
-
-    // SignalConversion generated from: '<Root>/events_rx'
-    *rty_events_rx_control_mode = can_decoder_B.BusCreator1.control_mode;
-
-    // SignalConversion generated from: '<Root>/events_rx'
-    *rty_events_rx_current_limit = can_decoder_B.BusCreator1.current_limit;
-
-    // SignalConversion generated from: '<Root>/events_rx'
-    *rty_events_rx_desired_current = can_decoder_B.BusCreator1.desired_current;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_control_mode_mo =
-      can_decoder_B.BusCreator2.control_mode.motor;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_control_mode__g =
-      can_decoder_B.BusCreator2.control_mode.mode;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_current_limit_m =
-      can_decoder_B.BusCreator2.current_limit.motor;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_current_limit_n =
-      can_decoder_B.BusCreator2.current_limit.nominal;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_current_limit_p =
-      can_decoder_B.BusCreator2.current_limit.peak;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_current_limit_o =
-      can_decoder_B.BusCreator2.current_limit.overload;
-
-    // SignalConversion generated from: '<Root>/messages_rx'
-    *rty_messages_rx_desired_current =
-      can_decoder_B.BusCreator2.desired_current.current;
   }
 
   // Constructor

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -40,13 +40,9 @@ namespace can_messaging
    public:
     // Block signals for model 'can_decoder'
     struct B_can_decoder_T {
-      BUS_CAN_PACKET_RX BusConversion_InsertedFor_Decod;
-      BUS_MESSAGES_RX BusCreator2;     // '<S1>/Bus Creator2'
       BUS_MSG_DESIRED_CURRENT msg_desired_current;// '<S1>/Decoding Logic'
       BUS_MSG_CURRENT_LIMIT msg_set_current_limit;// '<S1>/Decoding Logic'
       BUS_MSG_CONTROL_MODE msg_set_control_mode;// '<S1>/Decoding Logic'
-      BUS_EVENTS_RX BusCreator1;       // '<S1>/Bus Creator1'
-      BUS_CAN_RX_ERRORS BusCreator3;   // '<S1>/Bus Creator3'
       CANErrorTypes error_type;        // '<S1>/Decoding Logic'
       boolean_T ev_set_control_mode;   // '<S1>/Decoding Logic'
       boolean_T ev_set_current_limit;  // '<S1>/Decoding Logic'
@@ -62,6 +58,7 @@ namespace can_messaging
       uint32_T ev_desired_currentEventCounter;// '<S1>/Decoding Logic'
       uint32_T ev_errorEventCounter;   // '<S1>/Decoding Logic'
       uint16_T cmd_processed;          // '<S1>/Decoding Logic'
+      uint8_T is_active_c3_can_decoder;// '<S1>/Decoding Logic'
       uint8_T is_SET_CONTROL_MODE;     // '<S1>/Decoding Logic'
       uint8_T is_active_SET_CONTROL_MODE;// '<S1>/Decoding Logic'
       uint8_T is_DESIRED_CURRENT;      // '<S1>/Decoding Logic'
@@ -70,6 +67,7 @@ namespace can_messaging
       uint8_T is_active_SET_CURRENT_LIMIT;// '<S1>/Decoding Logic'
       uint8_T is_ERROR_HANDLING;       // '<S1>/Decoding Logic'
       uint8_T is_active_ERROR_HANDLING;// '<S1>/Decoding Logic'
+      boolean_T ev_async;              // '<S1>/Decoding Logic'
     };
 
     // Real-time Model Data Structure
@@ -84,38 +82,12 @@ namespace can_messaging
     DW_can_decoder_T can_decoder_DW;
 
     // model step function
-    void step(const uint8_T *rtu_pck_rx_available, const CANClassTypes
-              *rtu_pck_rx_packets_ID_CLS, const uint8_T
-              *rtu_pck_rx_packets_ID_SRC, const uint8_T
-              *rtu_pck_rx_packets_ID_DST_TYP, const uint8_T
-              *rtu_pck_rx_packets_PAYLOAD_LEN, const boolean_T
-              *rtu_pck_rx_packets_PAYLOAD_CMD_, const uint8_T
-              *rtu_pck_rx_packets_PAYLOAD_CM_k, const uint8_T
-              rtu_pck_rx_packets_PAYLOAD_ARG[7], boolean_T
-              *rty_messages_rx_control_mode_mo, MCControlModes
-              *rty_messages_rx_control_mode__g, boolean_T
-              *rty_messages_rx_current_limit_m, int16_T
-              *rty_messages_rx_current_limit_n, uint16_T
-              *rty_messages_rx_current_limit_p, uint16_T
-              *rty_messages_rx_current_limit_o, int16_T
-              *rty_messages_rx_desired_current, boolean_T
-              *rty_events_rx_control_mode, boolean_T
-              *rty_events_rx_current_limit, boolean_T
-              *rty_events_rx_desired_current, boolean_T *rty_errors_rx_event,
-              CANErrorTypes *rty_errors_rx_type);
+    void step(const BUS_CAN_RX &arg_pck_rx, BUS_MESSAGES_RX &arg_messages_rx,
+              BUS_EVENTS_RX &arg_events_rx, BUS_CAN_RX_ERRORS &arg_errors_rx);
 
     // Initial conditions function
-    void init(boolean_T *rty_messages_rx_control_mode_mo, MCControlModes
-              *rty_messages_rx_control_mode__g, boolean_T
-              *rty_messages_rx_current_limit_m, int16_T
-              *rty_messages_rx_current_limit_n, uint16_T
-              *rty_messages_rx_current_limit_p, uint16_T
-              *rty_messages_rx_current_limit_o, int16_T
-              *rty_messages_rx_desired_current, boolean_T
-              *rty_events_rx_control_mode, boolean_T
-              *rty_events_rx_current_limit, boolean_T
-              *rty_events_rx_desired_current, boolean_T *rty_errors_rx_event,
-              CANErrorTypes *rty_errors_rx_type);
+    void init(BUS_MESSAGES_RX *arg_messages_rx, BUS_EVENTS_RX *arg_events_rx,
+              BUS_CAN_RX_ERRORS *arg_errors_rx);
 
     // Constructor
     CAN_Decoder();
@@ -137,7 +109,7 @@ namespace can_messaging
     // private member function(s) for subsystem '<Root>/TmpModelReferenceSubsystem'
     int32_T can_de_safe_cast_to_MCStreaming(int32_T input);
     real_T can_decoder_merge_2bytes(real_T bl, real_T bh);
-    void can_decoder_ERROR_HANDLING(const uint8_T *rtu_pck_rx_available);
+    void can_decoder_ERROR_HANDLING(const BUS_CAN_RX *arg_pck_rx);
     real_T can_d_is_controlmode_recognized(real_T mode);
     int32_T can_safe_cast_to_MCControlModes(int32_T input);
   };

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-decoder/can_decoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.315
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:17 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -22,104 +22,100 @@
 namespace can_messaging
 {
   // Output and update for referenced model: 'can_encoder'
-  void CAN_Encoder::step(const real32_T *rtu_messages_tx_foc_current, const
-    real32_T *rtu_messages_tx_foc_position, const real32_T
-    *rtu_messages_tx_foc_velocity, const boolean_T *rtu_events_tx_foc, uint8_T
-    *rty_pck_tx_available, uint16_T *rty_pck_tx_packets_ID, uint8_T
-    rty_pck_tx_packets_PAYLOAD[8])
+  void CAN_Encoder::step(const BUS_MESSAGES_TX &arg_messages_tx, const
+    BUS_EVENTS_TX &arg_events_tx, BUS_CAN &arg_pck_tx)
   {
     int32_T rtb_DataTypeConversion2;
-    real32_T rtb_Gain;
+    real32_T u;
     int16_T rtb_DataTypeConversion1;
     int16_T rtb_DataTypeConversion3;
 
     // Outputs for Atomic SubSystem: '<Root>/CAN_Encoder'
     // DataTypeConversion: '<S1>/Data Type Conversion1'
-    rtb_Gain = *rtu_messages_tx_foc_current;
-    if (rtb_Gain < 0.0F) {
-      rtb_Gain = std::ceil(rtb_Gain);
+    if (arg_messages_tx.foc.current < 0.0F) {
+      u = std::ceil(arg_messages_tx.foc.current);
     } else {
-      rtb_Gain = std::floor(rtb_Gain);
+      u = std::floor(arg_messages_tx.foc.current);
     }
 
-    if (rtIsNaNF(rtb_Gain) || rtIsInfF(rtb_Gain)) {
-      rtb_Gain = 0.0F;
+    if (rtIsNaNF(u) || rtIsInfF(u)) {
+      u = 0.0F;
     } else {
-      rtb_Gain = std::fmod(rtb_Gain, 65536.0F);
+      u = std::fmod(u, 65536.0F);
     }
 
-    rtb_DataTypeConversion1 = static_cast<int16_T>(rtb_Gain < 0.0F ?
-      static_cast<int32_T>(static_cast<int16_T>(-static_cast<int16_T>(
-      static_cast<uint16_T>(-rtb_Gain)))) : static_cast<int32_T>
-      (static_cast<int16_T>(static_cast<uint16_T>(rtb_Gain))));
+    rtb_DataTypeConversion1 = static_cast<int16_T>(u < 0.0F ? static_cast<
+      int32_T>(static_cast<int16_T>(-static_cast<int16_T>(static_cast<uint16_T>(
+      -u)))) : static_cast<int32_T>(static_cast<int16_T>(static_cast<uint16_T>(u))));
 
     // End of DataTypeConversion: '<S1>/Data Type Conversion1'
 
-    // Gain: '<S1>/Gain1'
-    rtb_Gain = rtP_CAN_ANGLE_DEG2ICUB * *rtu_messages_tx_foc_position;
-
-    // DataTypeConversion: '<S1>/Data Type Conversion2'
-    if (rtb_Gain < 0.0F) {
-      rtb_Gain = std::ceil(rtb_Gain);
-    } else {
-      rtb_Gain = std::floor(rtb_Gain);
-    }
-
-    if (rtIsNaNF(rtb_Gain) || rtIsInfF(rtb_Gain)) {
-      rtb_Gain = 0.0F;
-    } else {
-      rtb_Gain = std::fmod(rtb_Gain, 4.2949673E+9F);
-    }
-
-    rtb_DataTypeConversion2 = rtb_Gain < 0.0F ? -static_cast<int32_T>(
-      static_cast<uint32_T>(-rtb_Gain)) : static_cast<int32_T>
-      (static_cast<uint32_T>(rtb_Gain));
-
-    // End of DataTypeConversion: '<S1>/Data Type Conversion2'
-
     // Gain: '<S1>/Gain'
-    rtb_Gain = rtP_CAN_ANGLE_DEG2ICUB * *rtu_messages_tx_foc_velocity;
+    u = rtP_CAN_ANGLE_DEG2ICUB * arg_messages_tx.foc.velocity;
 
     // DataTypeConversion: '<S1>/Data Type Conversion3'
-    if (rtb_Gain < 0.0F) {
-      rtb_Gain = std::ceil(rtb_Gain);
+    if (u < 0.0F) {
+      u = std::ceil(u);
     } else {
-      rtb_Gain = std::floor(rtb_Gain);
+      u = std::floor(u);
     }
 
-    if (rtIsNaNF(rtb_Gain) || rtIsInfF(rtb_Gain)) {
-      rtb_Gain = 0.0F;
+    if (rtIsNaNF(u) || rtIsInfF(u)) {
+      u = 0.0F;
     } else {
-      rtb_Gain = std::fmod(rtb_Gain, 65536.0F);
+      u = std::fmod(u, 65536.0F);
     }
 
-    rtb_DataTypeConversion3 = static_cast<int16_T>(rtb_Gain < 0.0F ?
+    rtb_DataTypeConversion3 = static_cast<int16_T>(u < 0.0F ?
       static_cast<int32_T>(static_cast<int16_T>(-static_cast<int16_T>(
-      static_cast<uint16_T>(-rtb_Gain)))) : static_cast<int32_T>
-      (static_cast<int16_T>(static_cast<uint16_T>(rtb_Gain))));
+      static_cast<uint16_T>(-u)))) : static_cast<int32_T>(static_cast<int16_T>(
+      static_cast<uint16_T>(u))));
 
     // End of DataTypeConversion: '<S1>/Data Type Conversion3'
 
+    // Gain: '<S1>/Gain1'
+    u = rtP_CAN_ANGLE_DEG2ICUB * arg_messages_tx.foc.position;
+
+    // DataTypeConversion: '<S1>/Data Type Conversion2'
+    if (u < 0.0F) {
+      u = std::ceil(u);
+    } else {
+      u = std::floor(u);
+    }
+
+    if (rtIsNaNF(u) || rtIsInfF(u)) {
+      u = 0.0F;
+    } else {
+      u = std::fmod(u, 4.2949673E+9F);
+    }
+
+    rtb_DataTypeConversion2 = u < 0.0F ? -static_cast<int32_T>
+      (static_cast<uint32_T>(-u)) : static_cast<int32_T>(static_cast<uint32_T>(u));
+
+    // End of DataTypeConversion: '<S1>/Data Type Conversion2'
+
     // MATLAB Function: '<S1>/MATLAB Function'
-    rty_pck_tx_packets_PAYLOAD[0] = static_cast<uint8_T>(rtb_DataTypeConversion1
+    arg_pck_tx.packets.PAYLOAD[0] = static_cast<uint8_T>(rtb_DataTypeConversion1
       & 255);
-    rty_pck_tx_packets_PAYLOAD[1] = static_cast<uint8_T>
+    arg_pck_tx.packets.PAYLOAD[1] = static_cast<uint8_T>
       ((rtb_DataTypeConversion1 & 32767) >> 8);
-    rty_pck_tx_packets_PAYLOAD[2] = static_cast<uint8_T>(rtb_DataTypeConversion3
+    arg_pck_tx.packets.PAYLOAD[2] = static_cast<uint8_T>(rtb_DataTypeConversion3
       & 255);
-    rty_pck_tx_packets_PAYLOAD[3] = static_cast<uint8_T>
+    arg_pck_tx.packets.PAYLOAD[3] = static_cast<uint8_T>
       ((rtb_DataTypeConversion3 & 32767) >> 8);
-    rty_pck_tx_packets_PAYLOAD[4] = static_cast<uint8_T>(rtb_DataTypeConversion2
+    arg_pck_tx.packets.PAYLOAD[4] = static_cast<uint8_T>(rtb_DataTypeConversion2
       & 255);
-    rty_pck_tx_packets_PAYLOAD[5] = static_cast<uint8_T>
+    arg_pck_tx.packets.PAYLOAD[5] = static_cast<uint8_T>
       ((rtb_DataTypeConversion2 & 65280) >> 8);
-    rty_pck_tx_packets_PAYLOAD[6] = static_cast<uint8_T>
+    arg_pck_tx.packets.PAYLOAD[6] = static_cast<uint8_T>
       ((rtb_DataTypeConversion2 & 16711680) >> 16);
-    rty_pck_tx_packets_PAYLOAD[7] = static_cast<uint8_T>
+    arg_pck_tx.packets.PAYLOAD[7] = static_cast<uint8_T>
       ((rtb_DataTypeConversion2 & MAX_int32_T) >> 24);
 
-    // Constant: '<S1>/Constant'
-    *rty_pck_tx_packets_ID = rtP_CAN_ID_HOST;
+    // BusCreator: '<S1>/Bus Creator1' incorporates:
+    //   Constant: '<S1>/Constant'
+
+    arg_pck_tx.packets.ID = rtP_CAN_ID_HOST;
 
     // DataTypeConversion: '<S1>/Data Type Conversion' incorporates:
     //   RelationalOperator: '<S2>/FixPt Relational Operator'
@@ -129,8 +125,13 @@ namespace can_messaging
     //
     //   Store in Global RAM
 
-    *rty_pck_tx_available = (*rtu_events_tx_foc !=
+    arg_pck_tx.available = (arg_events_tx.foc !=
       can_encoder_DW.DelayInput1_DSTATE);
+
+    // BusCreator: '<S1>/Bus Creator' incorporates:
+    //   Constant: '<S1>/lengths'
+
+    arg_pck_tx.lengths = 8U;
 
     // Update for UnitDelay: '<S2>/Delay Input1'
     //
@@ -138,7 +139,7 @@ namespace can_messaging
     //
     //   Store in Global RAM
 
-    can_encoder_DW.DelayInput1_DSTATE = *rtu_events_tx_foc;
+    can_encoder_DW.DelayInput1_DSTATE = arg_events_tx.foc;
 
     // End of Outputs for SubSystem: '<Root>/CAN_Encoder'
   }

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.315
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:17 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -48,11 +48,6 @@ namespace can_messaging
       boolean_T DelayInput1_DSTATE;    // '<S2>/Delay Input1'
     };
 
-    // Invariant block signals for model 'can_encoder'
-    struct ConstB_can_encoder_h_T {
-      uint8_T lengths;                 // '<S1>/lengths'
-    };
-
     // Real-time Model Data Structure
     struct RT_MODEL_can_encoder_T {
       const char_T **errorStatus;
@@ -65,11 +60,8 @@ namespace can_messaging
     void initialize();
 
     // model step function
-    void step(const real32_T *rtu_messages_tx_foc_current, const real32_T
-              *rtu_messages_tx_foc_position, const real32_T
-              *rtu_messages_tx_foc_velocity, const boolean_T *rtu_events_tx_foc,
-              uint8_T *rty_pck_tx_available, uint16_T *rty_pck_tx_packets_ID,
-              uint8_T rty_pck_tx_packets_PAYLOAD[8]);
+    void step(const BUS_MESSAGES_TX &arg_messages_tx, const BUS_EVENTS_TX &
+              arg_events_tx, BUS_CAN &arg_pck_tx);
 
     // Constructor
     CAN_Encoder();
@@ -89,10 +81,6 @@ namespace can_messaging
     RT_MODEL_can_encoder_T can_encoder_M;
   };
 }
-
-// Invariant block signals (default storage)
-extern const can_messaging::CAN_Encoder::ConstB_can_encoder_h_T
-  can_encoder_ConstB;
 
 //-
 //  The generated code includes comments that allow you to trace directly

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.315
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:17 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.315
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:17 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 1.310
+// Model version                  : 1.315
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:51 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:51 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -40,101 +40,53 @@ namespace can_messaging
 namespace can_messaging
 {
   // Output and update for referenced model: 'can_rx_raw2struct'
-  void CAN_RX_raw2struct::step(const uint8_T *rtu_pck_rx_raw_available, const
-    uint8_T *rtu_pck_rx_raw_lengths, const uint16_T *rtu_pck_rx_raw_packets_ID,
-    const uint8_T rtu_pck_rx_raw_packets_PAYLOAD[8], uint8_T
-    *rty_pck_rx_struct_available, CANClassTypes *rty_pck_rx_struct_packets_ID_CL,
-    uint8_T *rty_pck_rx_struct_packets_ID_SR, uint8_T
-    *rty_pck_rx_struct_packets_ID_DS, uint8_T *rty_pck_rx_struct_packets_PAYLO,
-    boolean_T *rty_pck_rx_struct_packets_PAY_f, uint8_T
-    *rty_pck_rx_struct_packets_PAY_k, uint8_T rty_pck_rx_struct_packets_PAY_h[7])
+  void CAN_RX_raw2struct::step(const BUS_CAN &arg_pck_rx_raw, BUS_CAN_RX &
+    arg_pck_rx_struct)
   {
     int32_T i;
     uint32_T qY;
-    uint8_T rtb_BusConversion_InsertedFor_0;
-    uint8_T varargin_1_idx_1;
+    uint8_T minval;
 
     // Outputs for Atomic SubSystem: '<Root>/CAN_RX_RAW2STRUCT'
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   BusCreator generated from: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_available = *rtu_pck_rx_raw_available;
-
-    // MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic' incorporates:
-    //   BusCreator generated from: '<S1>/RAW2STRUCT Decoding Logic'
-
-    varargin_1_idx_1 = *rtu_pck_rx_raw_lengths;
-    rtb_BusConversion_InsertedFor_0 = 8U;
-    if (8 > varargin_1_idx_1) {
-      rtb_BusConversion_InsertedFor_0 = varargin_1_idx_1;
+    // MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
+    arg_pck_rx_struct.available = arg_pck_rx_raw.available;
+    arg_pck_rx_struct.packets.ID.CLS = c_convert_to_enum_CANClassTypes(
+      static_cast<int32_T>(static_cast<uint16_T>(static_cast<uint32_T>
+      (arg_pck_rx_raw.packets.ID & 1792) >> 8)));
+    arg_pck_rx_struct.packets.ID.SRC = static_cast<uint8_T>(static_cast<uint32_T>
+      (arg_pck_rx_raw.packets.ID & 240) >> 4);
+    arg_pck_rx_struct.packets.ID.DST_TYP = static_cast<uint8_T>
+      (arg_pck_rx_raw.packets.ID & 15);
+    minval = 8U;
+    if (8 > arg_pck_rx_raw.lengths) {
+      minval = arg_pck_rx_raw.lengths;
     }
 
-    varargin_1_idx_1 = rtb_BusConversion_InsertedFor_0;
-    rtb_BusConversion_InsertedFor_0 = 0U;
-    if (0 < varargin_1_idx_1) {
-      rtb_BusConversion_InsertedFor_0 = varargin_1_idx_1;
+    arg_pck_rx_struct.packets.PAYLOAD.LEN = 0U;
+    if (0 < minval) {
+      arg_pck_rx_struct.packets.PAYLOAD.LEN = minval;
     }
 
+    arg_pck_rx_struct.packets.PAYLOAD.CMD.M = ((arg_pck_rx_raw.packets.PAYLOAD[0]
+      & 128U) != 0U);
+    arg_pck_rx_struct.packets.PAYLOAD.CMD.OPC = static_cast<uint8_T>
+      (arg_pck_rx_raw.packets.PAYLOAD[0] & 127);
     for (i = 0; i < 7; i++) {
-      // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-      //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-      rty_pck_rx_struct_packets_PAY_h[i] = 0U;
+      arg_pck_rx_struct.packets.PAYLOAD.ARG[i] = 0U;
     }
 
-    // MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic' incorporates:
-    //   BusCreator generated from: '<S1>/RAW2STRUCT Decoding Logic'
-    //   SignalConversion generated from: '<Root>/pck_rx_struct'
-
-    qY = rtb_BusConversion_InsertedFor_0 - 1U;
-    if (rtb_BusConversion_InsertedFor_0 - 1U > rtb_BusConversion_InsertedFor_0)
-    {
+    qY = arg_pck_rx_struct.packets.PAYLOAD.LEN - 1U;
+    if (arg_pck_rx_struct.packets.PAYLOAD.LEN - 1U >
+        arg_pck_rx_struct.packets.PAYLOAD.LEN) {
       qY = 0U;
     }
 
     for (i = 1; i - 1 < static_cast<uint8_T>(qY); i++) {
-      rty_pck_rx_struct_packets_PAY_h[static_cast<uint8_T>(i) - 1] =
-        rtu_pck_rx_raw_packets_PAYLOAD[static_cast<uint8_T>(i)];
+      arg_pck_rx_struct.packets.PAYLOAD.ARG[static_cast<uint8_T>(i) - 1] =
+        arg_pck_rx_raw.packets.PAYLOAD[static_cast<uint8_T>(i)];
     }
 
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_packets_ID_CL = c_convert_to_enum_CANClassTypes(
-      static_cast<int32_T>(static_cast<uint16_T>(static_cast<uint32_T>
-      (*rtu_pck_rx_raw_packets_ID & 1792) >> 8)));
-
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_packets_ID_SR = static_cast<uint8_T>(static_cast<uint32_T>
-      (*rtu_pck_rx_raw_packets_ID & 240) >> 4);
-
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_packets_ID_DS = static_cast<uint8_T>
-      (*rtu_pck_rx_raw_packets_ID & 15);
-
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_packets_PAYLO = rtb_BusConversion_InsertedFor_0;
-
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   BusCreator generated from: '<S1>/RAW2STRUCT Decoding Logic'
-    //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_packets_PAY_f = ((rtu_pck_rx_raw_packets_PAYLOAD[0] &
-      128U) != 0U);
-
-    // SignalConversion generated from: '<Root>/pck_rx_struct' incorporates:
-    //   BusCreator generated from: '<S1>/RAW2STRUCT Decoding Logic'
-    //   MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
-
-    *rty_pck_rx_struct_packets_PAY_k = static_cast<uint8_T>
-      (rtu_pck_rx_raw_packets_PAYLOAD[0] & 127);
-
+    // End of MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'
     // End of Outputs for SubSystem: '<Root>/CAN_RX_RAW2STRUCT'
   }
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 1.310
+// Model version                  : 1.315
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:51 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:51 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -36,17 +36,7 @@ namespace can_messaging
     };
 
     // model step function
-    void step(const uint8_T *rtu_pck_rx_raw_available, const uint8_T
-              *rtu_pck_rx_raw_lengths, const uint16_T *rtu_pck_rx_raw_packets_ID,
-              const uint8_T rtu_pck_rx_raw_packets_PAYLOAD[8], uint8_T
-              *rty_pck_rx_struct_available, CANClassTypes
-              *rty_pck_rx_struct_packets_ID_CL, uint8_T
-              *rty_pck_rx_struct_packets_ID_SR, uint8_T
-              *rty_pck_rx_struct_packets_ID_DS, uint8_T
-              *rty_pck_rx_struct_packets_PAYLO, boolean_T
-              *rty_pck_rx_struct_packets_PAY_f, uint8_T
-              *rty_pck_rx_struct_packets_PAY_k, uint8_T
-              rty_pck_rx_struct_packets_PAY_h[7]);
+    void step(const BUS_CAN &arg_pck_rx_raw, BUS_CAN_RX &arg_pck_rx_struct);
 
     // Constructor
     CAN_RX_raw2struct();

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 1.310
+// Model version                  : 1.315
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:51 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:51 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-raw2struct/can_rx_raw2struct_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 1.310
+// Model version                  : 1.315
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:51 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:51 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/Double2MultiWord.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/Double2MultiWord.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #include "rtwtypes.h"
 #include "div_s32.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/Double2MultiWord.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/Double2MultiWord.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #ifndef RTW_HEADER_Double2MultiWord_h_
 #define RTW_HEADER_Double2MultiWord_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/MultiWordIor.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/MultiWordIor.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #include "rtwtypes.h"
 #include "MultiWordIor.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/MultiWordIor.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/MultiWordIor.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #ifndef RTW_HEADER_MultiWordIor_h_
 #define RTW_HEADER_MultiWordIor_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/const_params.cpp
@@ -1,0 +1,18 @@
+//
+//  const_params.cpp
+//
+//  Non-Degree Granting Education License -- for use at non-degree
+//  granting, nonprofit, educational organizations only. Not for
+//  government, commercial, or other organizational use.
+//
+//  Code generation for model "control_foc".
+//
+//  Model version              : 1.128
+//  Simulink Coder version : 9.5 (R2021a) 14-Nov-2020
+//  C++ source code generated on : Mon Sep 20 12:43:59 2021
+
+#include "rtwtypes.h"
+
+extern const real32_T rtCP_pooled_UMvRVJ73F4lr[6];
+const real32_T rtCP_pooled_UMvRVJ73F4lr[6] = { 0.666666687F, -0.333333343F,
+  -0.333333343F, 0.666666687F, -0.333333343F, -0.333333343F } ;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/div_s32.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/div_s32.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #include "rtwtypes.h"
 #include "div_s32.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/div_s32.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/div_s32.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #ifndef RTW_HEADER_div_s32_h_
 #define RTW_HEADER_div_s32_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/multiword_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/multiword_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #ifndef MULTIWORD_TYPES_H
 #define MULTIWORD_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/mw_cmsis.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/mw_cmsis.h
@@ -1,0 +1,84 @@
+/* Copyright 2015 The MathWorks, Inc. */
+
+/****************************************************
+*                                                   *   
+* wrapper fuctions for CMSIS  functions             *
+*                                                   *  
+****************************************************/
+
+#ifndef MW_CMSIS_H
+#define MW_CMSIS_H
+
+#include "arm_math.h"
+#include "rtwtypes.h"
+
+#define mw_arm_abs_f32(pSrc, pDst, blockSize) arm_abs_f32((float32_t *)pSrc, (float32_t *)pDst, blockSize)
+#define mw_arm_abs_q7(pSrc, pDst, blockSize) arm_abs_q7((q7_t *)pSrc, (q7_t *)pDst, blockSize) 
+#define mw_arm_abs_q15(pSrc, pDst, blockSize) arm_abs_q15((q15_t *)pSrc, (q15_t *)pDst, blockSize) 
+#define mw_arm_abs_q31(pSrc, pDst, blockSize) arm_abs_q31((q31_t *)pSrc, (q31_t *)pDst, blockSize) 
+
+#define mw_arm_sqrt_q15(in, pOut) arm_sqrt_q15((q15_t)in,(q15_t *)pOut)
+#define mw_arm_sqrt_q31(in, pOut) arm_sqrt_q31((q31_t)in,(q31_t *)pOut)
+#define mw_arm_sqrt_f32(in, pOut) arm_sqrt_f32((float32_t)in,(float32_t *)pOut)
+
+#define mw_arm_float_to_q31(pSrc, pDst, blockSize) arm_float_to_q31((float32_t *)pSrc, (q31_t *)pDst, blockSize)
+#define mw_arm_float_to_q15(pSrc, pDst, blockSize) arm_float_to_q15((float32_t *)pSrc, (q15_t *)pDst, blockSize)
+#define mw_arm_float_to_q7(pSrc, pDst, blockSize) arm_float_to_q7((float32_t *)pSrc, (q7_t *)pDst, blockSize)
+
+#define mw_arm_q15_to_float(pSrc, pDst, blockSize) arm_q15_to_float((q15_t *)pSrc, (float32_t *)pDst, blockSize)
+#define mw_arm_q15_to_q31(pSrc, pDst, blockSize) arm_q15_to_q31((q15_t *)pSrc, (q31_t *)pDst, blockSize)
+#define mw_arm_q15_to_q7(pSrc, pDst, blockSize) arm_q15_to_q7((q15_t *)pSrc, (q7_t *)pDst, blockSize)
+
+#define mw_arm_q31_to_float(pSrc, pDst, blockSize) arm_q31_to_float((q31_t *)pSrc, (float32_t *)pDst, blockSize)
+#define mw_arm_q31_to_q15(pSrc, pDst, blockSize) arm_q31_to_q15((q31_t *)pSrc, (q15_t *)pDst, blockSize)
+#define mw_arm_q31_to_q7(pSrc, pDst, blockSize) arm_q31_to_q7((q31_t *)pSrc, (q7_t *)pDst, blockSize)
+
+#define mw_arm_q7_to_float(pSrc, pDst, blockSize) arm_q7_to_float((q7_t *)pSrc, (float32_t *)pDst, blockSize)
+#define mw_arm_q7_to_q31(pSrc, pDst, blockSize) arm_q7_to_q31((q7_t *)pSrc, (q31_t *)pDst, blockSize)
+#define mw_arm_q7_to_q15(pSrc, pDst, blockSize) arm_q7_to_q15((q7_t *)pSrc, (q15_t *)pDst, blockSize)
+
+#define mw_arm_add_f32(pSrcA, pSrcB, pDst, blockSize) arm_add_f32((float32_t *)pSrcA, (float32_t *)pSrcB, (float32_t *)pDst, blockSize)
+#define mw_arm_add_q31(pSrcA, pSrcB, pDst, blockSize) arm_add_q31((q31_t *)pSrcA, (q31_t *)pSrcB, (q31_t *)pDst, blockSize)
+#define mw_arm_add_q15(pSrcA, pSrcB, pDst, blockSize) arm_add_q15((q15_t *)pSrcA, (q15_t *)pSrcB, (q15_t *)pDst, blockSize)
+#define mw_arm_add_q7(pSrcA, pSrcB, pDst, blockSize)  arm_add_q7((q7_t *)pSrcA, (q7_t *)pSrcB, (q7_t *)pDst, blockSize)
+
+#define mw_arm_sub_f32(pSrcA, pSrcB, pDst, blockSize) arm_sub_f32((float32_t *)pSrcA, (float32_t *)pSrcB, (float32_t *)pDst, blockSize)
+#define mw_arm_sub_q31(pSrcA, pSrcB, pDst, blockSize) arm_sub_q31((q31_t *)pSrcA, (q31_t *)pSrcB, (q31_t *)pDst, blockSize)
+#define mw_arm_sub_q15(pSrcA, pSrcB, pDst, blockSize) arm_sub_q15((q15_t *)pSrcA, (q15_t *)pSrcB, (q15_t *)pDst, blockSize)
+#define mw_arm_sub_q7(pSrcA, pSrcB, pDst, blockSize)  arm_sub_q7((q7_t *)pSrcA, (q7_t *)pSrcB, (q7_t *)pDst, blockSize)
+
+#define mw_arm_mult_f32(pSrcA, pSrcB, pDst, blockSize) arm_mult_f32((float32_t *)pSrcA, (float32_t *)pSrcB, (float32_t *)pDst, blockSize)
+#define mw_arm_mult_q31(pSrcA, pSrcB, pDst, blockSize) arm_mult_q31((q31_t *)pSrcA, (q31_t *)pSrcB, (q31_t *)pDst, blockSize)
+#define mw_arm_mult_q15(pSrcA, pSrcB, pDst, blockSize) arm_mult_q15((q15_t *)pSrcA, (q15_t *)pSrcB, (q15_t *)pDst, blockSize)
+#define mw_arm_mult_q7(pSrcA, pSrcB, pDst, blockSize)  arm_mult_q7((q7_t *)pSrcA, (q7_t *)pSrcB, (q7_t *)pDst, blockSize)
+
+#define mw_arm_cmplx_conj_f32(pSrc, pDst, numSamples) arm_cmplx_conj_f32((float32_t *)pSrc, (float32_t *)pDst, numSamples)
+#define mw_arm_cmplx_conj_q31(pSrc, pDst, numSamples) arm_cmplx_conj_q31((q31_t *)pSrc, (q31_t *)pDst, numSamples)
+#define mw_arm_cmplx_conj_q15(pSrc, pDst, numSamples) arm_cmplx_conj_q15((q15_t *)pSrc, (q15_t *)pDst, numSamples)
+
+#define mw_arm_cmplx_mult_cmplx_f32(pSrcA, pSrcB, pDst, blockSize) arm_cmplx_mult_cmplx_f32((float32_t *)pSrcA, (float32_t *)pSrcB, (float32_t *)pDst, blockSize)
+#define mw_arm_cmplx_mult_cmplx_q31(pSrcA, pSrcB, pDst, blockSize) arm_cmplx_mult_cmplx_q31((q31_t *)pSrcA, (q31_t *)pSrcB, (q31_t *)pDst, blockSize)
+#define mw_arm_cmplx_mult_cmplx_q15(pSrcA, pSrcB, pDst, blockSize) arm_cmplx_mult_cmplx_q15((q15_t *)pSrcA, (q15_t *)pSrcB, (q15_t *)pDst, blockSize)
+
+#define mw_arm_cmplx_mult_real_f32(pSrcA, pSrcB, pDst, blockSize) arm_cmplx_mult_real_f32((float32_t *)pSrcA, (float32_t *)pSrcB, (float32_t *)pDst, blockSize)
+#define mw_arm_cmplx_mult_real_q31(pSrcA, pSrcB, pDst, blockSize) arm_cmplx_mult_real_q31((q31_t *)pSrcA, (q31_t *)pSrcB, (q31_t *)pDst, blockSize)
+#define mw_arm_cmplx_mult_real_q15(pSrcA, pSrcB, pDst, blockSize) arm_cmplx_mult_real_q15((q15_t *)pSrcA, (q15_t *)pSrcB, (q15_t *)pDst, blockSize)
+
+#define mw_arm_rshift_q15(pSrc, shiftBits, pDst, blockSize) arm_shift_q15 ((q15_t *)pSrc, -(shiftBits),(q15_t *)pDst, blockSize)
+#define mw_arm_rshift_q31(pSrc, shiftBits, pDst, blockSize) arm_shift_q31 ((q31_t *)pSrc, -(shiftBits), (q31_t *)pDst, blockSize)
+#define mw_arm_rshift_q7(pSrc, shiftBits, pDst, blockSize) arm_shift_q7 ((q7_t *)pSrc,  -(shiftBits), (q7_t *)pDst, blockSize)
+
+#define mw_arm_shift_q15(pSrc, shiftBits, pDst, blockSize) arm_shift_q15 ((q15_t *)pSrc, shiftBits,(q15_t *)pDst, blockSize)
+#define mw_arm_shift_q31(pSrc, shiftBits, pDst, blockSize) arm_shift_q31 ((q31_t *)pSrc, shiftBits, (q31_t *)pDst, blockSize)
+#define mw_arm_shift_q7(pSrc, shiftBits, pDst, blockSize) arm_shift_q7 ((q7_t *)pSrc, shiftBits, (q7_t *)pDst, blockSize)
+
+/* Wrapper function prototypes for Matrix Addition */
+void mw_arm_mat_add_f32(real32_T * pSrcA, real32_T * pSrcB, real32_T * pDst, uint16_t nRows, uint16_t nCols);
+void mw_arm_mat_add_q15(int16_T * pSrcA, int16_T * pSrcB, int16_T * pDst, uint16_t nRows, uint16_t nCols);
+void mw_arm_mat_add_q31(int32_T * pSrcA, int32_T * pSrcB, int32_T * pDst, uint16_t nRows, uint16_t nCols);
+/* Wrapper function prototypes for Matrix Subtraction */
+void mw_arm_mat_sub_f32(real32_T * pSrcA, real32_T * pSrcB, real32_T * pDst, uint16_t nRows, uint16_t nCols);
+void mw_arm_mat_sub_q15(int16_T * pSrcA, int16_T * pSrcB, int16_T * pDst, uint16_t nRows, uint16_t nCols);
+void mw_arm_mat_sub_q31(int32_T * pSrcA, int32_T * pSrcB, int32_T * pDst, uint16_t nRows, uint16_t nCols);
+
+#endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.314
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:44 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetInf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.314
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:44 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.314
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:44 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtGetNaN.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.314
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:44 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.314
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:44 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.314
+// Model version                  : 1.322
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:44 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 2.33
+// Model version                  : 2.44
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:15 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:16 2021
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWord2Double.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWord2Double.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #include "rtwtypes.h"
 #include <cmath>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWord2Double.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWord2Double.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #ifndef RTW_HEADER_uMultiWord2Double_h_
 #define RTW_HEADER_uMultiWord2Double_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWordShl.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWordShl.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #include "rtwtypes.h"
 #include "uMultiWordShl.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWordShl.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/uMultiWordShl.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 1.267
+// Model version                  : 1.280
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Tue Jul 20 13:35:37 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:37 2021
 //
 #ifndef RTW_HEADER_uMultiWordShl_h_
 #define RTW_HEADER_uMultiWordShl_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -1,0 +1,47 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, educational organizations only. Not for
+// government, commercial, or other organizational use.
+//
+// File: zero_crossing_types.h
+//
+// Code generated for Simulink model 'control_outer'.
+//
+// Model version                  : 1.100
+// Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
+// C/C++ source code generated on : Mon Sep 20 12:44:08 2021
+//
+#ifndef ZERO_CROSSING_TYPES_H
+#define ZERO_CROSSING_TYPES_H
+#include "rtwtypes.h"
+
+// Trigger directions: falling, either, and rising
+typedef enum {
+  FALLING_ZERO_CROSSING = -1,
+  ANY_ZERO_CROSSING = 0,
+  RISING_ZERO_CROSSING = 1
+} ZCDirection;
+
+// Previous state of a trigger signal
+typedef uint8_T ZCSigState;
+
+// Initial value of a trigger zero crossing signal
+#define UNINITIALIZED_ZCSIG            0x03U
+#define NEG_ZCSIG                      0x02U
+#define POS_ZCSIG                      0x01U
+#define ZERO_ZCSIG                     0x00U
+
+// Current state of a trigger signal
+typedef enum {
+  FALLING_ZCEVENT = -1,
+  NO_ZCEVENT = 0,
+  RISING_ZCEVENT = 1
+} ZCEventType;
+
+#endif                                 // ZERO_CROSSING_TYPES_H
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 2.34
+// Model version                  : 2.44
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:12:54 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:16 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,7 +19,7 @@
 #include "SupervisorFSM_RX.h"
 #include "SupervisorFSM_RX_private.h"
 
-// Named constants for Chart: '<Root>/Chart'
+// Named constants for Chart: '<Root>/SupervisorFSM_RX'
 const uint8_T Su_IN_Controller_Not_Configured = 1U;
 const uint8_T Supe_IN_Hardware_Not_Configured = 2U;
 const int32_T Superv_event_SetCurrentLimitEvt = 3;
@@ -44,34 +44,35 @@ const int32_T SupervisorFSM__event_HwFaultEvt = 2;
 const uint8_T SupervisorFS_IN_NO_ACTIVE_CHILD = 0U;
 const int32_T SupervisorFS_event_ForceIdleEvt = 1;
 
-// Function for Chart: '<Root>/Chart'
-void SupervisorFSM_RXModelClass::Supervisor_CONTROL_MODE_HANDLER(void)
+// Function for Chart: '<Root>/SupervisorFSM_RX'
+void SupervisorFSM_RXModelClass::Supervisor_CONTROL_MODE_HANDLER(const
+  InternalMessages *arg_Internal_Messages, const MotorSensors *arg_MotorSensors,
+  const BUS_MESSAGES_RX *arg_MessagesRx, Flags *arg_Flags)
 {
   int32_T b_previousEvent;
   switch (SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER) {
    case SupervisorFSM_RX_IN_Motor_OFF:
-    if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-        BoardCommand_Reset) {
+    if (arg_Internal_Messages->Command == BoardCommand_Reset) {
       SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFS_IN_NO_ACTIVE_CHILD;
       SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
         SupervisorFSM_IN_Not_Configured;
       SupervisorFSM_RX_DW.is_Not_Configured = Supe_IN_Hardware_Not_Configured;
-      SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_NotConfigured;
+      arg_Flags->control_mode = ControlModes_NotConfigured;
     } else {
       switch (SupervisorFSM_RX_DW.is_Motor_OFF) {
        case SupervisorFSM_IN_Hardware_Fault:
-        if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-            BoardCommand_ForceIdle) {
+        if (arg_Internal_Messages->Command == BoardCommand_ForceIdle) {
           b_previousEvent = SupervisorFSM_RX_DW.sfEvent;
           SupervisorFSM_RX_DW.sfEvent = SupervisorFS_event_ForceIdleEvt;
           if (SupervisorFSM_RX_DW.is_active_FAULT_HANDLER != 0U) {
-            SupervisorFSM_RX_FAULT_HANDLER();
+            SupervisorFSM_RX_FAULT_HANDLER(arg_Internal_Messages,
+              arg_MotorSensors, arg_MessagesRx, arg_Flags);
           }
 
           SupervisorFSM_RX_DW.sfEvent = b_previousEvent;
           if (SupervisorFSM_RX_DW.is_Motor_OFF == 1) {
             SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFSM_RX_IN_Idle;
-            SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Idle;
+            arg_Flags->control_mode = ControlModes_Idle;
           }
         }
         break;
@@ -79,17 +80,12 @@ void SupervisorFSM_RXModelClass::Supervisor_CONTROL_MODE_HANDLER(void)
        case SupervisorFSM_RX_IN_Idle:
         if (SupervisorFSM_RX_DW.sfEvent == SupervisorFSM__event_HwFaultEvt) {
           SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFSM_IN_Hardware_Fault;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_HwFaultCM;
-        } else if ((SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                    BoardCommand_SetPosition) ||
-                   (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                    BoardCommand_SetCurrent) ||
-                   (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                    BoardCommand_SetVelocity) ||
-                   (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                    BoardCommand_SetVoltage) ||
-                   (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                    BoardCommand_SetTorque)) {
+          arg_Flags->control_mode = ControlModes_HwFaultCM;
+        } else if ((arg_Internal_Messages->Command == BoardCommand_SetPosition) ||
+                   (arg_Internal_Messages->Command == BoardCommand_SetCurrent) ||
+                   (arg_Internal_Messages->Command == BoardCommand_SetVelocity) ||
+                   (arg_Internal_Messages->Command == BoardCommand_SetVoltage) ||
+                   (arg_Internal_Messages->Command == BoardCommand_SetTorque)) {
           SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFS_IN_NO_ACTIVE_CHILD;
           SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
             SupervisorFSM_RX_IN_Motor_ON;
@@ -101,183 +97,179 @@ void SupervisorFSM_RXModelClass::Supervisor_CONTROL_MODE_HANDLER(void)
     break;
 
    case SupervisorFSM_RX_IN_Motor_ON:
-    if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-        BoardCommand_Reset) {
+    if (arg_Internal_Messages->Command == BoardCommand_Reset) {
       SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFS_IN_NO_ACTIVE_CHILD;
       SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
         SupervisorFSM_IN_Not_Configured;
       SupervisorFSM_RX_DW.is_Not_Configured = Supe_IN_Hardware_Not_Configured;
-      SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_NotConfigured;
+      arg_Flags->control_mode = ControlModes_NotConfigured;
     } else if (SupervisorFSM_RX_DW.sfEvent == SupervisorFSM__event_HwFaultEvt) {
       SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFS_IN_NO_ACTIVE_CHILD;
       SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
         SupervisorFSM_RX_IN_Motor_OFF;
       SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFSM_IN_Hardware_Fault;
-      SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_HwFaultCM;
-    } else if ((SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.State ==
-                BoardState_FaultPressed) ||
-               (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                BoardCommand_SetIdle) ||
-               (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-                BoardCommand_ForceIdle)) {
+      arg_Flags->control_mode = ControlModes_HwFaultCM;
+    } else if ((arg_Internal_Messages->State == BoardState_FaultPressed) ||
+               (arg_Internal_Messages->Command == BoardCommand_SetIdle) ||
+               (arg_Internal_Messages->Command == BoardCommand_ForceIdle)) {
       SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFS_IN_NO_ACTIVE_CHILD;
       SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
         SupervisorFSM_RX_IN_Motor_OFF;
       SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFSM_RX_IN_Idle;
-      SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Idle;
+      arg_Flags->control_mode = ControlModes_Idle;
     } else if (SupervisorFSM_RX_DW.sfEvent == Superviso_event_FaultPressedEvt) {
       SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFS_IN_NO_ACTIVE_CHILD;
       SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
         SupervisorFSM_RX_IN_Motor_OFF;
       SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFSM_RX_IN_Idle;
-      SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Idle;
+      arg_Flags->control_mode = ControlModes_Idle;
     } else {
       switch (SupervisorFSM_RX_DW.is_Motor_ON) {
        case SupervisorFSM_RX_IN_Command:
-        switch (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command) {
+        switch (arg_Internal_Messages->Command) {
          case BoardCommand_SetPosition:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Position;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Position;
+          arg_Flags->control_mode = ControlModes_Position;
           break;
 
          case BoardCommand_SetVelocity:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Current;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Current;
+          arg_Flags->control_mode = ControlModes_Current;
           break;
 
          case BoardCommand_SetCurrent:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Velocity;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Velocity;
+          arg_Flags->control_mode = ControlModes_Velocity;
           break;
 
          case BoardCommand_SetVoltage:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Voltage;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Voltage;
+          arg_Flags->control_mode = ControlModes_Voltage;
           break;
 
-         case BoardCommand_SetTorque:
+         default:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Torque;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Torque;
+          arg_Flags->control_mode = ControlModes_Torque;
           break;
         }
         break;
 
        case SupervisorFSM_RX_IN_Current:
-        switch (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command) {
+        switch (arg_Internal_Messages->Command) {
          case BoardCommand_SetVelocity:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Velocity;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Velocity;
+          arg_Flags->control_mode = ControlModes_Velocity;
           break;
 
          case BoardCommand_SetVoltage:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Voltage;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Voltage;
+          arg_Flags->control_mode = ControlModes_Voltage;
           break;
 
          case BoardCommand_SetTorque:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Torque;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Torque;
+          arg_Flags->control_mode = ControlModes_Torque;
           break;
 
          case BoardCommand_SetPosition:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Position;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Position;
+          arg_Flags->control_mode = ControlModes_Position;
           break;
         }
         break;
 
        case SupervisorFSM_RX_IN_Position:
-        switch (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command) {
+        switch (arg_Internal_Messages->Command) {
          case BoardCommand_SetCurrent:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Current;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Current;
+          arg_Flags->control_mode = ControlModes_Current;
           break;
 
          case BoardCommand_SetVelocity:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Velocity;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Velocity;
+          arg_Flags->control_mode = ControlModes_Velocity;
           break;
 
          case BoardCommand_SetVoltage:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Voltage;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Voltage;
+          arg_Flags->control_mode = ControlModes_Voltage;
           break;
 
          case BoardCommand_SetTorque:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Torque;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Torque;
+          arg_Flags->control_mode = ControlModes_Torque;
           break;
         }
         break;
 
        case SupervisorFSM_RX_IN_Torque:
-        switch (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command) {
+        switch (arg_Internal_Messages->Command) {
          case BoardCommand_SetVoltage:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Voltage;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Voltage;
+          arg_Flags->control_mode = ControlModes_Voltage;
           break;
 
          case BoardCommand_SetVelocity:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Velocity;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Velocity;
+          arg_Flags->control_mode = ControlModes_Velocity;
           break;
 
          case BoardCommand_SetCurrent:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Current;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Current;
+          arg_Flags->control_mode = ControlModes_Current;
           break;
 
          case BoardCommand_SetPosition:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Position;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Position;
+          arg_Flags->control_mode = ControlModes_Position;
           break;
         }
         break;
 
        case SupervisorFSM_RX_IN_Velocity:
-        switch (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command) {
+        switch (arg_Internal_Messages->Command) {
          case BoardCommand_SetVoltage:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Voltage;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Voltage;
+          arg_Flags->control_mode = ControlModes_Voltage;
           break;
 
          case BoardCommand_SetTorque:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Torque;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Torque;
+          arg_Flags->control_mode = ControlModes_Torque;
           break;
 
          case BoardCommand_SetCurrent:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Current;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Current;
+          arg_Flags->control_mode = ControlModes_Current;
           break;
 
          case BoardCommand_SetPosition:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Position;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Position;
+          arg_Flags->control_mode = ControlModes_Position;
           break;
         }
         break;
 
        case SupervisorFSM_RX_IN_Voltage:
-        switch (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command) {
+        switch (arg_Internal_Messages->Command) {
          case BoardCommand_SetTorque:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Torque;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Torque;
+          arg_Flags->control_mode = ControlModes_Torque;
           break;
 
          case BoardCommand_SetVelocity:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Velocity;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Velocity;
+          arg_Flags->control_mode = ControlModes_Velocity;
           break;
 
          case BoardCommand_SetCurrent:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Current;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Current;
+          arg_Flags->control_mode = ControlModes_Current;
           break;
 
          case BoardCommand_SetPosition:
           SupervisorFSM_RX_DW.is_Motor_ON = SupervisorFSM_RX_IN_Position;
-          SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Position;
+          arg_Flags->control_mode = ControlModes_Position;
           break;
         }
         break;
@@ -288,21 +280,19 @@ void SupervisorFSM_RXModelClass::Supervisor_CONTROL_MODE_HANDLER(void)
    case SupervisorFSM_IN_Not_Configured:
     switch (SupervisorFSM_RX_DW.is_Not_Configured) {
      case Su_IN_Controller_Not_Configured:
-      if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.State ==
-          BoardState_ControllerConfigured) {
+      if (arg_Internal_Messages->State == BoardState_ControllerConfigured) {
         SupervisorFSM_RX_DW.is_Not_Configured = SupervisorFS_IN_NO_ACTIVE_CHILD;
         SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
           SupervisorFSM_RX_IN_Motor_OFF;
         SupervisorFSM_RX_DW.is_Motor_OFF = SupervisorFSM_RX_IN_Idle;
-        SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_Idle;
+        arg_Flags->control_mode = ControlModes_Idle;
       }
       break;
 
      case Supe_IN_Hardware_Not_Configured:
-      if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.State ==
-          BoardState_HardwareConfigured) {
+      if (arg_Internal_Messages->State == BoardState_HardwareConfigured) {
         SupervisorFSM_RX_DW.is_Not_Configured = Su_IN_Controller_Not_Configured;
-        SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_NotConfigured;
+        arg_Flags->control_mode = ControlModes_NotConfigured;
       }
       break;
     }
@@ -310,8 +300,10 @@ void SupervisorFSM_RXModelClass::Supervisor_CONTROL_MODE_HANDLER(void)
   }
 }
 
-// Function for Chart: '<Root>/Chart'
-void SupervisorFSM_RXModelClass::SupervisorFSM_RX_FAULT_HANDLER(void)
+// Function for Chart: '<Root>/SupervisorFSM_RX'
+void SupervisorFSM_RXModelClass::SupervisorFSM_RX_FAULT_HANDLER(const
+  InternalMessages *arg_Internal_Messages, const MotorSensors *arg_MotorSensors,
+  const BUS_MESSAGES_RX *arg_MessagesRx, Flags *arg_Flags)
 {
   int32_T f_previousEvent;
   switch (SupervisorFSM_RX_DW.is_FAULT_HANDLER) {
@@ -322,69 +314,70 @@ void SupervisorFSM_RXModelClass::SupervisorFSM_RX_FAULT_HANDLER(void)
     break;
 
    case SupervisorFSM_RX_IN_NO_FAULT:
-    if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command ==
-        BoardCommand_ForceIdle) {
+    // Chart: '<Root>/SupervisorFSM_RX'
+    if (arg_Internal_Messages->Command == BoardCommand_ForceIdle) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_NO_FAULT;
-    } else if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.voltage <
-               SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.voltage_low)
-    {
+    } else if (arg_MotorSensors->voltage <
+               arg_MotorSensors->threshold.voltage_low) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_FAULT;
       f_previousEvent = SupervisorFSM_RX_DW.sfEvent;
       SupervisorFSM_RX_DW.sfEvent = SupervisorFSM__event_HwFaultEvt;
       if (SupervisorFSM_RX_DW.is_active_CONTROL_MODE_HANDLER != 0U) {
-        Supervisor_CONTROL_MODE_HANDLER();
+        Supervisor_CONTROL_MODE_HANDLER(arg_Internal_Messages, arg_MotorSensors,
+          arg_MessagesRx, arg_Flags);
       }
 
       SupervisorFSM_RX_DW.sfEvent = f_previousEvent;
-    } else if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.voltage >
-               SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.voltage_high)
-    {
+    } else if (arg_MotorSensors->voltage >
+               arg_MotorSensors->threshold.voltage_high) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_FAULT;
       f_previousEvent = SupervisorFSM_RX_DW.sfEvent;
       SupervisorFSM_RX_DW.sfEvent = SupervisorFSM__event_HwFaultEvt;
       if (SupervisorFSM_RX_DW.is_active_CONTROL_MODE_HANDLER != 0U) {
-        Supervisor_CONTROL_MODE_HANDLER();
+        Supervisor_CONTROL_MODE_HANDLER(arg_Internal_Messages, arg_MotorSensors,
+          arg_MessagesRx, arg_Flags);
       }
 
       SupervisorFSM_RX_DW.sfEvent = f_previousEvent;
-    } else if ((SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.current >
-                SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.current_high)
-               || (SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.current >
-                   SupervisorFSM_RX_DW.CurrLimit)) {
+    } else if ((arg_MotorSensors->current >
+                arg_MotorSensors->threshold.current_high) ||
+               (arg_MotorSensors->current > SupervisorFSM_RX_DW.CurrLimit)) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_FAULT;
       f_previousEvent = SupervisorFSM_RX_DW.sfEvent;
       SupervisorFSM_RX_DW.sfEvent = SupervisorFSM__event_HwFaultEvt;
       if (SupervisorFSM_RX_DW.is_active_CONTROL_MODE_HANDLER != 0U) {
-        Supervisor_CONTROL_MODE_HANDLER();
+        Supervisor_CONTROL_MODE_HANDLER(arg_Internal_Messages, arg_MotorSensors,
+          arg_MessagesRx, arg_Flags);
       }
 
       SupervisorFSM_RX_DW.sfEvent = f_previousEvent;
-    } else if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.temperature >
-               SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.temperature_high)
-    {
+    } else if (arg_MotorSensors->temperature >
+               arg_MotorSensors->threshold.temperature_high) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_FAULT;
       f_previousEvent = SupervisorFSM_RX_DW.sfEvent;
       SupervisorFSM_RX_DW.sfEvent = SupervisorFSM__event_HwFaultEvt;
       if (SupervisorFSM_RX_DW.is_active_CONTROL_MODE_HANDLER != 0U) {
-        Supervisor_CONTROL_MODE_HANDLER();
+        Supervisor_CONTROL_MODE_HANDLER(arg_Internal_Messages, arg_MotorSensors,
+          arg_MessagesRx, arg_Flags);
       }
 
       SupervisorFSM_RX_DW.sfEvent = f_previousEvent;
-    } else if (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.State ==
-               BoardState_FaultPressed) {
+    } else if (arg_Internal_Messages->State == BoardState_FaultPressed) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_FAULT;
       f_previousEvent = SupervisorFSM_RX_DW.sfEvent;
       SupervisorFSM_RX_DW.sfEvent = Superviso_event_FaultPressedEvt;
       if (SupervisorFSM_RX_DW.is_active_CONTROL_MODE_HANDLER != 0U) {
-        Supervisor_CONTROL_MODE_HANDLER();
+        Supervisor_CONTROL_MODE_HANDLER(arg_Internal_Messages, arg_MotorSensors,
+          arg_MessagesRx, arg_Flags);
       }
 
       SupervisorFSM_RX_DW.sfEvent = f_previousEvent;
     } else if (SupervisorFSM_RX_DW.sfEvent == Superv_event_SetCurrentLimitEvt) {
       SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_IN_SET_CURR_LIMIT;
-      SupervisorFSM_RX_DW.CurrLimit =
-        SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.current_limit.overload;
+      SupervisorFSM_RX_DW.CurrLimit = arg_MessagesRx->current_limit.overload;
     }
+
+    // End of Chart: '<Root>/SupervisorFSM_RX'
     break;
 
    case SupervisorFSM_IN_SET_CURR_LIMIT:
@@ -393,7 +386,7 @@ void SupervisorFSM_RXModelClass::SupervisorFSM_RX_FAULT_HANDLER(void)
   }
 }
 
-// Function for Chart: '<Root>/Chart'
+// Function for Chart: '<Root>/SupervisorFSM_RX'
 ControlModes SupervisorFSM_RXModelClass::SupervisorFSM_RX_convert(MCControlModes
   mccontrolmode)
 {
@@ -424,168 +417,54 @@ ControlModes SupervisorFSM_RXModelClass::SupervisorFSM_RX_convert(MCControlModes
 }
 
 // System initialize for referenced model: 'SupervisorFSM_RX'
-void SupervisorFSM_RXModelClass::init(ControlModes *rty_Flags_control_mode,
-  boolean_T *rty_Flags_PID_reset, real32_T *rty_Targets_jointpositions_posi,
-  real32_T *rty_Targets_jointvelocities_vel, real32_T
-  *rty_Targets_motorcurrent_curren, real32_T *rty_Targets_motorvoltage_voltag)
+void SupervisorFSM_RXModelClass::init(Flags *arg_Flags, Targets *arg_Targets)
 {
-  // SystemInitialize for Chart: '<Root>/Chart'
+  // SystemInitialize for Chart: '<Root>/SupervisorFSM_RX'
   SupervisorFSM_RX_DW.sfEvent = SupervisorFSM_RX_CALL_EVENT;
   SupervisorFSM_RX_DW.CurrLimit = MAX_uint16_T;
-  SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_NotConfigured;
-  SupervisorFSM_RX_B.Flags_o.PID_reset = false;
-  SupervisorFSM_RX_B.Targets_n.jointpositions.position = 0.0F;
-  SupervisorFSM_RX_B.Targets_n.jointvelocities.velocity = 0.0F;
-  SupervisorFSM_RX_B.Targets_n.motorcurrent.current = 0.0F;
-  SupervisorFSM_RX_B.Targets_n.motorvoltage.voltage = 0.0F;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/Flags'
-  *rty_Flags_control_mode = SupervisorFSM_RX_B.Flags_o.control_mode;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/Flags'
-  *rty_Flags_PID_reset = SupervisorFSM_RX_B.Flags_o.PID_reset;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_jointpositions_posi =
-    SupervisorFSM_RX_B.Targets_n.jointpositions.position;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_jointvelocities_vel =
-    SupervisorFSM_RX_B.Targets_n.jointvelocities.velocity;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_motorcurrent_curren =
-    SupervisorFSM_RX_B.Targets_n.motorcurrent.current;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_motorvoltage_voltag =
-    SupervisorFSM_RX_B.Targets_n.motorvoltage.voltage;
+  arg_Flags->control_mode = ControlModes_NotConfigured;
+  arg_Flags->PID_reset = false;
+  arg_Targets->jointpositions.position = 0.0F;
+  arg_Targets->jointvelocities.velocity = 0.0F;
+  arg_Targets->motorcurrent.current = 0.0F;
+  arg_Targets->motorvoltage.voltage = 0.0F;
 }
 
 // Output and update for referenced model: 'SupervisorFSM_RX'
-void SupervisorFSM_RXModelClass::step(const BoardState
-  *rtu_InternalMessages_State, const BoardCommand *rtu_InternalMessages_Command,
-  const real32_T rtu_MotorSensors_Iabc[3], const real32_T
-  *rtu_MotorSensors_angle, const real32_T *rtu_MotorSensors_omega, const
-  real32_T *rtu_MotorSensors_temperature, const real32_T
-  *rtu_MotorSensors_voltage, const real32_T *rtu_MotorSensors_threshold_curr,
-  const real32_T *rtu_MotorSensors_threshold_cu_k, const real32_T
-  *rtu_MotorSensors_threshold_volt, const real32_T
-  *rtu_MotorSensors_threshold_vo_k, const real32_T
-  *rtu_MotorSensors_threshold_temp, const real32_T
-  *rtu_MotorSensors_threshold_te_c, const real32_T *rtu_MotorSensors_current,
-  const boolean_T *rtu_ErrorsRx_event, const boolean_T
-  *rtu_EventsRx_control_mode, const boolean_T *rtu_EventsRx_current_limit, const
-  boolean_T *rtu_EventsRx_desired_current, const boolean_T
-  *rtu_MessagesRx_control_mode_mot, const MCControlModes
-  *rtu_MessagesRx_control_mode_mod, const boolean_T
-  *rtu_MessagesRx_current_limit_mo, const int16_T
-  *rtu_MessagesRx_current_limit_no, const uint16_T
-  *rtu_MessagesRx_current_limit_pe, const uint16_T
-  *rtu_MessagesRx_current_limit_ov, const int16_T
-  *rtu_MessagesRx_desired_current_, ControlModes *rty_Flags_control_mode,
-  boolean_T *rty_Flags_PID_reset, real32_T *rty_Targets_jointpositions_posi,
-  real32_T *rty_Targets_jointvelocities_vel, real32_T
-  *rty_Targets_motorcurrent_curren, real32_T *rty_Targets_motorvoltage_voltag)
+void SupervisorFSM_RXModelClass::step(const InternalMessages &
+  arg_Internal_Messages, const MotorSensors &arg_MotorSensors, const
+  BUS_EVENTS_RX &arg_EventsRx, const BUS_MESSAGES_RX &arg_MessagesRx, const
+  BUS_CAN_RX_ERRORS &arg_ErrorsRx, Flags &arg_Flags, Targets &arg_Targets)
 {
   int32_T b_previousEvent;
-  boolean_T BusConversion_InsertedFor_Cha_0;
-  boolean_T BusConversion_InsertedFor_Cha_1;
-  boolean_T BusConversion_InsertedFor_Cha_g;
-  boolean_T BusConversion_InsertedFor_Cha_p;
 
-  // BusCreator generated from: '<Root>/Chart'
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.State =
-    *rtu_InternalMessages_State;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_i.Command =
-    *rtu_InternalMessages_Command;
-
-  // BusCreator generated from: '<Root>/Chart'
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.current_low =
-    *rtu_MotorSensors_threshold_curr;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.current_high =
-    *rtu_MotorSensors_threshold_cu_k;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.voltage_low =
-    *rtu_MotorSensors_threshold_volt;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.voltage_high =
-    *rtu_MotorSensors_threshold_vo_k;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.temperature_low =
-    *rtu_MotorSensors_threshold_temp;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.threshold.temperature_high =
-    *rtu_MotorSensors_threshold_te_c;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.Iabc[0] =
-    rtu_MotorSensors_Iabc[0];
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.Iabc[1] =
-    rtu_MotorSensors_Iabc[1];
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.Iabc[2] =
-    rtu_MotorSensors_Iabc[2];
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.angle =
-    *rtu_MotorSensors_angle;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.omega =
-    *rtu_MotorSensors_omega;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.temperature =
-    *rtu_MotorSensors_temperature;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.voltage =
-    *rtu_MotorSensors_voltage;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Chart.current =
-    *rtu_MotorSensors_current;
-
-  // BusCreator generated from: '<Root>/Chart'
-  BusConversion_InsertedFor_Cha_g = *rtu_ErrorsRx_event;
-
-  // BusCreator generated from: '<Root>/Chart'
-  BusConversion_InsertedFor_Cha_p = *rtu_EventsRx_control_mode;
-  BusConversion_InsertedFor_Cha_0 = *rtu_EventsRx_current_limit;
-  BusConversion_InsertedFor_Cha_1 = *rtu_EventsRx_desired_current;
-
-  // BusCreator generated from: '<Root>/Chart'
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.control_mode.motor =
-    *rtu_MessagesRx_control_mode_mot;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.current_limit.motor =
-    *rtu_MessagesRx_current_limit_mo;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.current_limit.nominal =
-    *rtu_MessagesRx_current_limit_no;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.current_limit.peak =
-    *rtu_MessagesRx_current_limit_pe;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.current_limit.overload =
-    *rtu_MessagesRx_current_limit_ov;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.desired_current.current =
-    *rtu_MessagesRx_desired_current_;
-  SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.control_mode.mode =
-    *rtu_MessagesRx_control_mode_mod;
-
-  // Chart: '<Root>/Chart'
+  // Chart: '<Root>/SupervisorFSM_RX'
   SupervisorFSM_RX_DW.sfEvent = SupervisorFSM_RX_CALL_EVENT;
   SupervisorFSM_RX_DW.ErrorsRx_event_prev =
     SupervisorFSM_RX_DW.ErrorsRx_event_start;
-  SupervisorFSM_RX_DW.ErrorsRx_event_start = BusConversion_InsertedFor_Cha_g;
+  SupervisorFSM_RX_DW.ErrorsRx_event_start = arg_ErrorsRx.event;
   SupervisorFSM_RX_DW.EventsRx_control_mode_prev =
     SupervisorFSM_RX_DW.EventsRx_control_mode_start;
-  SupervisorFSM_RX_DW.EventsRx_control_mode_start =
-    BusConversion_InsertedFor_Cha_p;
+  SupervisorFSM_RX_DW.EventsRx_control_mode_start = arg_EventsRx.control_mode;
   SupervisorFSM_RX_DW.EventsRx_current_limit_prev =
     SupervisorFSM_RX_DW.EventsRx_current_limit_start;
-  SupervisorFSM_RX_DW.EventsRx_current_limit_start =
-    BusConversion_InsertedFor_Cha_0;
+  SupervisorFSM_RX_DW.EventsRx_current_limit_start = arg_EventsRx.current_limit;
   SupervisorFSM_RX_DW.EventsRx_desired_current_prev =
     SupervisorFSM_RX_DW.EventsRx_desired_current_start;
   SupervisorFSM_RX_DW.EventsRx_desired_current_start =
-    BusConversion_InsertedFor_Cha_1;
+    arg_EventsRx.desired_current;
   if (SupervisorFSM_RX_DW.is_active_c3_SupervisorFSM_RX == 0U) {
-    SupervisorFSM_RX_DW.ErrorsRx_event_prev = BusConversion_InsertedFor_Cha_g;
-    SupervisorFSM_RX_DW.ErrorsRx_event_start = BusConversion_InsertedFor_Cha_g;
-    SupervisorFSM_RX_DW.EventsRx_control_mode_prev =
-      BusConversion_InsertedFor_Cha_p;
-    SupervisorFSM_RX_DW.EventsRx_control_mode_start =
-      BusConversion_InsertedFor_Cha_p;
-    SupervisorFSM_RX_DW.EventsRx_current_limit_prev =
-      BusConversion_InsertedFor_Cha_0;
+    SupervisorFSM_RX_DW.ErrorsRx_event_prev = arg_ErrorsRx.event;
+    SupervisorFSM_RX_DW.ErrorsRx_event_start = arg_ErrorsRx.event;
+    SupervisorFSM_RX_DW.EventsRx_control_mode_prev = arg_EventsRx.control_mode;
+    SupervisorFSM_RX_DW.EventsRx_control_mode_start = arg_EventsRx.control_mode;
+    SupervisorFSM_RX_DW.EventsRx_current_limit_prev = arg_EventsRx.current_limit;
     SupervisorFSM_RX_DW.EventsRx_current_limit_start =
-      BusConversion_InsertedFor_Cha_0;
+      arg_EventsRx.current_limit;
     SupervisorFSM_RX_DW.EventsRx_desired_current_prev =
-      BusConversion_InsertedFor_Cha_1;
+      arg_EventsRx.desired_current;
     SupervisorFSM_RX_DW.EventsRx_desired_current_start =
-      BusConversion_InsertedFor_Cha_1;
+      arg_EventsRx.desired_current;
     SupervisorFSM_RX_DW.is_active_c3_SupervisorFSM_RX = 1U;
     SupervisorFSM_RX_DW.is_active_FAULT_HANDLER = 1U;
     SupervisorFSM_RX_DW.is_FAULT_HANDLER = SupervisorFSM_RX_IN_NO_FAULT;
@@ -593,16 +472,18 @@ void SupervisorFSM_RXModelClass::step(const BoardState
     SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
       SupervisorFSM_IN_Not_Configured;
     SupervisorFSM_RX_DW.is_Not_Configured = Supe_IN_Hardware_Not_Configured;
-    SupervisorFSM_RX_B.Flags_o.control_mode = ControlModes_NotConfigured;
+    arg_Flags.control_mode = ControlModes_NotConfigured;
     SupervisorFSM_RX_DW.is_active_CAN_RX_HANDLER = 1U;
     SupervisorFSM_RX_DW.is_CAN_RX_HANDLER = SupervisorFSM_RX_IN_Home;
   } else {
     if (SupervisorFSM_RX_DW.is_active_FAULT_HANDLER != 0U) {
-      SupervisorFSM_RX_FAULT_HANDLER();
+      SupervisorFSM_RX_FAULT_HANDLER(&arg_Internal_Messages, &arg_MotorSensors,
+        &arg_MessagesRx, &arg_Flags);
     }
 
     if (SupervisorFSM_RX_DW.is_active_CONTROL_MODE_HANDLER != 0U) {
-      Supervisor_CONTROL_MODE_HANDLER();
+      Supervisor_CONTROL_MODE_HANDLER(&arg_Internal_Messages, &arg_MotorSensors,
+        &arg_MessagesRx, &arg_Flags);
     }
 
     if ((SupervisorFSM_RX_DW.is_active_CAN_RX_HANDLER != 0U) &&
@@ -617,21 +498,22 @@ void SupervisorFSM_RXModelClass::step(const BoardState
            SupervisorFSM_RX_DW.EventsRx_desired_current_start)) {
         if (SupervisorFSM_RX_DW.EventsRx_control_mode_prev !=
             SupervisorFSM_RX_DW.EventsRx_control_mode_start) {
-          SupervisorFSM_RX_B.Flags_o.control_mode = SupervisorFSM_RX_convert
-            (SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.control_mode.mode);
+          arg_Flags.control_mode = SupervisorFSM_RX_convert
+            (arg_MessagesRx.control_mode.mode);
         } else if (SupervisorFSM_RX_DW.EventsRx_desired_current_prev !=
                    SupervisorFSM_RX_DW.EventsRx_desired_current_start) {
           b_previousEvent = SupervisorFSM_RX_DW.sfEvent;
           SupervisorFSM_RX_DW.sfEvent = Superv_event_SetCurrentLimitEvt;
           if (SupervisorFSM_RX_DW.is_active_FAULT_HANDLER != 0U) {
-            SupervisorFSM_RX_FAULT_HANDLER();
+            SupervisorFSM_RX_FAULT_HANDLER(&arg_Internal_Messages,
+              &arg_MotorSensors, &arg_MessagesRx, &arg_Flags);
           }
 
           SupervisorFSM_RX_DW.sfEvent = b_previousEvent;
         } else if (SupervisorFSM_RX_DW.EventsRx_current_limit_prev !=
                    SupervisorFSM_RX_DW.EventsRx_current_limit_start) {
-          SupervisorFSM_RX_B.Targets_n.motorcurrent.current =
-            SupervisorFSM_RX_B.BusConversion_InsertedFor_Cha_h.desired_current.current;
+          arg_Targets.motorcurrent.current =
+            arg_MessagesRx.desired_current.current;
         }
       }
 
@@ -639,34 +521,11 @@ void SupervisorFSM_RXModelClass::step(const BoardState
     }
   }
 
-  // End of Chart: '<Root>/Chart'
-
-  // SignalConversion generated from: '<Root>/Flags'
-  *rty_Flags_control_mode = SupervisorFSM_RX_B.Flags_o.control_mode;
-
-  // SignalConversion generated from: '<Root>/Flags'
-  *rty_Flags_PID_reset = SupervisorFSM_RX_B.Flags_o.PID_reset;
-
-  // SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_jointpositions_posi =
-    SupervisorFSM_RX_B.Targets_n.jointpositions.position;
-
-  // SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_jointvelocities_vel =
-    SupervisorFSM_RX_B.Targets_n.jointvelocities.velocity;
-
-  // SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_motorcurrent_curren =
-    SupervisorFSM_RX_B.Targets_n.motorcurrent.current;
-
-  // SignalConversion generated from: '<Root>/Targets'
-  *rty_Targets_motorvoltage_voltag =
-    SupervisorFSM_RX_B.Targets_n.motorvoltage.voltage;
+  // End of Chart: '<Root>/SupervisorFSM_RX'
 }
 
 // Constructor
 SupervisorFSM_RXModelClass::SupervisorFSM_RXModelClass() :
-  SupervisorFSM_RX_B(),
   SupervisorFSM_RX_DW()
 {
   // Currently there is no constructor body generated.

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 2.34
+// Model version                  : 2.44
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:12:54 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:16 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -28,37 +28,28 @@
 class SupervisorFSM_RXModelClass {
   // public data and function members
  public:
-  // Block signals for model 'SupervisorFSM_RX'
-  struct B_SupervisorFSM_RX_T {
-    MotorSensors BusConversion_InsertedFor_Chart;
-    Targets Targets_n;                 // '<Root>/Chart'
-    BUS_MESSAGES_RX BusConversion_InsertedFor_Cha_h;
-    InternalMessages BusConversion_InsertedFor_Cha_i;
-    Flags Flags_o;                     // '<Root>/Chart'
-  };
-
   // Block states (default storage) for model 'SupervisorFSM_RX'
   struct DW_SupervisorFSM_RX_T {
-    int32_T sfEvent;                   // '<Root>/Chart'
-    uint16_T CurrLimit;                // '<Root>/Chart'
-    uint8_T is_active_c3_SupervisorFSM_RX;// '<Root>/Chart'
-    uint8_T is_CONTROL_MODE_HANDLER;   // '<Root>/Chart'
-    uint8_T is_active_CONTROL_MODE_HANDLER;// '<Root>/Chart'
-    uint8_T is_Not_Configured;         // '<Root>/Chart'
-    uint8_T is_Motor_ON;               // '<Root>/Chart'
-    uint8_T is_Motor_OFF;              // '<Root>/Chart'
-    uint8_T is_FAULT_HANDLER;          // '<Root>/Chart'
-    uint8_T is_active_FAULT_HANDLER;   // '<Root>/Chart'
-    uint8_T is_CAN_RX_HANDLER;         // '<Root>/Chart'
-    uint8_T is_active_CAN_RX_HANDLER;  // '<Root>/Chart'
-    boolean_T ErrorsRx_event_prev;     // '<Root>/Chart'
-    boolean_T ErrorsRx_event_start;    // '<Root>/Chart'
-    boolean_T EventsRx_control_mode_prev;// '<Root>/Chart'
-    boolean_T EventsRx_control_mode_start;// '<Root>/Chart'
-    boolean_T EventsRx_current_limit_prev;// '<Root>/Chart'
-    boolean_T EventsRx_current_limit_start;// '<Root>/Chart'
-    boolean_T EventsRx_desired_current_prev;// '<Root>/Chart'
-    boolean_T EventsRx_desired_current_start;// '<Root>/Chart'
+    int32_T sfEvent;                   // '<Root>/SupervisorFSM_RX'
+    uint16_T CurrLimit;                // '<Root>/SupervisorFSM_RX'
+    uint8_T is_active_c3_SupervisorFSM_RX;// '<Root>/SupervisorFSM_RX'
+    uint8_T is_CONTROL_MODE_HANDLER;   // '<Root>/SupervisorFSM_RX'
+    uint8_T is_active_CONTROL_MODE_HANDLER;// '<Root>/SupervisorFSM_RX'
+    uint8_T is_Not_Configured;         // '<Root>/SupervisorFSM_RX'
+    uint8_T is_Motor_ON;               // '<Root>/SupervisorFSM_RX'
+    uint8_T is_Motor_OFF;              // '<Root>/SupervisorFSM_RX'
+    uint8_T is_FAULT_HANDLER;          // '<Root>/SupervisorFSM_RX'
+    uint8_T is_active_FAULT_HANDLER;   // '<Root>/SupervisorFSM_RX'
+    uint8_T is_CAN_RX_HANDLER;         // '<Root>/SupervisorFSM_RX'
+    uint8_T is_active_CAN_RX_HANDLER;  // '<Root>/SupervisorFSM_RX'
+    boolean_T ErrorsRx_event_prev;     // '<Root>/SupervisorFSM_RX'
+    boolean_T ErrorsRx_event_start;    // '<Root>/SupervisorFSM_RX'
+    boolean_T EventsRx_control_mode_prev;// '<Root>/SupervisorFSM_RX'
+    boolean_T EventsRx_control_mode_start;// '<Root>/SupervisorFSM_RX'
+    boolean_T EventsRx_current_limit_prev;// '<Root>/SupervisorFSM_RX'
+    boolean_T EventsRx_current_limit_start;// '<Root>/SupervisorFSM_RX'
+    boolean_T EventsRx_desired_current_prev;// '<Root>/SupervisorFSM_RX'
+    boolean_T EventsRx_desired_current_start;// '<Root>/SupervisorFSM_RX'
   };
 
   // Real-time Model Data Structure
@@ -67,41 +58,13 @@ class SupervisorFSM_RXModelClass {
   };
 
   // model step function
-  void step(const BoardState *rtu_InternalMessages_State, const BoardCommand
-            *rtu_InternalMessages_Command, const real32_T rtu_MotorSensors_Iabc
-            [3], const real32_T *rtu_MotorSensors_angle, const real32_T
-            *rtu_MotorSensors_omega, const real32_T
-            *rtu_MotorSensors_temperature, const real32_T
-            *rtu_MotorSensors_voltage, const real32_T
-            *rtu_MotorSensors_threshold_curr, const real32_T
-            *rtu_MotorSensors_threshold_cu_k, const real32_T
-            *rtu_MotorSensors_threshold_volt, const real32_T
-            *rtu_MotorSensors_threshold_vo_k, const real32_T
-            *rtu_MotorSensors_threshold_temp, const real32_T
-            *rtu_MotorSensors_threshold_te_c, const real32_T
-            *rtu_MotorSensors_current, const boolean_T *rtu_ErrorsRx_event,
-            const boolean_T *rtu_EventsRx_control_mode, const boolean_T
-            *rtu_EventsRx_current_limit, const boolean_T
-            *rtu_EventsRx_desired_current, const boolean_T
-            *rtu_MessagesRx_control_mode_mot, const MCControlModes
-            *rtu_MessagesRx_control_mode_mod, const boolean_T
-            *rtu_MessagesRx_current_limit_mo, const int16_T
-            *rtu_MessagesRx_current_limit_no, const uint16_T
-            *rtu_MessagesRx_current_limit_pe, const uint16_T
-            *rtu_MessagesRx_current_limit_ov, const int16_T
-            *rtu_MessagesRx_desired_current_, ControlModes
-            *rty_Flags_control_mode, boolean_T *rty_Flags_PID_reset, real32_T
-            *rty_Targets_jointpositions_posi, real32_T
-            *rty_Targets_jointvelocities_vel, real32_T
-            *rty_Targets_motorcurrent_curren, real32_T
-            *rty_Targets_motorvoltage_voltag);
+  void step(const InternalMessages &arg_Internal_Messages, const MotorSensors &
+            arg_MotorSensors, const BUS_EVENTS_RX &arg_EventsRx, const
+            BUS_MESSAGES_RX &arg_MessagesRx, const BUS_CAN_RX_ERRORS &
+            arg_ErrorsRx, Flags &arg_Flags, Targets &arg_Targets);
 
   // Initial conditions function
-  void init(ControlModes *rty_Flags_control_mode, boolean_T *rty_Flags_PID_reset,
-            real32_T *rty_Targets_jointpositions_posi, real32_T
-            *rty_Targets_jointvelocities_vel, real32_T
-            *rty_Targets_motorcurrent_curren, real32_T
-            *rty_Targets_motorvoltage_voltag);
+  void init(Flags *arg_Flags, Targets *arg_Targets);
 
   // Constructor
   SupervisorFSM_RXModelClass();
@@ -117,9 +80,6 @@ class SupervisorFSM_RXModelClass {
 
   // private data and function members
  private:
-  // Block signals
-  B_SupervisorFSM_RX_T SupervisorFSM_RX_B;
-
   // Block states
   DW_SupervisorFSM_RX_T SupervisorFSM_RX_DW;
 
@@ -127,8 +87,12 @@ class SupervisorFSM_RXModelClass {
   RT_MODEL_SupervisorFSM_RX_T SupervisorFSM_RX_M;
 
   // private member function(s) for subsystem '<Root>/TmpModelReferenceSubsystem'
-  void Supervisor_CONTROL_MODE_HANDLER(void);
-  void SupervisorFSM_RX_FAULT_HANDLER(void);
+  void Supervisor_CONTROL_MODE_HANDLER(const InternalMessages
+    *arg_Internal_Messages, const MotorSensors *arg_MotorSensors, const
+    BUS_MESSAGES_RX *arg_MessagesRx, Flags *arg_Flags);
+  void SupervisorFSM_RX_FAULT_HANDLER(const InternalMessages
+    *arg_Internal_Messages, const MotorSensors *arg_MotorSensors, const
+    BUS_MESSAGES_RX *arg_MessagesRx, Flags *arg_Flags);
   ControlModes SupervisorFSM_RX_convert(MCControlModes mccontrolmode);
 };
 
@@ -147,7 +111,7 @@ class SupervisorFSM_RXModelClass {
 //  Here is the system hierarchy for this model
 //
 //  '<Root>' : 'SupervisorFSM_RX'
-//  '<S1>'   : 'SupervisorFSM_RX/Chart'
+//  '<S1>'   : 'SupervisorFSM_RX/SupervisorFSM_RX'
 
 #endif                                 // RTW_HEADER_SupervisorFSM_RX_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 2.34
+// Model version                  : 2.44
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:12:54 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:16 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 2.34
+// Model version                  : 2.44
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:12:54 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:16 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -87,33 +87,7 @@ struct MotorSensors
   real32_T voltage;
   Thresholds threshold;
   real32_T current;
-};
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_CANErrorTypes_
-#define DEFINED_TYPEDEF_FOR_CANErrorTypes_
-
-typedef enum {
-  CANErrorTypes_No_Error = 0,          // Default value
-  CANErrorTypes_Packet_Not4Us,
-  CANErrorTypes_Packet_Unrecognized,
-  CANErrorTypes_Packet_Malformed,
-  CANErrorTypes_Packet_MultiFunctionsDetected,
-  CANErrorTypes_Mode_Unrecognized
-} CANErrorTypes;
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_BUS_CAN_RX_ERRORS_
-#define DEFINED_TYPEDEF_FOR_BUS_CAN_RX_ERRORS_
-
-// Specifies the CAN error types.
-struct BUS_CAN_RX_ERRORS
-{
-  // True if an error has been detected.
-  boolean_T event;
-  CANErrorTypes type;
+  uint8_T hallABC;
 };
 
 #endif
@@ -200,6 +174,33 @@ struct BUS_MESSAGES_RX
   BUS_MSG_CONTROL_MODE control_mode;
   BUS_MSG_CURRENT_LIMIT current_limit;
   BUS_MSG_DESIRED_CURRENT desired_current;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_CANErrorTypes_
+#define DEFINED_TYPEDEF_FOR_CANErrorTypes_
+
+typedef enum {
+  CANErrorTypes_No_Error = 0,          // Default value
+  CANErrorTypes_Packet_Not4Us,
+  CANErrorTypes_Packet_Unrecognized,
+  CANErrorTypes_Packet_Malformed,
+  CANErrorTypes_Packet_MultiFunctionsDetected,
+  CANErrorTypes_Mode_Unrecognized
+} CANErrorTypes;
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_BUS_CAN_RX_ERRORS_
+#define DEFINED_TYPEDEF_FOR_BUS_CAN_RX_ERRORS_
+
+// Specifies the CAN error types.
+struct BUS_CAN_RX_ERRORS
+{
+  // True if an error has been detected.
+  boolean_T event;
+  CANErrorTypes type;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 2.43
+// Model version                  : 2.50
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:07 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:29 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,71 +20,42 @@
 #include "SupervisorFSM_TX_private.h"
 
 // System initialize for referenced model: 'SupervisorFSM_TX'
-void SupervisorFSM_TXModelClass::init(real32_T *rty_MessagesTx_foc_current,
-  real32_T *rty_MessagesTx_foc_position, real32_T *rty_MessagesTx_foc_velocity)
+void SupervisorFSM_TXModelClass::init(BUS_MESSAGES_TX *arg_MessagesTx,
+  BUS_EVENTS_TX *arg_EventsTx)
 {
-  // SystemInitialize for Chart: '<Root>/Chart'
-  SupervisorFSM_TX_B.MessagesTx.foc.current = 0.0F;
-  SupervisorFSM_TX_B.MessagesTx.foc.position = 0.0F;
-  SupervisorFSM_TX_B.MessagesTx.foc.velocity = 0.0F;
+  // SystemInitialize for Chart: '<Root>/SupervisorFSM_TX'
+  arg_MessagesTx->foc.current = 0.0F;
+  arg_MessagesTx->foc.position = 0.0F;
+  arg_MessagesTx->foc.velocity = 0.0F;
 
-  // SystemInitialize for SignalConversion generated from: '<Root>/MessagesTx'
-  *rty_MessagesTx_foc_current = SupervisorFSM_TX_B.MessagesTx.foc.current;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/MessagesTx'
-  *rty_MessagesTx_foc_position = SupervisorFSM_TX_B.MessagesTx.foc.position;
-
-  // SystemInitialize for SignalConversion generated from: '<Root>/MessagesTx'
-  *rty_MessagesTx_foc_velocity = SupervisorFSM_TX_B.MessagesTx.foc.velocity;
+  // SystemInitialize for BusCreator: '<Root>/BUS_EVENTS_TX'
+  arg_EventsTx->foc = SupervisorFSM_TX_B.ev_foc;
 }
 
 // Output and update for referenced model: 'SupervisorFSM_TX'
-void SupervisorFSM_TXModelClass::step(const real32_T
-  *rtu_SensorsData_jointpositions_, const real32_T
-  *rtu_SensorsData_motorsensors_om, const real32_T
-  *rtu_SensorsData_motorsensors_cu, const MCControlModes
-  *rtu_MessagesRx_control_mode_mod, real32_T *rty_MessagesTx_foc_current,
-  real32_T *rty_MessagesTx_foc_position, real32_T *rty_MessagesTx_foc_velocity,
-  boolean_T *rty_EventsTx_foc)
+void SupervisorFSM_TXModelClass::step(const SensorsData &arg_SensorsData, const
+  BUS_MESSAGES_RX &arg_MessagesRx, BUS_MESSAGES_TX &arg_MessagesTx,
+  BUS_EVENTS_TX &arg_EventsTx)
 {
-  real32_T rtb_jointpositions_position;
-  real32_T rtb_motorsensors_current;
-  real32_T rtb_motorsensors_omega;
-
-  // BusCreator generated from: '<Root>/Chart'
-  rtb_jointpositions_position = *rtu_SensorsData_jointpositions_;
-
-  // BusCreator generated from: '<Root>/Chart'
-  rtb_motorsensors_omega = *rtu_SensorsData_motorsensors_om;
-  rtb_motorsensors_current = *rtu_SensorsData_motorsensors_cu;
-
-  // Chart: '<Root>/Chart' incorporates:
-  //   BusCreator generated from: '<Root>/Chart'
-
+  // Chart: '<Root>/SupervisorFSM_TX'
   if (SupervisorFSM_TX_DW.is_active_c3_SupervisorFSM_TX == 0U) {
     SupervisorFSM_TX_DW.is_active_c3_SupervisorFSM_TX = 1U;
-  } else if (*rtu_MessagesRx_control_mode_mod != MCControlModes_Idle) {
-    SupervisorFSM_TX_B.MessagesTx.foc.current = rtb_motorsensors_current;
-    SupervisorFSM_TX_B.MessagesTx.foc.velocity = rtb_motorsensors_omega;
-    SupervisorFSM_TX_B.MessagesTx.foc.position = rtb_jointpositions_position;
+  } else if (arg_MessagesRx.control_mode.mode != MCControlModes_Idle) {
+    arg_MessagesTx.foc.current = arg_SensorsData.motorsensors.current;
+    arg_MessagesTx.foc.velocity = arg_SensorsData.motorsensors.omega;
+    arg_MessagesTx.foc.position = arg_SensorsData.jointpositions.position;
     SupervisorFSM_TX_DW.ev_focEventCounter++;
   }
 
   if (SupervisorFSM_TX_DW.ev_focEventCounter > 0U) {
-    *rty_EventsTx_foc = !*rty_EventsTx_foc;
+    SupervisorFSM_TX_B.ev_foc = !SupervisorFSM_TX_B.ev_foc;
     SupervisorFSM_TX_DW.ev_focEventCounter--;
   }
 
-  // End of Chart: '<Root>/Chart'
+  // End of Chart: '<Root>/SupervisorFSM_TX'
 
-  // SignalConversion generated from: '<Root>/MessagesTx'
-  *rty_MessagesTx_foc_current = SupervisorFSM_TX_B.MessagesTx.foc.current;
-
-  // SignalConversion generated from: '<Root>/MessagesTx'
-  *rty_MessagesTx_foc_position = SupervisorFSM_TX_B.MessagesTx.foc.position;
-
-  // SignalConversion generated from: '<Root>/MessagesTx'
-  *rty_MessagesTx_foc_velocity = SupervisorFSM_TX_B.MessagesTx.foc.velocity;
+  // BusCreator: '<Root>/BUS_EVENTS_TX'
+  arg_EventsTx.foc = SupervisorFSM_TX_B.ev_foc;
 }
 
 // Constructor

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 2.43
+// Model version                  : 2.50
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:07 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:29 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -30,13 +30,13 @@ class SupervisorFSM_TXModelClass {
  public:
   // Block signals for model 'SupervisorFSM_TX'
   struct B_SupervisorFSM_TX_T {
-    BUS_MESSAGES_TX MessagesTx;        // '<Root>/Chart'
+    boolean_T ev_foc;                  // '<Root>/SupervisorFSM_TX'
   };
 
   // Block states (default storage) for model 'SupervisorFSM_TX'
   struct DW_SupervisorFSM_TX_T {
-    uint32_T ev_focEventCounter;       // '<Root>/Chart'
-    uint8_T is_active_c3_SupervisorFSM_TX;// '<Root>/Chart'
+    uint32_T ev_focEventCounter;       // '<Root>/SupervisorFSM_TX'
+    uint8_T is_active_c3_SupervisorFSM_TX;// '<Root>/SupervisorFSM_TX'
   };
 
   // Real-time Model Data Structure
@@ -45,16 +45,12 @@ class SupervisorFSM_TXModelClass {
   };
 
   // model step function
-  void step(const real32_T *rtu_SensorsData_jointpositions_, const real32_T
-            *rtu_SensorsData_motorsensors_om, const real32_T
-            *rtu_SensorsData_motorsensors_cu, const MCControlModes
-            *rtu_MessagesRx_control_mode_mod, real32_T
-            *rty_MessagesTx_foc_current, real32_T *rty_MessagesTx_foc_position,
-            real32_T *rty_MessagesTx_foc_velocity, boolean_T *rty_EventsTx_foc);
+  void step(const SensorsData &arg_SensorsData, const BUS_MESSAGES_RX &
+            arg_MessagesRx, BUS_MESSAGES_TX &arg_MessagesTx, BUS_EVENTS_TX &
+            arg_EventsTx);
 
   // Initial conditions function
-  void init(real32_T *rty_MessagesTx_foc_current, real32_T
-            *rty_MessagesTx_foc_position, real32_T *rty_MessagesTx_foc_velocity);
+  void init(BUS_MESSAGES_TX *arg_MessagesTx, BUS_EVENTS_TX *arg_EventsTx);
 
   // Constructor
   SupervisorFSM_TXModelClass();
@@ -95,7 +91,7 @@ class SupervisorFSM_TXModelClass {
 //  Here is the system hierarchy for this model
 //
 //  '<Root>' : 'SupervisorFSM_TX'
-//  '<S1>'   : 'SupervisorFSM_TX/Chart'
+//  '<S1>'   : 'SupervisorFSM_TX/SupervisorFSM_TX'
 
 #endif                                 // RTW_HEADER_SupervisorFSM_TX_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 2.43
+// Model version                  : 2.50
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:07 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:29 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 2.43
+// Model version                  : 2.50
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Wed Aug  4 14:13:07 2021
+// C/C++ source code generated on : Mon Sep 20 12:43:29 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -59,6 +59,7 @@ struct MotorSensors
   real32_T voltage;
   Thresholds threshold;
   real32_T current;
+  uint8_T hallABC;
 };
 
 #endif


### PR DESCRIPTION
This PR updates `application 03` from MVP 0.2 to the recent change in using nonvirtual buses (from [this PR in `study-amc-bldc`](https://github.com/icub-tech-iit/study-mbd-amc-bldc/pull/38)). 

C++ code was re-generated using nonvirtual buses and added as part of the project files. The `theMBDagent` class has been updated to use the new code.

As expected, adapting the new code was significantly easier and required less variables than before. Here is an example in the previous code:

```diff
-               can_decoder.step(&decoder_available, &packet_CLS, &packet_SRC, &packet_DST_TYP, &packet_LEN, &packet_M, &packet_OPC, &packet_ARG[0],
-                                                                               &rtb_motor, &rtb_mode, &rtb_motor_e, &rtb_nominal, &rtb_peak, &rtb_overload, &rtb_current_o, &rtb_control_mode, &rtb_current_limit, &rtb_desired_current, &rtb_event, &rtb_type);
+               can_decoder.step(bus_can_rx, bus_messages_rx, bus_events_rx, bus_can_rx_errors);

-    supervisor_rx.step((const BoardState*)board_state_gnd, (const BoardCommand*)board_command_gnd,
-                                                                                               &iabc[0], &angle, &omega, &temperature, &motor_sensors_voltage,
-                                                                                               &current_threshold, &cu_k_threshold, &voltage_threshold, &vo_k_threshold, &temperature_threshold, &te_c_threshold,
-                                                                                               &motor_sensors_current,
-                                                                                               &rtb_event, &rtb_control_mode, &rtb_current_limit, &rtb_desired_current,
-                                                                                               &rtb_motor, &rtb_mode, &rtb_motor_e, &rtb_nominal, &rtb_peak, &rtb_overload, &rtb_current_o,
-                                                                                               &supervisor_control_mode, &pid_reset, &position, &velocity, &current, &voltage);
+    supervisor_rx.step(internal_messages, motor_sensors, bus_events_rx, bus_messages_rx, bus_can_rx_errors, flags, targets);

```

The application has been tested using `CANReal` and the behavior remains identical to before. Particularly when using the `scan`, `set control mode idle` and `set control mode speedvoltage` commands. 

This PR addresses [#747](https://github.com/icub-tech-iit/code/issues/747).

cc @sgiraz @valegagge @pattacini 