### PR TITLE
More RTOS trace for the mc4plus board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
@@ -49,6 +49,7 @@ volatile uint32_t FATALERR_tmrman[8] = {0};
 
 #if defined(FATALERR_trace_RTOS)
 volatile uint32_t FATALERR_rtos[8] = {0};
+volatile uint32_t FATALERR_rtos2[16] = {0};
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -699,6 +700,12 @@ static void s_save_rtos(void)
     {
         pRTOS[i] = FATALERR_rtos[i];
     }
+    
+    volatile uint32_t *pRTOS2 = (volatile uint32_t*) (0x10000000+384);
+    for(int i=0; i<8; i++)
+    {
+        pRTOS2[i] = FATALERR_rtos2[i];
+    }    
 #endif      
 }
 
@@ -755,6 +762,7 @@ static void s_info_rtos(EOtheFatalError *p)
 #if defined(FATALERR_trace_RTOS)   
     
     volatile uint32_t *pRTOS = (volatile uint32_t*) (0x10000000+256);
+    volatile uint32_t *pOS = (volatile uint32_t*) (0x10000000+384);
     
     uint16_t par16 = 0;
     uint64_t par64 = p->detectedfatalerror.params.par64;     
@@ -771,8 +779,19 @@ static void s_info_rtos(EOtheFatalError *p)
 
     // caveat the string can be at most 48 characters 
     
-    // System control registers. 
-    
+    // RTOS
+
+    for(int i=0; i<8; i++)
+    {
+        int f0 = 2*i;
+        int f1 = 2*i+1;
+        snprintf(str, sizeof(str), "OS%02d = 0x%08x OS%02d = 0x%08x", 
+            f0, pOS[f0], f1, pOS[f1]
+        );        
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, str, s_eobj_ownname, &p->errdes); 
+    }
+
+    // the others  
     snprintf(str, sizeof(str), "RT0 = 0x%08x RT1 = 0x%08x", 
         pRTOS[0], pRTOS[1]
     );        

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
@@ -702,7 +702,7 @@ static void s_save_rtos(void)
     }
     
     volatile uint32_t *pRTOS2 = (volatile uint32_t*) (0x10000000+384);
-    for(int i=0; i<8; i++)
+    for(int i=0; i<16; i++)
     {
         pRTOS2[i] = FATALERR_rtos2[i];
     }    

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -85,7 +85,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          39
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          40
 
 
 //  </h>version
@@ -94,13 +94,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2021
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          2
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/osal/src/osal-oosiit.c
+++ b/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/osal/src/osal-oosiit.c
@@ -35,6 +35,10 @@
 
 #include "stdio.h"
 
+#if defined(FATALERR_trace_RTOS)
+#include "oosiit.h"
+#endif
+
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of extern public interface
 // --------------------------------------------------------------------------------------------------------------------
@@ -1046,6 +1050,8 @@ extern osal_result_t osal_messagequeue_get(osal_messagequeue_t *mq, osal_message
 
 extern osal_message_t osal_messagequeue_getquick(osal_messagequeue_t *mq, osal_reltime_t tout, osal_caller_t caller)
 {
+    FATALERR_RT2_set(FT_0, 1);
+    FATALERR_RT2_set(FT_1, mq);
     void *p = NULL;
 
     if(NULL == mq)
@@ -1057,7 +1063,10 @@ extern osal_message_t osal_messagequeue_getquick(osal_messagequeue_t *mq, osal_r
     if(NULL == (rtosobj = s_osal_rtosobj_get((osal_obj_t*)mq, osal_messagequeue_signature)))
     {
         return((osal_message_t)0);
-    }    
+    }   
+
+    FATALERR_RT2_set(FT_0, 2);
+    FATALERR_RT2_set(FT_2, rtosobj);    
     
     // any caller
     oosiit_mbx_retrieve(rtosobj, &p, s_osal_timeout2tick(tout));

--- a/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/osal/src/osal-oosiit.c
+++ b/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/osal/src/osal-oosiit.c
@@ -1056,12 +1056,14 @@ extern osal_message_t osal_messagequeue_getquick(osal_messagequeue_t *mq, osal_r
 
     if(NULL == mq)
     {
+        FATALERR_RT2_set(FT_0, 256);
         return((osal_message_t)0);
     }
     
     void* rtosobj = NULL;
     if(NULL == (rtosobj = s_osal_rtosobj_get((osal_obj_t*)mq, osal_messagequeue_signature)))
     {
+        FATALERR_RT2_set(FT_0, 257);
         return((osal_message_t)0);
     }   
 
@@ -1071,6 +1073,8 @@ extern osal_message_t osal_messagequeue_getquick(osal_messagequeue_t *mq, osal_r
     // any caller
     oosiit_mbx_retrieve(rtosobj, &p, s_osal_timeout2tick(tout));
 
+    FATALERR_RT2_set(FT_0, 255);
+    FATALERR_RT2_set(FT_15, p);
     
     return((osal_message_t)p);
 }

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/api/oosiit.h
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/api/oosiit.h
@@ -53,6 +53,35 @@ extern "C" {
 #define OOSIIT_NOTIMEOUT    0xffffffff
 #define OOSIIT_ASAPTIME     0xffffffffffffffff
 
+#if defined(FATALERR_trace_RTOS)
+extern volatile uint32_t FATALERR_rtos[8];
+extern volatile uint32_t FATALERR_rtos2[16];
+#define FT_0 0
+#define FT_1 1
+#define FT_2 2
+#define FT_3 3
+#define FT_4 4
+#define FT_5 5
+#define FT_6 6
+#define FT_7 7
+#define FT_8 8
+#define FT_9 9
+#define FT_10 10
+#define FT_11 11
+#define FT_12 12
+#define FT_13 13
+#define FT_14 14
+#define FT_15 15
+#define FATALERR_RT_set(a, b)           FATALERR_rtos[(a)] = (uint32_t)(b)
+#define FATALERR_RT_setcond(a, b, c)    FATALERR_rtos[(a)] = (c) ? ((uint32_t)(b)) : (0)
+#define FATALERR_RT2_set(a, b)          FATALERR_rtos2[(a)] = (uint32_t)(b)
+#define FATALERR_RT2_setcond(a, b, c)   FATALERR_rtos2[(a)] = (c) ? ((uint32_t)(b)) : (0)
+#else
+#define FATALERR_RT_set(a, b)
+#define FATALERR_RT_setcond(a, b, c) 
+#define FATALERR_RT2_set(a, b)          
+#define FATALERR_RT2_setcond(a, b, c)   FATALERR_rtos2[(a)] = (c) ? ((uint32_t)(b)) : (0)
+#endif
 
 // - declaration of public user-defined types ------------------------------------------------------------------------- 
 

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/RTX_Config.h
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/RTX_Config.h
@@ -36,6 +36,7 @@
 
 #if defined(FATALERR_trace_RTOS)
 extern volatile uint32_t FATALERR_rtos[8];
+extern volatile uint32_t FATALERR_rtos2[16];
 #define FT_0 0
 #define FT_1 1
 #define FT_2 2
@@ -44,11 +45,23 @@ extern volatile uint32_t FATALERR_rtos[8];
 #define FT_5 5
 #define FT_6 6
 #define FT_7 7
+#define FT_8 8
+#define FT_9 9
+#define FT_10 10
+#define FT_11 11
+#define FT_12 12
+#define FT_13 13
+#define FT_14 14
+#define FT_15 15
 #define FATALERR_RT_set(a, b)           FATALERR_rtos[(a)] = (uint32_t)(b)
 #define FATALERR_RT_setcond(a, b, c)    FATALERR_rtos[(a)] = (c) ? ((uint32_t)(b)) : (0)
+#define FATALERR_RT2_set(a, b)          FATALERR_rtos2[(a)] = (uint32_t)(b)
+#define FATALERR_RT2_setcond(a, b, c)   FATALERR_rtos2[(a)] = (c) ? ((uint32_t)(b)) : (0)
 #else
 #define FATALERR_RT_set(a, b)
 #define FATALERR_RT_setcond(a, b, c) 
+#define FATALERR_RT2_set(a, b)          
+#define FATALERR_RT2_setcond(a, b, c)   FATALERR_rtos2[(a)] = (c) ? ((uint32_t)(b)) : (0)
 #endif
 
 /* Error Codes */

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/rt_List.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/rt_List.c
@@ -98,6 +98,8 @@ P_TCB rt_get_first (P_XCB p_CB) {
   P_TCB p_first;
 
   p_first = p_CB->p_lnk;
+    FATALERR_RT2_set(FT_14, p_first);
+    FATALERR_RT2_set(FT_0, 8);
   p_CB->p_lnk = p_first->p_lnk;
   if ((p_CB->cb_type == SCB) || (p_CB->cb_type == MCB) || (p_CB->cb_type == MUCB)) {
     if (p_first->p_lnk != NULL) {

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/rt_Mailbox.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/rt_Mailbox.c
@@ -206,8 +206,11 @@ OS_RESULT isr_mbx_receive (OS_ID mailbox, void **message) {
   /* Receive a message in the interrupt function. The interrupt function   */
   /* should not wait for a message since this would block the rtx os.      */
   P_MCB p_MCB = mailbox;
+    
+    FATALERR_RT2_set(FT_0, 33);
 
   if (p_MCB->count) {
+      FATALERR_RT2_set(FT_0, 34);
     /* A message is available in the fifo buffer. */
     *message = p_MCB->msg[p_MCB->last];
     if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2U)) {
@@ -262,7 +265,8 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       }
       p_TCB->state = READY;
         FATALERR_RT_set(FT_0, 23);
-        FATALERR_RT_set(FT_1, 0);      rt_rmv_dly (p_TCB);
+        FATALERR_RT_set(FT_1, 0);      
+      rt_rmv_dly (p_TCB);
       rt_put_prio (&os_rdy, p_TCB);
       break;
     case 1:

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/oosiit.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/oosiit.c
@@ -989,12 +989,12 @@ extern oosiit_result_t oosiit_mbx_retrieve(oosiit_objptr_t mailbox, void** messa
     
     if(0 != __get_IPSR()) 
     {   // inside isr
-        FATALERR_RT2_set(FT_0, 3);
+        FATALERR_RT2_set(FT_0, 31); // unlikely path
         return(isr_oosiit_mbx_retrieve(mailbox, message));
     } 
     else if(1 == s_oosiit_started)
     {   // call svc
-         FATALERR_RT2_set(FT_0, 4);
+         FATALERR_RT2_set(FT_0, 30); // detected path
          return(__svc_oosiit_mbx_retrieve(mailbox, message, timeout));
     }
     else
@@ -2192,6 +2192,7 @@ static __INLINE void* isr_oosiit_tsk_get_extdata(oosiit_tskptr_t tp)
 
 static __INLINE oosiit_result_t isr_oosiit_mbx_retrieve(oosiit_objptr_t mailbox, void** message)
 {
+    FATALERR_RT2_set(FT_0, 32);
     int32_t r = isr_mbx_receive(mailbox, message);
     
     if(OS_R_OK == r)

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/oosiit.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/oosiit.c
@@ -989,10 +989,12 @@ extern oosiit_result_t oosiit_mbx_retrieve(oosiit_objptr_t mailbox, void** messa
     
     if(0 != __get_IPSR()) 
     {   // inside isr
+        FATALERR_RT2_set(FT_0, 3);
         return(isr_oosiit_mbx_retrieve(mailbox, message));
     } 
     else if(1 == s_oosiit_started)
     {   // call svc
+         FATALERR_RT2_set(FT_0, 4);
          return(__svc_oosiit_mbx_retrieve(mailbox, message, timeout));
     }
     else

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/rt_iit_changes.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/rt_iit_changes.c
@@ -1237,22 +1237,48 @@ OS_RESULT iitchanged_rt_mbx_send (OS_ID mailbox, void *p_msg, TIME_t timeout) {
   return (OS_R_OK);
 }
 
+#if defined(FATALERR_trace_RTOS)
+// i use it in here to avoid stack 
+uint32_t ft_tmp0 = 0;
+uint32_t ft_tmp1 = 0;
+uint32_t ft_tmp2 = 0;
+#endif
 
 // in here we just use TIME_t for type of timeout and use iitchanged_rt_block() 
 OS_RESULT iitchanged_rt_mbx_wait (OS_ID mailbox, void **message, TIME_t timeout) {
   /* Receive a message; possibly wait for it */
   P_MCB p_MCB = mailbox;
   P_TCB p_TCB;
+    
+    FATALERR_RT2_set(FT_0, 3);
+    FATALERR_RT2_set(FT_3, mailbox);
+    FATALERR_RT2_set(FT_4, message);
+    FATALERR_RT2_set(FT_5, timeout);
+    #if defined(FATALERR_trace_RTOS)
+    ft_tmp0 = (uint32_t)p_MCB->cb_type | ((uint32_t)p_MCB->state << 8) | ((uint32_t)p_MCB->isr_st << 16); 
+    ft_tmp1 = (uint32_t)p_MCB->first | ((uint32_t)p_MCB->last << 16);
+    ft_tmp2 = (uint32_t)p_MCB->count | ((uint32_t)p_MCB->size << 16);    
+    #endif
+    FATALERR_RT2_set(FT_6, ft_tmp0);
+    FATALERR_RT2_set(FT_7, p_MCB->p_lnk);
+    FATALERR_RT2_set(FT_8, ft_tmp1);
+    FATALERR_RT2_set(FT_9, ft_tmp2);
+    FATALERR_RT2_set(FT_10, p_MCB->msg);
+    FATALERR_RT2_set(FT_0, 4);
 
   /* If a message is available in the fifo buffer */
   /* remove it from the fifo buffer and return. */
   if (p_MCB->count) {
     *message = p_MCB->msg[p_MCB->last];
+      FATALERR_RT2_set(FT_0, 5);
     if (++p_MCB->last == p_MCB->size) {
       p_MCB->last = 0U;
+        FATALERR_RT2_set(FT_0, 6);
     }
     if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2U)) {
       /* A task is waiting to send message */
+        FATALERR_RT2_set(FT_0, 7);
+        FATALERR_RT2_set(FT_11, p_MCB);
       p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
       rt_ret_val(p_TCB, 0U/*osOK*/);

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/rt_iit_changes.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/rt_iit_changes.c
@@ -1251,7 +1251,7 @@ OS_RESULT iitchanged_rt_mbx_wait (OS_ID mailbox, void **message, TIME_t timeout)
   P_TCB p_TCB;
     
     FATALERR_RT2_set(FT_0, 3);
-    FATALERR_RT2_set(FT_3, mailbox);
+    FATALERR_RT2_set(FT_3, p_MCB);
     FATALERR_RT2_set(FT_4, message);
     FATALERR_RT2_set(FT_5, timeout);
     #if defined(FATALERR_trace_RTOS)
@@ -1265,6 +1265,7 @@ OS_RESULT iitchanged_rt_mbx_wait (OS_ID mailbox, void **message, TIME_t timeout)
     FATALERR_RT2_set(FT_9, ft_tmp2);
     FATALERR_RT2_set(FT_10, p_MCB->msg);
     FATALERR_RT2_set(FT_0, 4);
+      
 
   /* If a message is available in the fifo buffer */
   /* remove it from the fifo buffer and return. */
@@ -1277,14 +1278,18 @@ OS_RESULT iitchanged_rt_mbx_wait (OS_ID mailbox, void **message, TIME_t timeout)
     }
     if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2U)) {
       /* A task is waiting to send message */
-        FATALERR_RT2_set(FT_0, 7);
         FATALERR_RT2_set(FT_11, p_MCB);
+        FATALERR_RT2_set(FT_0, 7);
       p_TCB = rt_get_first ((P_XCB)p_MCB);
+        FATALERR_RT2_set(FT_12, p_TCB);
+        FATALERR_RT2_set(FT_0, 9);
 #ifdef __CMSIS_RTOS
       rt_ret_val(p_TCB, 0U/*osOK*/);
 #else
       rt_ret_val(p_TCB, OS_R_OK);
 #endif
+        FATALERR_RT2_set(FT_13, p_TCB->msg);
+        FATALERR_RT2_set(FT_0, 10);
       p_MCB->msg[p_MCB->first] = p_TCB->msg;
       if (++p_MCB->first == p_MCB->size) {
         p_MCB->first = 0U;


### PR DESCRIPTION
This PR builds up on the results logged with the mc4plus application generated by a former [PR](https://github.com/robotology/icub-firmware/pull/209) and adds further trace information for the RTOS according to what the analysis of the log has shown (see [here](https://github.com/robotology/icub-tech-support/issues/673#issuecomment-958998097)). 

In particular in here we trace the execution of the function `osal_messagequeue_getquick()`.
We have added for this purpose 16 more variables in which:
- OS00 contains a value which show the progress of execution,
- OS01 to OS15 contain snapshots of the variables.

A companion PR is being produced in [icub-firmware-build](https://github.com/robotology/icub-firmware-build/pull/37) for a new binary of the mc4plus.

Tests on a dedicated setup have validate the [binary](https://github.com/robotology/icub-firmware-build/pull/37) of the mc4plus generated by this PR so we can safely merge this code and associated PR on icub-firmware-build.