### PR TITLE
Add latest fault state to motor status data structure 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          47
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          48
 
 //  </h>version
 
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2021
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          34
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          35
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -813,7 +813,19 @@ extern eOresult_t eo_motioncontrol_Deactivate(EOtheMotionController *p)
         eo_vector_Clear(p->sharedcan.entitydescriptor);
         eo_vector_Clear(p->sharedcan.boardproperties);   
         eo_array_Reset(p->sharedcan.discoverytargets);                
-    }      
+    }
+    
+    // Reset the communicated fault state to dummy for each motor
+    uint8_t n_motors = eo_entities_NumOfMotors(eo_entities_GetHandle());
+    
+    for(uint8_t mId = 0; mId < n_motors; mId++)
+    {
+       eOmc_motor_status_t *mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), mId);
+       if (NULL != mstatus)
+       {
+           mstatus->mc_fault_state = eoerror_code_dummy;
+       }
+    }
     
     p->numofjomos = 0;
     eo_entities_SetNumOfJoints(eo_entities_GetHandle(), 0);
@@ -1665,6 +1677,9 @@ extern void eoprot_fun_INIT_mc_motor_status(const EOnv* nv)
 {
     eOmc_motor_status_t *sta = (eOmc_motor_status_t*)eo_nv_RAM(nv);
     memmove(sta, &s_motor_default_value.status, sizeof(eOmc_motor_status_t));
+    
+    // Initialize the fault state to dummy since code zero is assigned to unspecified system error
+    sta->mc_fault_state = eoerror_code_dummy;
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          31
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          32
 //  </h>version
 
 //  <h> build date
@@ -84,11 +84,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          35
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -87,7 +87,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          45
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          46
 
 
 //  </h>version
@@ -98,11 +98,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          38
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          35
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -692,7 +692,7 @@ static void AbsEncoder_send_error(uint8_t id, eOerror_value_MC_t err_id, uint64_
     
     eOmc_motor_status_t *mstatus = NULL;
     mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), id);
-    mstatus->fault_state_mask = descriptor.code;
+    mstatus->mc_fault_state = descriptor.code;
 }
 
 BOOL AbsEncoder_is_in_fault(AbsEncoder* o)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -692,7 +692,10 @@ static void AbsEncoder_send_error(uint8_t id, eOerror_value_MC_t err_id, uint64_
     
     eOmc_motor_status_t *mstatus = NULL;
     mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), id);
-    mstatus->mc_fault_state = descriptor.code;
+    if (NULL != mstatus)
+    {
+        mstatus->mc_fault_state = descriptor.code;
+    }
 }
 
 BOOL AbsEncoder_is_in_fault(AbsEncoder* o)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -21,6 +21,8 @@
 #include "EoError.h"
 #include "EOtheErrorManager.h"
 
+#include "EOtheEntities.h"
+
 #include "EOMtheEMSrunner.h"
 
 #include "EOemsControllerCfg.h"
@@ -687,6 +689,10 @@ static void AbsEncoder_send_error(uint8_t id, eOerror_value_MC_t err_id, uint64_
     descriptor.sourceaddress = 0;
     descriptor.code = eoerror_code_get(eoerror_category_MotionControl, err_id);
     eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
+    
+    eOmc_motor_status_t *mstatus = NULL;
+    mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), id);
+    mstatus->fault_state_mask = descriptor.code;
 }
 
 BOOL AbsEncoder_is_in_fault(AbsEncoder* o)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -413,7 +413,10 @@ BOOL Joint_check_faults(Joint* o)
             
             eOmc_motor_status_t *mstatus = NULL;
             mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
-            mstatus->mc_fault_state = descriptor.code;
+            if (NULL != mstatus)
+            {
+                mstatus->mc_fault_state = descriptor.code;
+            }
         }
         
         if (o->fault_state.bits.hard_limit_reached && !o->fault_state_prec.bits.hard_limit_reached)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -412,8 +412,8 @@ BOOL Joint_check_faults(Joint* o)
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
             eOmc_motor_status_t *mstatus = NULL;
-            mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(),  o->ID);
-            mstatus->fault_state_mask = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_axis_torque_sens);
+            mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
+            mstatus->fault_state_mask = descriptor.code;
         }
         
         if (o->fault_state.bits.hard_limit_reached && !o->fault_state_prec.bits.hard_limit_reached)
@@ -427,8 +427,8 @@ BOOL Joint_check_faults(Joint* o)
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
             eOmc_motor_status_t *mstatus = NULL;
-            mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(),  o->ID);
-            mstatus->fault_state_mask = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_joint_hard_limit);
+            mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
+            mstatus->fault_state_mask = descriptor.code;
         }
         
         o->fault_state_prec.bitmask = o->fault_state.bitmask;
@@ -923,7 +923,6 @@ void Joint_get_state(Joint* o, eOmc_joint_status_t* joint_state)
     joint_state->core.modes.interactionmodestatus    = o->interaction_mode;
     joint_state->core.modes.controlmodestatus        = o->control_mode;
     joint_state->core.modes.ismotiondone             = Trajectory_is_done(&o->trajectory);
-    //joint_state->core.modes.fault_state_mask              = o->fault_state.bitmask;
     joint_state->core.measures.meas_position         = o->pos_fbk;           
     joint_state->core.measures.meas_velocity         = o->vel_fbk;        
     joint_state->core.measures.meas_acceleration     = o->acc_fbk;      

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -428,7 +428,10 @@ BOOL Joint_check_faults(Joint* o)
             
             eOmc_motor_status_t *mstatus = NULL;
             mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
-            mstatus->mc_fault_state = descriptor.code;
+            if (NULL != mstatus)
+            {
+                mstatus->mc_fault_state = descriptor.code;
+            }
         }
         
         o->fault_state_prec.bitmask = o->fault_state.bitmask;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -25,6 +25,8 @@
 #include "EOtheErrorManager.h"
 #include "EoError.h"
 
+#include "EOtheEntities.h"
+
 static void Joint_set_inner_control_flags(Joint* o);
 
 Joint* Joint_new(uint8_t n)
@@ -408,6 +410,10 @@ BOOL Joint_check_faults(Joint* o)
             descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_axis_torque_sens);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
+            
+            eOmc_motor_status_t *mstatus = NULL;
+            mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(),  o->ID);
+            mstatus->fault_state_mask = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_axis_torque_sens);
         }
         
         if (o->fault_state.bits.hard_limit_reached && !o->fault_state_prec.bits.hard_limit_reached)
@@ -419,6 +425,10 @@ BOOL Joint_check_faults(Joint* o)
             descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_joint_hard_limit);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
+            
+            eOmc_motor_status_t *mstatus = NULL;
+            mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(),  o->ID);
+            mstatus->fault_state_mask = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_joint_hard_limit);
         }
         
         o->fault_state_prec.bitmask = o->fault_state.bitmask;
@@ -913,10 +923,11 @@ void Joint_get_state(Joint* o, eOmc_joint_status_t* joint_state)
     joint_state->core.modes.interactionmodestatus    = o->interaction_mode;
     joint_state->core.modes.controlmodestatus        = o->control_mode;
     joint_state->core.modes.ismotiondone             = Trajectory_is_done(&o->trajectory);
+    //joint_state->core.modes.fault_state_mask              = o->fault_state.bitmask;
     joint_state->core.measures.meas_position         = o->pos_fbk;           
     joint_state->core.measures.meas_velocity         = o->vel_fbk;        
     joint_state->core.measures.meas_acceleration     = o->acc_fbk;      
-    joint_state->core.measures.meas_torque           = o->trq_fbk;
+    joint_state->core.measures.meas_torque           = o->trq_fbk;    
 }
 
 BOOL Joint_get_pid_state(Joint* o, eOmc_joint_status_ofpid_t* pid_state)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -413,7 +413,7 @@ BOOL Joint_check_faults(Joint* o)
             
             eOmc_motor_status_t *mstatus = NULL;
             mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
-            mstatus->fault_state_mask = descriptor.code;
+            mstatus->mc_fault_state = descriptor.code;
         }
         
         if (o->fault_state.bits.hard_limit_reached && !o->fault_state_prec.bits.hard_limit_reached)
@@ -428,7 +428,7 @@ BOOL Joint_check_faults(Joint* o)
             
             eOmc_motor_status_t *mstatus = NULL;
             mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
-            mstatus->fault_state_mask = descriptor.code;
+            mstatus->mc_fault_state = descriptor.code;
         }
         
         o->fault_state_prec.bitmask = o->fault_state.bitmask;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -289,12 +289,6 @@ BOOL JointSet_do_check_faults(JointSet* o)
     BOOL fault = FALSE;
     o->external_fault = FALSE;
     
-    // Set to dummy the fault state communicated to embObj before checking for new faults
-    for(int k=0; k<N; ++k)
-    {
-        Motor_set_fault_state_dummy(o->motor+o->motors_of_set[k]);
-    }
-    
     for (int k=0; k<N; ++k)
     {
         if (Joint_check_faults(o->joint+o->joints_of_set[k]))

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -289,6 +289,12 @@ BOOL JointSet_do_check_faults(JointSet* o)
     BOOL fault = FALSE;
     o->external_fault = FALSE;
     
+    // Set to dummy the fault state communicated to embObj before checking for new faults
+    for(int k=0; k<N; ++k)
+    {
+        Motor_set_fault_state_dummy(o->motor+o->motors_of_set[k]);
+    }
+    
     for (int k=0; k<N; ++k)
     {
         if (Joint_check_faults(o->joint+o->joints_of_set[k]))

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -1218,8 +1218,7 @@ void Motor_get_state(Motor* o, eOmc_motor_status_t* motor_status)
     
     motor_status->basic.mot_current  = o->Iqq_fbk; //o->Iqq_peak_fbk;    
     motor_status->basic.mot_pwm      = o->pwm_fbk;
-    
-    
+    motor_status->fault_state_mask   = o->fault_state.bitmask;
 }
 
 void Motor_update_odometry_fbk_can(Motor* o, CanOdometry2FocMsg* can_msg) //

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -32,8 +32,6 @@
 #include "EoError.h"
 #include "EOtheEntities.h"
 
-#include "AbsEncoder.h"
-
 #if defined(EOTHESERVICES_customize_handV3_7joints)
 
 // -- here is new code for the pmc board

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -705,7 +705,10 @@ static void Motor_send_error(uint8_t id, eOerror_value_MC_t err_id, uint64_t mas
     
     eOmc_motor_status_t *mstatus = NULL;
     mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), id);
-    mstatus->mc_fault_state = descriptor.code;
+    if (NULL != mstatus)
+    {
+        mstatus->mc_fault_state = descriptor.code;
+    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -32,6 +32,8 @@
 #include "EoError.h"
 #include "EOtheEntities.h"
 
+#include "AbsEncoder.h"
+
 #if defined(EOTHESERVICES_customize_handV3_7joints)
 
 // -- here is new code for the pmc board
@@ -1226,7 +1228,12 @@ void Motor_get_state(Motor* o, eOmc_motor_status_t* motor_status)
     motor_status->basic.mot_acceleration = 0; // not implemented  
     
     motor_status->basic.mot_current  = o->Iqq_fbk; //o->Iqq_peak_fbk;    
-    motor_status->basic.mot_pwm      = o->pwm_fbk; 
+    motor_status->basic.mot_pwm      = o->pwm_fbk;
+    
+//    if (Motor_is_motor_joint_fault_over(o))
+//    {
+//        motor_status->mc_fault_state = eoerror_code_dummy;
+//    }
 }
 
 void Motor_update_odometry_fbk_can(Motor* o, CanOdometry2FocMsg* can_msg) //
@@ -1385,6 +1392,28 @@ void Motor_reset(Motor *o)
     //o->control_mode_req;
 }
 
+
+//BOOL Motor_is_motor_joint_fault_over(Motor* o)
+//{
+//    BOOL ret = TRUE;
+//    
+//    ret &= !Motor_is_in_fault(o);
+//    
+//    eOmc_joint_status_t* jstatus = eo_entities_GetJointStatus(eo_entities_GetHandle(), o->ID);    
+//    
+//    if (NULL != jstatus)
+//    {
+//        ret &= (jstatus->core.modes.controlmodestatus != eomc_ctrlmval_hwFault);
+//    }
+//        
+//    return ret;
+//}
+
+void Motor_set_fault_state_dummy(Motor* o)
+{
+    eOmc_motor_status_t* mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
+    mstatus->mc_fault_state = eoerror_code_dummy;
+}
 
 #if defined(EOTHESERVICES_customize_handV3_7joints)
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -705,7 +705,7 @@ static void Motor_send_error(uint8_t id, eOerror_value_MC_t err_id, uint64_t mas
     
     eOmc_motor_status_t *mstatus = NULL;
     mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), id);
-    mstatus->fault_state_mask = descriptor.code;
+    mstatus->mc_fault_state = descriptor.code;
 }
 
 
@@ -786,12 +786,10 @@ BOOL Motor_check_faults(Motor* o) //
             {
                 if (o->qe_state.bits.dirty) {
                     Motor_send_error(o->ID, eoerror_value_MC_motor_qencoder_dirty, 0);
-                    //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_qencoder_dirty);
                     ++o->qencoder_err_counter;
                 }
                 if (o->qe_state.bits.phase_broken) {
                     Motor_send_error(o->ID, eoerror_value_MC_motor_qencoder_phase, 0);
-                    //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_qencoder_phase);
                     ++o->qencoder_err_counter;
                 }
             }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -1228,10 +1228,10 @@ void Motor_get_state(Motor* o, eOmc_motor_status_t* motor_status)
     motor_status->basic.mot_current  = o->Iqq_fbk; //o->Iqq_peak_fbk;    
     motor_status->basic.mot_pwm      = o->pwm_fbk;
     
-//    if (Motor_is_motor_joint_fault_over(o))
-//    {
-//        motor_status->mc_fault_state = eoerror_code_dummy;
-//    }
+    if (Motor_is_motor_joint_fault_over(o))
+    {
+        motor_status->mc_fault_state = eoerror_code_dummy;
+    }
 }
 
 void Motor_update_odometry_fbk_can(Motor* o, CanOdometry2FocMsg* can_msg) //
@@ -1391,26 +1391,20 @@ void Motor_reset(Motor *o)
 }
 
 
-//BOOL Motor_is_motor_joint_fault_over(Motor* o)
-//{
-//    BOOL ret = TRUE;
-//    
-//    ret &= !Motor_is_in_fault(o);
-//    
-//    eOmc_joint_status_t* jstatus = eo_entities_GetJointStatus(eo_entities_GetHandle(), o->ID);    
-//    
-//    if (NULL != jstatus)
-//    {
-//        ret &= (jstatus->core.modes.controlmodestatus != eomc_ctrlmval_hwFault);
-//    }
-//        
-//    return ret;
-//}
-
-void Motor_set_fault_state_dummy(Motor* o)
+BOOL Motor_is_motor_joint_fault_over(Motor* o)
 {
-    eOmc_motor_status_t* mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), o->ID);
-    mstatus->mc_fault_state = eoerror_code_dummy;
+    BOOL ret = TRUE;
+    
+    ret &= !Motor_is_in_fault(o);
+    
+    eOmc_joint_status_t* jstatus = eo_entities_GetJointStatus(eo_entities_GetHandle(), o->ID);    
+    
+    if (NULL != jstatus)
+    {
+        ret &= (jstatus->core.modes.controlmodestatus != eomc_ctrlmval_hwFault);
+    }
+        
+    return ret;
 }
 
 #if defined(EOTHESERVICES_customize_handV3_7joints)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -705,7 +705,7 @@ static void Motor_send_error(uint8_t id, eOerror_value_MC_t err_id, uint64_t mas
     
     eOmc_motor_status_t *mstatus = NULL;
     mstatus = eo_entities_GetMotorStatus(eo_entities_GetHandle(), id);
-    mstatus->fault_state_mask = eoerror_code_get(eoerror_category_MotionControl, err_id);
+    mstatus->fault_state_mask = descriptor.code;
 }
 
 
@@ -849,21 +849,18 @@ BOOL Motor_check_faults(Motor* o) //
         if (o->fault_state.bits.ExternalFaultAsserted && !o->fault_state_prec.bits.ExternalFaultAsserted)
         {
             Motor_send_error(o->ID, eoerror_value_MC_motor_external_fault, 0);
-            //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_external_fault);
             fault_state.bits.ExternalFaultAsserted = FALSE;
         }
         
         if (o->fault_state.bits.OverCurrentFailure && !o->fault_state_prec.bits.OverCurrentFailure)
         {
             Motor_send_error(o->ID, eoerror_value_MC_motor_overcurrent, 0);
-            //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_overcurrent);
             fault_state.bits.OverCurrentFailure = FALSE;
         }
         
         if (o->fault_state.bits.I2TFailure && !o->fault_state_prec.bits.I2TFailure)
         {
             Motor_send_error(o->ID, eoerror_value_MC_motor_i2t_limit, 0);
-            //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_i2t_limit);
             fault_state.bits.I2TFailure = FALSE;
         }
         
@@ -871,7 +868,6 @@ BOOL Motor_check_faults(Motor* o) //
          || (o->fault_state.bits.DHESInvalidValue && !o->fault_state_prec.bits.DHESInvalidValue))
         {
             Motor_send_error(o->ID, eoerror_value_MC_motor_hallsensors, 0);
-            //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_hallsensors);
             fault_state.bits.DHESInvalidSequence = FALSE;
             fault_state.bits.DHESInvalidValue = FALSE;
         }
@@ -879,7 +875,6 @@ BOOL Motor_check_faults(Motor* o) //
         if (o->fault_state.bits.CANInvalidProtocol && !o->fault_state_prec.bits.CANInvalidProtocol)
         {
             Motor_send_error(o->ID, eoerror_value_MC_motor_can_invalid_prot, 0);
-            //Motor_set_error_on_status(o->ID, eoerror_value_MC_motor_can_invalid_prot);
             fault_state.bits.CANInvalidProtocol = FALSE;
         }
         
@@ -1230,9 +1225,7 @@ void Motor_get_state(Motor* o, eOmc_motor_status_t* motor_status)
     motor_status->basic.mot_acceleration = 0; // not implemented  
     
     motor_status->basic.mot_current  = o->Iqq_fbk; //o->Iqq_peak_fbk;    
-    motor_status->basic.mot_pwm      = o->pwm_fbk;
-    //motor_status->fault_state_mask     = o->fault_state.bitmask;
- 
+    motor_status->basic.mot_pwm      = o->pwm_fbk; 
 }
 
 void Motor_update_odometry_fbk_can(Motor* o, CanOdometry2FocMsg* can_msg) //

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -295,6 +295,9 @@ extern BOOL Motor_is_external_fault(Motor* o);
 extern BOOL Motor_is_in_fault(Motor* o);
 extern BOOL Motor_is_running(Motor* o);
 
+// extern BOOL Motor_is_motor_joint_fault_over(Motor* o);
+extern void Motor_set_fault_state_dummy(Motor *o);
+
 //BOOL Motor_clear_ext_fault(Motor *o);
 
 ////////////////////////////////////////////////////////////////////////////

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -295,8 +295,7 @@ extern BOOL Motor_is_external_fault(Motor* o);
 extern BOOL Motor_is_in_fault(Motor* o);
 extern BOOL Motor_is_running(Motor* o);
 
-// extern BOOL Motor_is_motor_joint_fault_over(Motor* o);
-extern void Motor_set_fault_state_dummy(Motor *o);
+extern BOOL Motor_is_motor_joint_fault_over(Motor* o);
 
 //BOOL Motor_clear_ext_fault(Motor *o);
 


### PR DESCRIPTION
This PR aims to complement the work done to address: robotology/community#561 , in which the feature request involved communicating the latest fault to the `yarpmotorgui`. 
To address it, the error code is stored in the free space of the struct `motor_status_t`, right after the diagnostics function sends the error towards the `yarplogger`. 
The data is retrieved by embObjMotionControl upon periodical request of the `yarpmotorgui`, whenever a fault is detected.

The fault states that can be communicated are the following:
```
  {eoerror_value_MC_motor_external_fault,  "MC: exernal fault button pressed."},
    {eoerror_value_MC_motor_overcurrent,     "MC: overcurrent. The motor has been turned off to prevent it from being damaged by an impulsive spike of current. par16 = ID of joint."},
    {eoerror_value_MC_motor_i2t_limit,       "MC: i2t limit exceeded. The motor has been turned off to prevent it from being damaged by overheating due to a continuous high current. par16 = ID of joint."},
    {eoerror_value_MC_motor_hallsensors,     "MC: 2FOC hall sensors fault. Invalid sequence in motor Hall effect sensors, please check motor hall cable connections. par16 = ID of joint."},
    {eoerror_value_MC_motor_can_invalid_prot,"MC: 2FOC CAN invalid protocol. The EMS and 2FOC firmware versions are incompatible, please update. par16 = ID of joint."},
    {eoerror_value_MC_motor_can_generic,     "MC: 2FOC CAN generic error. Errors happened in the CAN bus between the EMS and the 2FOC board. par16 = ID of joint."},
    {eoerror_value_MC_motor_can_no_answer,   "MC: 2FOC CAN no answer. The communication between the EMS and the 2FOC board has been lost for more than 50 ms. par16 = ID of joint."},
    {eoerror_value_MC_axis_torque_sens,      "MC: torque sensor timeout. The joint is in a compliant interaction mode or torque control mode, and data from torque sensor have been unavailable for more than 100 ms. par16 = ID of joint."},
    {eoerror_value_MC_aea_abs_enc_invalid,   "MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. par16 = AEA port (msb) and ID of joint (lsb)."},
    {eoerror_value_MC_aea_abs_enc_timeout,   "MC: AEA encoder timeout. No answer from the magnetic position sensor of the joint (cable broken?). par16 = AEA port (msb) and ID of joint (lsb)."},
    {eoerror_value_MC_aea_abs_enc_spikes,    "MC: AEA encoder has spikes. There is impulsive noise in the measures of the magnetic position sensor of the joint. par16 = AEA port (msb) and ID of joint (lsb)."},
    {eoerror_value_MC_motor_qencoder_dirty,  "MC: 2FOC quadrature encoder dirty. The number of thicks in a complete revolution of the motor was lower than expected, the optical disks need to be cleaned. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
    {eoerror_value_MC_motor_qencoder_index,  "MC: 2FOC quadrature encoder index broken. The reference special thick was not detected during a complete revolution of the motor, please check motor encoder cables. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
    {eoerror_value_MC_motor_qencoder_phase,  "MC: 2FOC quadrature encoder phase broken. The motor encoder is not counting even if the motor is moving, please check motor encoder cables. In par64 0xFF is the mask of raw encoder value. par16 = ID of joint."},
    {eoerror_value_MC_generic_error,         "MC: generic motor error (see 64 bit mask parameter)."},
    {eoerror_value_MC_motor_wrong_state,     "MC: 2FOC wrong state. The 2FOC motor controller is in a control state different from required by the EMS. In par64 0xF0 is the mask of requested state, 0x0F is the mask of actual state. par16 = ID of joint."},
    {eoerror_value_MC_joint_hard_limit,      "MC: hard limit reached. The joint position is outside its hardware boundaries. par16 = ID of joint."},
    {eoerror_value_MC_motor_qencoder_phase_disappeared, "MC: qenc error has disappeared, warning counter has been reset."}
```
which belong to the `motion controller` category. 
Here below is a little demo of the `yarpmotorgui` displaying a hardware limit fault:


https://user-images.githubusercontent.com/38140169/145057677-9b9af4e4-94ae-497c-a74e-dec12718574f.mp4

Related PR:
icub-firmware-shared: https://github.com/robotology/icub-firmware-shared/pull/52
icub-main: icub-main: https://github.com/robotology/icub-main/pull/779