### PR TITLE
Fixed bootloader for boards amcbldc and pmc

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_bootloader_theCANparser.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_bootloader_theCANparser.cpp
@@ -394,11 +394,16 @@ bool embot::app::bootloader::theCANparser::Impl::process_bl_board(const embot::p
     embot::prot::can::bootloader::Message_BOARD msg;
     msg.load(frame);
     
-    // get the eraseeeprom info.    
+    // get the eraseeeprom info. we erase eeprom at the end    
     eraseAPPLstorage = (1 == msg.info.eepromerase) ? (true) : (false);
     
-    // we may erase flash (and eeprom now) but ... we wait.
-            
+    // we erase flash now so that when the bursts of {address, data, data, data} arrive, then
+    // the flash is ready to be written. that is required for some boards whose flash erase operation
+    // is slow but it is ok for every board.  
+    // NOTE THIS: flashburner->erase() is guaranteed to erase only once.
+
+    flashburner->erase();
+          
     if(true == msg.reply(reply, embot::app::theCANboardInfo::getInstance().cachedCANaddress()))
     {
         replies.push_back(reply);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_FlashBurner.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_FlashBurner.cpp
@@ -109,7 +109,10 @@ struct embot::hw::FlashBurner::Impl
         for(uint32_t i=0; i<n64bitwords; i++)
         {
 #if !defined(TEST_DONT_USE_FLASH)            
-            HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, tmpadr, buffer.data[i]);
+            if(isaddressvalid(tmpadr))
+            {                
+                HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, tmpadr, buffer.data[i]);
+            }
 #endif
             tmpadr += 8;
         }
@@ -134,7 +137,7 @@ struct embot::hw::FlashBurner::Impl
         
         // init the page size used by the flash 
         PAGEsize = embot::hw::flash::getBSP().getPROP(embot::hw::FLASH::whole)->partition.pagesize;
-        
+        _buffersize = PAGEsize;
         size = _size;
         
         buffer.page = noPAGE;
@@ -176,6 +179,15 @@ struct embot::hw::FlashBurner::Impl
             delete[] buffer.data;
         }
     }
+
+    bool isaddressvalid(std::uint32_t address)
+    {
+        if((address < start) || (address > (start+size)) )
+        {
+            return false;
+        }
+        return true;
+    }    
 };
 
 
@@ -198,11 +210,7 @@ embot::hw::FlashBurner::~FlashBurner()
 
 bool embot::hw::FlashBurner::isAddressValid(std::uint32_t address)
 {
-    if((address < pImpl->start) || (address > (pImpl->start+pImpl->size)) )
-    {
-        return false;
-    }
-    return true;
+    return pImpl->isaddressvalid(address);
 }
 
 
@@ -290,12 +298,12 @@ bool embot::hw::FlashBurner::flush()
 }
 
 
-#if 0
+
 bool embot::hw::FlashBurner::erase()
 { 
     return pImpl->eraseall();
 }
-#endif
+
 
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_FlashBurner.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_FlashBurner.h
@@ -41,7 +41,7 @@ namespace embot { namespace hw {
         // it forces a write of the content of the buffer.
         bool flush();
         
-        //bool erase();
+        bool erase();
         
         bool isAddressValid(std::uint32_t address);
       


### PR DESCRIPTION
This PR allows correct operativity of the board `amcbldc` and `pmc` w/ FirmwareUpdater.

This PR is linked w/ two other PRs: one on [`icub-firmware-shared`](https://github.com/robotology/icub-firmware-shared/pull/51) which gives support for the `amcbldc`  and one in [`icub-main`](https://github.com/robotology/icub-main/pull/778) which allows the FirmwareUpdater to operate correctly with `pmc` and `amcbldc`. 

The boards `amcbldc` and `pmc` need longer time for the erase of the FLASH which joined w/ the timing used by the `canloader` library in `icub-main` and the impossibility to process CAN frames during the erase operation cause a failure in updating the binaries via CAN.

The solution is to be solved jointly:
- in `icub-firmware`: we anticipate the erase FLASH operation at rx of CAN message `BOOTLOADER:board`;
- in `icub-main`: we wait for a slightly longer time after we send the `BOOTLOADER:board` CAN message.

Tests have shown that this solution solves the problem for these two boards and is also compatible w/ legacy CAN boards.

| ![amcbldc-updating](https://user-images.githubusercontent.com/7148284/144589875-a1507fdb-ca01-49ec-b2f7-d07aa23f1bbd.png)   |  ![amcbldc-updated](https://user-images.githubusercontent.com/7148284/144589943-762ef984-6905-44e2-8b65-76a9b90e7174.png) |
| ---- | ---- |
|  ![Screenshot from 2021-12-03 11-42-56](https://user-images.githubusercontent.com/7148284/144590177-8e49e1ea-3037-40a0-8f78-812d3b77d213.png) | ![Screenshot from 2021-12-03 11-46-14](https://user-images.githubusercontent.com/7148284/144590243-2d27bb30-c195-4b54-b17f-0849c5890d49.png)  |

**Figure**. Updating the `amcbldc` and the `strain2` boards.










