### PR TITLE
Increased stack in mc4plus 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheFatalError.c
@@ -180,8 +180,8 @@ extern void eo_fatalerror_AtStartup(EOtheFatalError *p)
                 s_info_standard(p);                
             }
             s_info_mpustate(p);
-            s_info_tmrman(p);
             s_info_rtos(p);
+            s_info_tmrman(p);
         }                        
     } 
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/hal_startup_mpu_name_stm32f407ig-v6.s
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/hal_startup_mpu_name_stm32f407ig-v6.s
@@ -61,7 +61,7 @@
 ;#include "hal_core_cfg.h"
     
 
-Stack_Size      EQU     0x00002000
+Stack_Size      EQU     0x00002C00
 ;Stack_Size      EQU     HAL_SYS_CFG_STACKSIZE
                 EXPORT  Stack_Size
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -85,7 +85,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          40
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          41
 
 
 //  </h>version
@@ -96,11 +96,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          2
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          11
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          25
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/rt_List.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/cmsis-rtx-modified/cm/rt_List.c
@@ -98,7 +98,7 @@ P_TCB rt_get_first (P_XCB p_CB) {
   P_TCB p_first;
 
   p_first = p_CB->p_lnk;
-    FATALERR_RT2_set(FT_14, p_first);
+    FATALERR_RT2_set(FT_15, p_first);
     FATALERR_RT2_set(FT_0, 8);
   p_CB->p_lnk = p_first->p_lnk;
   if ((p_CB->cb_type == SCB) || (p_CB->cb_type == MCB) || (p_CB->cb_type == MUCB)) {

--- a/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/rt_iit_changes.c
+++ b/emBODY/eBcode/arch-arm/libs/midware/oosiit/src/others/rt_iit_changes.c
@@ -1252,18 +1252,19 @@ OS_RESULT iitchanged_rt_mbx_wait (OS_ID mailbox, void **message, TIME_t timeout)
     
     FATALERR_RT2_set(FT_0, 3);
     FATALERR_RT2_set(FT_3, p_MCB);
-    FATALERR_RT2_set(FT_4, message);
-    FATALERR_RT2_set(FT_5, timeout);
+    FATALERR_RT2_set(FT_4, &p_MCB);
+    FATALERR_RT2_set(FT_5, message);
+    FATALERR_RT2_set(FT_6, timeout);
     #if defined(FATALERR_trace_RTOS)
     ft_tmp0 = (uint32_t)p_MCB->cb_type | ((uint32_t)p_MCB->state << 8) | ((uint32_t)p_MCB->isr_st << 16); 
     ft_tmp1 = (uint32_t)p_MCB->first | ((uint32_t)p_MCB->last << 16);
     ft_tmp2 = (uint32_t)p_MCB->count | ((uint32_t)p_MCB->size << 16);    
     #endif
-    FATALERR_RT2_set(FT_6, ft_tmp0);
-    FATALERR_RT2_set(FT_7, p_MCB->p_lnk);
-    FATALERR_RT2_set(FT_8, ft_tmp1);
-    FATALERR_RT2_set(FT_9, ft_tmp2);
-    FATALERR_RT2_set(FT_10, p_MCB->msg);
+    FATALERR_RT2_set(FT_7, ft_tmp0);
+    FATALERR_RT2_set(FT_8, p_MCB->p_lnk);
+    FATALERR_RT2_set(FT_9, ft_tmp1);
+    FATALERR_RT2_set(FT_10, ft_tmp2);
+    FATALERR_RT2_set(FT_11, p_MCB->msg);
     FATALERR_RT2_set(FT_0, 4);
       
 
@@ -1278,17 +1279,17 @@ OS_RESULT iitchanged_rt_mbx_wait (OS_ID mailbox, void **message, TIME_t timeout)
     }
     if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2U)) {
       /* A task is waiting to send message */
-        FATALERR_RT2_set(FT_11, p_MCB);
+        FATALERR_RT2_set(FT_12, p_MCB);
         FATALERR_RT2_set(FT_0, 7);
       p_TCB = rt_get_first ((P_XCB)p_MCB);
-        FATALERR_RT2_set(FT_12, p_TCB);
+        FATALERR_RT2_set(FT_13, p_TCB);
         FATALERR_RT2_set(FT_0, 9);
 #ifdef __CMSIS_RTOS
       rt_ret_val(p_TCB, 0U/*osOK*/);
 #else
       rt_ret_val(p_TCB, OS_R_OK);
 #endif
-        FATALERR_RT2_set(FT_13, p_TCB->msg);
+        FATALERR_RT2_set(FT_14, p_TCB->msg);
         FATALERR_RT2_set(FT_0, 10);
       p_MCB->msg[p_MCB->first] = p_TCB->msg;
       if (++p_MCB->first == p_MCB->size) {


### PR DESCRIPTION
Following my comment in [here](https://github.com/robotology/icub-tech-support/issues/673#issuecomment-966207702), the PR adds:
- 3K more stack to IRQ handlers
- print of address of the used stack in diagnostics.

 