### PR TITLE
Mutual exclusion in amcbldc

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
@@ -125,7 +125,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UAny -O206 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC10000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIEFFFFFFFF -TIP8 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
+          <Name>-UAny -O206 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC160000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -153,136 +153,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>68</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>61</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>51</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>3</Number>
-          <Type>0</Type>
-          <LineNumber>45</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>4</Number>
-          <Type>0</Type>
-          <LineNumber>44</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134378336</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\44</Expression>
-        </Bp>
-        <Bp>
-          <Number>5</Number>
-          <Type>0</Type>
-          <LineNumber>50</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134378352</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\50</Expression>
-        </Bp>
-        <Bp>
-          <Number>6</Number>
-          <Type>0</Type>
-          <LineNumber>60</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134378382</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\60</Expression>
-        </Bp>
-        <Bp>
-          <Number>7</Number>
-          <Type>0</Type>
-          <LineNumber>67</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134378404</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\67</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -477,7 +348,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ST-LINKIII-KEIL_SWO</Key>
-          <Name>-U51FF6C067871515222521767 -O206 -SF10000 -C0 -A0 -I0 -HNlocalhost -HP7184 -P1 -N00("ARM CoreSight SW-DP (ARM Core") -D00(2BA01477) -L00(0) -TO131091 -TC160000000 -TT10000000 -TP21 -TDS804F -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512.FLM)</Name>
+          <Name>-U51FF6C067871515222521767 -O206 -SF10000 -C0 -A0 -I0 -HNlocalhost -HP7184 -P1 -N00("") -D00(00000000) -L00(0) -TO131091 -TC160000000 -TT10000000 -TP21 -TDS800D -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -1667,7 +1538,7 @@
 
   <Group>
     <GroupName>mbd</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
@@ -157,18 +157,130 @@
         <Bp>
           <Number>0</Number>
           <Type>0</Type>
-          <LineNumber>298</LineNumber>
+          <LineNumber>68</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134381624</Address>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
+        <Bp>
+          <Number>1</Number>
+          <Type>0</Type>
+          <LineNumber>61</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
+        <Bp>
+          <Number>2</Number>
+          <Type>0</Type>
+          <LineNumber>51</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
+        <Bp>
+          <Number>3</Number>
+          <Type>0</Type>
+          <LineNumber>45</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
+        <Bp>
+          <Number>4</Number>
+          <Type>0</Type>
+          <LineNumber>44</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134378336</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
           <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\motorhal\pwm.c</Filename>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
           <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/motorhal/pwm.c\298</Expression>
+          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\44</Expression>
+        </Bp>
+        <Bp>
+          <Number>5</Number>
+          <Type>0</Type>
+          <LineNumber>50</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134378352</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\50</Expression>
+        </Bp>
+        <Bp>
+          <Number>6</Number>
+          <Type>0</Type>
+          <LineNumber>60</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134378382</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\60</Expression>
+        </Bp>
+        <Bp>
+          <Number>7</Number>
+          <Type>0</Type>
+          <LineNumber>67</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134378404</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\model-based-design\sharedutils\rtw_mutex.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/model-based-design/sharedutils/rtw_mutex.cpp\67</Expression>
         </Bp>
       </Breakpoint>
       <WatchWindow1>
@@ -237,7 +349,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>1</aSer4>
+        <aSer4>0</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -855,7 +967,7 @@
 
   <Group>
     <GroupName>embot::tools</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1063,7 +1175,7 @@
 
   <Group>
     <GroupName>embot::hw::lowlevel</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2203,7 +2315,7 @@
 
   <Group>
     <GroupName>mbd::amc-bldc</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -772,75 +772,6 @@
         </Group>
         <Group>
           <GroupName>others</GroupName>
-          <GroupOption>
-            <CommonProperty>
-              <UseCPPCompiler>0</UseCPPCompiler>
-              <RVCTCodeConst>0</RVCTCodeConst>
-              <RVCTZI>0</RVCTZI>
-              <RVCTOtherData>0</RVCTOtherData>
-              <ModuleSelection>0</ModuleSelection>
-              <IncludeInBuild>2</IncludeInBuild>
-              <AlwaysBuild>2</AlwaysBuild>
-              <GenerateAssemblyFile>2</GenerateAssemblyFile>
-              <AssembleAssemblyFile>2</AssembleAssemblyFile>
-              <PublicsOnly>2</PublicsOnly>
-              <StopOnExitCode>11</StopOnExitCode>
-              <CustomArgument></CustomArgument>
-              <IncludeLibraryModules></IncludeLibraryModules>
-              <ComprImg>1</ComprImg>
-            </CommonProperty>
-            <GroupArmAds>
-              <Cads>
-                <interw>2</interw>
-                <Optim>0</Optim>
-                <oTime>2</oTime>
-                <SplitLS>2</SplitLS>
-                <OneElfS>2</OneElfS>
-                <Strict>2</Strict>
-                <EnumInt>2</EnumInt>
-                <PlainCh>2</PlainCh>
-                <Ropi>2</Ropi>
-                <Rwpi>2</Rwpi>
-                <wLevel>0</wLevel>
-                <uThumb>2</uThumb>
-                <uSurpInc>2</uSurpInc>
-                <uC99>2</uC99>
-                <uGnu>2</uGnu>
-                <useXO>2</useXO>
-                <v6Lang>0</v6Lang>
-                <v6LangP>0</v6LangP>
-                <vShortEn>2</vShortEn>
-                <vShortWch>2</vShortWch>
-                <v6Lto>2</v6Lto>
-                <v6WtE>2</v6WtE>
-                <v6Rtti>2</v6Rtti>
-                <VariousControls>
-                  <MiscControls></MiscControls>
-                  <Define></Define>
-                  <Undefine></Undefine>
-                  <IncludePath>..\src\model-based-design\sharedutils;..\src\model-based-design\can-decoder;..\src\model-based-design\can-raw2struct;..\src\model-based-design\supervisor-rx;..\src\model-based-design\supervisor-tx;..\src\model-based-design\can-encoder;..\src\model-based-design\control-outer;..\src\model-based-design\control-foc</IncludePath>
-                </VariousControls>
-              </Cads>
-              <Aads>
-                <interw>2</interw>
-                <Ropi>2</Ropi>
-                <Rwpi>2</Rwpi>
-                <thumb>2</thumb>
-                <SplitLS>2</SplitLS>
-                <SwStkChk>2</SwStkChk>
-                <NoWarn>2</NoWarn>
-                <uSurpInc>2</uSurpInc>
-                <useXO>2</useXO>
-                <ClangAsOpt>0</ClangAsOpt>
-                <VariousControls>
-                  <MiscControls></MiscControls>
-                  <Define></Define>
-                  <Undefine></Undefine>
-                  <IncludePath></IncludePath>
-                </VariousControls>
-              </Aads>
-            </GroupArmAds>
-          </GroupOption>
           <Files>
             <File>
               <FileName>embot_app_application_theCANparserMBD.cpp</FileName>
@@ -1283,7 +1214,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2481,7 +2412,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_mutex.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_mutex.cpp
@@ -17,6 +17,8 @@
 
 #include "rtw_mutex.h"
 
+#if !defined(RTW_MUTEX_USE_INLINE)
+
 
 // marco.accame: this code provides protection vs concurrent access between
 // a user thread and the DMA IRQHandler for DMA1 Channel2. the mechanism
@@ -73,12 +75,14 @@ void rtw_mutex_unlock(void)
 
 
 // static funtions
-static bool IsException(void) 
+bool IsException(void) 
 {
     return(__get_IPSR() != 0U);
 }
 
-
+#else
+    // implementation moved to the .h file
+#endif
 
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_mutex.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_mutex.cpp
@@ -17,10 +17,69 @@
 
 #include "rtw_mutex.h"
 
-void rtw_mutex_lock(void) {
 
+// marco.accame: this code provides protection vs concurrent access between
+// a user thread and the DMA IRQHandler for DMA1 Channel2. the mechanism
+// is that the user-thread disables the interrupt to lock and reanables it
+// to unlock. the IRQHandler must not do anything, so if we are in an 
+// exception (irq handler) we dont lock / unlock. 
+// you can use macro TEST_CALLING to verify the correct mechanism.
+
+#include "stm32hal.h"
+
+static bool IsException(void); 
+
+//#define TEST_CALLING
+
+
+#if defined(TEST_CALLING)
+volatile int32_t test_numThreadMode {0};
+volatile int32_t test_numHandlerMode {0};
+#endif
+
+void rtw_mutex_lock(void) 
+{    
+    if(false == IsException())
+    {
+        NVIC_DisableIRQ(DMA1_Channel2_IRQn);  
+#if defined(TEST_CALLING)        
+        test_numThreadMode++;
+#endif                
+    }  
+#if defined(TEST_CALLING)    
+    else
+    {
+        test_numHandlerMode++;
+    }
+#endif
 }
 
-void rtw_mutex_unlock(void) {
-    
+void rtw_mutex_unlock(void) 
+{
+    if(false == IsException())
+    { 
+#if defined(TEST_CALLING)        
+        test_numThreadMode--;    
+#endif        
+        NVIC_EnableIRQ(DMA1_Channel2_IRQn);
+    }
+#if defined(TEST_CALLING)    
+    else
+    {
+        test_numHandlerMode--;
+    }  
+#endif    
 }
+
+
+// static funtions
+static bool IsException(void) 
+{
+    return(__get_IPSR() != 0U);
+}
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_mutex.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_mutex.h
@@ -18,9 +18,50 @@
 #ifndef RTW_MUTEX_H
 #define RTW_MUTEX_H
 
+#define RTW_MUTEX_USE_INLINE
+
+#if !defined(RTW_MUTEX_USE_INLINE)
+
 #define rtw_mutex_init()
 void rtw_mutex_lock(void);
 void rtw_mutex_unlock(void);
 #define rtw_mutex_destroy()
 
+#else
+
+#include "stm32hal.h"
+
+#define rtw_mutex_init()
+#define rtw_mutex_destroy()
+
+inline bool IsException(void) 
+{
+    return(__get_IPSR() != 0U);
+}
+
+inline void rtw_mutex_lock(void) 
+{    
+    if(false == IsException())
+    {
+        NVIC_DisableIRQ(DMA1_Channel2_IRQn);  
+            
+    }  
+}
+
+inline void rtw_mutex_unlock(void) 
+{
+    if(false == IsException())
+    {       
+        NVIC_EnableIRQ(DMA1_Channel2_IRQn);
+    }  
+}
+
 #endif
+
+
+
+#endif // RTW_MUTEX_H
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+


### PR DESCRIPTION
This PR just adds a mechanism of mutual exclusion in the `amcbldc` board between a `user thread` and `DMA1_Channel2_IRQHandler(`) which both run MBD code.

The code was successfully tested on the `amcbldc` board. 

Moreover, this change has a local impact only on the `amcbldc` and hence it can be safely merged.