### PR TITLE
rfe: fixed the i2c bus of the imu bosch bno055 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
@@ -24,7 +24,7 @@ constexpr uint32_t numMilli = 50;
 
 constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
 { 
-    embot::prot::can::versionOfAPPLICATION {1, 2, 1},    
+    embot::prot::can::versionOfAPPLICATION {1, 2, 2},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0}    
 };
 

--- a/emBODY/eBcode/arch-arm/board/rfe/bsp/embot_hw_bsp_rfe.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/bsp/embot_hw_bsp_rfe.cpp
@@ -692,7 +692,7 @@ namespace embot { namespace hw { namespace bno055 {
     
     // .boot = { BNO055_BOOT_GPIO_Port, BNO055_BOOT_Pin }, .reset = { BNO055_RESET_GPIO_Port, BNO055_RESET_Pin } 
     constexpr PROP prop01 {
-        { embot::hw::I2C::two, 0x50 },
+        { embot::hw::I2C::one, 0x50 },
         { embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::fourteen },   // .boot
         { embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::fifteen }      // .reset
     };


### PR DESCRIPTION
This PR fixes a typo on the bsp configuration of board `rfe`.

The i2C bus of the chip IMU BOSCH BNO055 is on `embot::hw::I2C::one` and not on `embot::hw::I2C::two`. This typo prevented teh correct initialization of the chip and the streaming of IMU data.

The correction has showed that now iCub correctly streams the IMU values. As a result of that I have updated the application version to be 1.2.2 and produced the associated PR on https://github.com/robotology/icub-firmware-build/pull/46
