### PR TITLE
Board mc4plus: different application versions for the standard and trace-RTOS versions 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/hal_core_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/abslayer/hal_core_cfg.h
@@ -66,7 +66,7 @@ extern "C" {
 //   <o> stack size         <0x0-0xFFFFFFFF:8>
 //   <i> define how much stack you want.
 #ifndef HAL_SYS_CFG_STACKSIZE
- #define HAL_SYS_CFG_STACKSIZE      0x00002000
+ #define HAL_SYS_CFG_STACKSIZE      0x00002C00
 #endif
 
 //   <o> heap size         <0x0-0xFFFFFFFF:8>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -67,6 +67,8 @@ extern "C" {
     #define VERSION_MAJOR_OFFSET  70
 #elif defined(EOTHESERVICES_customize_handV3)
     #define VERSION_MAJOR_OFFSET  30
+#elif defined(FATALERR_trace_RTOS) || defined(FATALERR_trace_TMRMAN)
+    #define VERSION_MAJOR_OFFSET  100
 #else
     #define VERSION_MAJOR_OFFSET 0
 #endif
@@ -85,7 +87,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          41
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          42
 
 
 //  </h>version
@@ -96,11 +98,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          25
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          33
 
 //  </h>build date
 


### PR DESCRIPTION
This PR allows to differentiate the two versions of binaries for the mc4plus: the one dedicated to trace the RTOS execution in case of fatal error uses version 103.xx and the traditional one 3.xx.

Both versions use now 11K of stack size.

The associated PR in  icub-firmware-build is https://github.com/robotology/icub-firmware-build/pull/41 which produces the binaries, versions 103.42 and 3.42.

Both binaries have been validated by running yarprobotinterface on a dedicated setup w/ an AEA2 and a DC motor.

