### PR TITLE
No nonius management of AMO sensors

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          44
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          45
 
 //  </h>version
 
@@ -89,11 +89,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2021
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          59
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
@@ -623,6 +623,20 @@ extern eOresult_t eo_appEncReader_GetValue(EOappEncReader *p, uint8_t jomo, eOen
                     //spiRawValue = (spiRawValue>>4) & 0xFFFF; marco.accame on 07jun17: why is there this comment? shall we remove it?
                     
                     // GOOD VALUE
+                    
+                    eOmc_joint_t *joint = (eOmc_joint_t*) eoprot_entity_ramof_get(eoprot_board_localboard, eoprot_endpoint_motioncontrol, eoprot_entity_mc_joint, jomo);
+                    
+                    int16_t sectors = (int16_t)(joint->config.gearbox_E2J + 0.5f);
+                    
+                    if (sectors == 32)
+                    {
+                        spiRawValue = (spiRawValue >> 1) & 0x3FFF;
+                    }
+                    else if (sectors == 64)
+                    {
+                        spiRawValue = spiRawValue & 0x3FFF;
+                    }
+                    
                     prop.valueinfo->value[0] = s_eo_appEncReader_rescale2icubdegrees(spiRawValue, jomo, (eOmc_position_t)prop.descriptor->pos);
                 }
                 else

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -569,6 +569,16 @@ BOOL JointSet_do_wait_calibration_10(JointSet* o)
 {
     BOOL calibrated = TRUE;
     
+    for (int ms=0; ms<*(o->pN); ++ms)
+    {
+        if (!Motor_is_calibrated(o->motor+o->motors_of_set[ms])) 
+        {
+            calibrated = FALSE;
+        }
+    }
+    
+    if (!calibrated) return FALSE;
+    
     for (int k=0; k<*(o->pN); ++k)
     {
         int m = o->motors_of_set[k];
@@ -579,7 +589,7 @@ BOOL JointSet_do_wait_calibration_10(JointSet* o)
         {
             Motor_set_pwm_ref(o->motor+m, o->motor[m].calib_pwm);
         
-            if (AbsEncoder_is_still(o->absEncoder+e, 12000, 500))
+            if (AbsEncoder_is_still(o->absEncoder+e, 12000, 1000))
             {
                 AbsEncoder_calibrate_in_hard_stop(o->absEncoder+e);
             }


### PR DESCRIPTION
Now, AMO sensors can be read as multi-sector (64 or 32) 14-bit resolution encoders (20 or 19-bit resolution total).

The calibration is hard-stop (type 10) as in R1 wrist pronosupination.
