### PR TITLE
Updated AMC BLDC firmware to use new format ID function

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.322
+// Model version                  : 1.327
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
+// C/C++ source code generated on : Tue Sep 21 16:48:15 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -112,10 +112,15 @@ namespace can_messaging
     arg_pck_tx.packets.PAYLOAD[7] = static_cast<uint8_T>
       ((rtb_DataTypeConversion2 & MAX_int32_T) >> 24);
 
-    // BusCreator: '<S1>/Bus Creator1' incorporates:
-    //   Constant: '<S1>/Constant'
+    // MATLAB Function: '<S1>/format_can_id' incorporates:
+    //   Constant: '<S1>/Constant1'
+    //   Constant: '<S1>/Motor Control Streaming'
+    //   Constant: '<S1>/TYPE2FOC'
 
-    arg_pck_tx.packets.ID = rtP_CAN_ID_HOST;
+    arg_pck_tx.packets.ID = 256U;
+    arg_pck_tx.packets.ID = static_cast<uint16_T>(rtP_CAN_ID_AMC << 4 |
+      arg_pck_tx.packets.ID);
+    arg_pck_tx.packets.ID = static_cast<uint16_T>(arg_pck_tx.packets.ID | 15);
 
     // DataTypeConversion: '<S1>/Data Type Conversion' incorporates:
     //   RelationalOperator: '<S2>/FixPt Relational Operator'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application03/src/model-based-design/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 1.322
+// Model version                  : 1.327
 // Simulink Coder version         : 9.5 (R2021a) 14-Nov-2020
-// C/C++ source code generated on : Mon Sep 20 12:43:44 2021
+// C/C++ source code generated on : Tue Sep 21 16:48:15 2021
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -33,8 +33,8 @@ extern real32_T rtP_CAN_ANGLE_DEG2ICUB;// Variable: CAN_ANGLE_DEG2ICUB
                                           //    '<S1>/Gain'
                                           //    '<S1>/Gain1'
 
-extern uint16_T rtP_CAN_ID_HOST;       // Variable: CAN_ID_HOST
-                                          //  Referenced by: '<S1>/Constant'
+extern uint8_T rtP_CAN_ID_AMC;         // Variable: CAN_ID_AMC
+                                          //  Referenced by: '<S1>/Constant1'
 
 
 // Class declaration for model can_encoder
@@ -100,6 +100,7 @@ namespace can_messaging
 //  '<S1>'   : 'can_encoder/CAN_Encoder'
 //  '<S2>'   : 'can_encoder/CAN_Encoder/Detect Change'
 //  '<S3>'   : 'can_encoder/CAN_Encoder/MATLAB Function'
+//  '<S4>'   : 'can_encoder/CAN_Encoder/format_can_id'
 
 #endif                                 // RTW_HEADER_can_encoder_h_
 


### PR DESCRIPTION
This PR updates `application03` to reflect the [latest changes](https://github.com/icub-tech-iit/study-mbd-amc-bldc/pull/48) in `study-mbd-amc-bldc`, regarding the use of a new function for setting the ID of the output CAN messages.

This has been tested on the board and the behavior remains the same, only difference is a more correct ID in the output messages, as you can see in [this comment](https://github.com/icub-tech-iit/study-mbd-amc-bldc/pull/48#issue-1002754676) 