### PR TITLE
Fix of bootloader of mtb4 (and strain2, rfe, psc)

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_flash.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_flash.cpp
@@ -108,14 +108,14 @@ namespace embot { namespace hw { namespace flash {
             return maxNumOfPAGEs;
         }
         
-        return ((address - part.address) % part.pagesize);
+        return ((address - part.address) / part.pagesize);
     }
     
     std::uint32_t page2address(std::uint32_t page)
     {
         const embot::hw::Partition &part = embot::hw::flash::getpartition(embot::hw::FLASH::whole);
-        
-        uint32_t adr = part.pagesize*page;
+
+        uint32_t adr = part.address + part.pagesize*page;
         
         if(false == isaddressvalid(adr))
         {


### PR DESCRIPTION
This PR fixed the issue https://github.com/robotology/icub-firmware/issues/202 by correcting how the memory address is mapped into pages of the FLASH and vice-versa. The bug was introduced when we added support for page of FLASH different from 2KB, as for the `pmc` and `amcbldc` boards which use 4BB.

The bug affected only the bootloaders and not the application. Moreover, the bootloader in icub-firmware-build have always worked because were produced w/ source code which did not have the bug, so new binary is required.

Tests w/ latest build of icub-main in devel have shown that the boards `mtb4` and `rfe` successfully update the application both when the start from the `bootloader` and the old `application`.

So, we can safely merge the change.
