### PR TITLE
Calibration support for the FAP boards

### DIFF
--- a/emBODY/eBcode/arch-arm/board/pmc/application02/proj/pmc-application02.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/pmc/application02/proj/pmc-application02.uvoptx
@@ -538,7 +538,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -594,7 +594,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -854,7 +854,7 @@
 
   <Group>
     <GroupName>embot-protocol</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1046,7 +1046,7 @@
 
   <Group>
     <GroupName>embot-hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1354,7 +1354,7 @@
 
   <Group>
     <GroupName>drivers-encoder</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1386,7 +1386,7 @@
 
   <Group>
     <GroupName>drivers-piezo</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1462,7 +1462,7 @@
 
   <Group>
     <GroupName>drivers-irqhandlers</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1482,7 +1482,7 @@
 
   <Group>
     <GroupName>pzmdriver</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/pmc/application02/proj/pmc-application02.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/pmc/application02/proj/pmc-application02.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>pmc-app</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6150000::V6.15::ARMCLANG</pCCUsed>
+      <pCCUsed>6160000::V6.16::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.2.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -336,7 +336,7 @@
             <v6WtE>0</v6WtE>
             <v6Rtti>0</v6Rtti>
             <VariousControls>
-              <MiscControls>-DEMBOT_HW_BSP_PMC_emulates_SNSR_PZM -DUSE_thePOSreader2_qe -DUSE_PZMdriver -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal </MiscControls>
+              <MiscControls>-DxEMBOT_HW_BSP_PMC_emulates_SNSR_PZM -DUSE_thePOSreader2_qe -DUSE_PZMdriver -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_PMC STM32HAL_DRIVER_V120</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\..\..\..\..\eBcode\arch-arm\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\eBcode\arch-arm\libs\midware\eventviewer\api;..\..\..\..\..\..\eBcode\arch-arm\embobj\core\exec\multitask-;..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core-;..\..\..\..\..\..\eBcode\arch-arm\libs\lowlevel\stm32hal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\eBcode\arch-arm\embot\app;..\..\..\..\..\..\eBcode\arch-arm\embot\i2h;..\..\..\..\..\..\eBcode\arch-arm\embot\hw;..\..\..\..\..\..\eBcode\arch-arm\embot\os;..\..\..\..\..\..\eBcode\arch-arm\embot;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\app\dsp;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\bsp;..\..\..\stm32g4eval\application02\src;..\..\drivers\encoder;..\..\drivers\piezo;..\..\drivers\piezo\tables\generated</IncludePath>
@@ -1168,7 +1168,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.2.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/pmc/application02/src/pmc-main-fapreader.cpp
+++ b/emBODY/eBcode/arch-arm/board/pmc/application02/src/pmc-main-fapreader.cpp
@@ -155,88 +155,95 @@ embot::app::ctrl::tCTRL *t_ctrl {nullptr};
 
     using namespace embot::app::application;
 
+    constexpr thePOSreader2::Sensor s1 {
+        thePOSreader2::sensorType::tlv, embot::hw::ANY::one, // propJ4
+        embot::prot::can::analog::posLABEL::zero, // as eobrd_portpos_hand_thumb = 0
+        {{true, embot::prot::can::analog::polling::deciDegCalib::ROT::none, 2180}},
+        evtSNSR01_askdata,
+        evtSNSR01_dataready,
+        evtSNSR01_noreply,
+        5*embot::core::time1millisec // timeout  
+    };
+    
+    constexpr thePOSreader2::Sensor s2 {
+        thePOSreader2::sensorType::tlv, embot::hw::ANY::two,    // propJ5
+        embot::prot::can::analog::posLABEL::one,  // as eobrd_portpos_hand_index = 1
+        {{true, embot::prot::can::analog::polling::deciDegCalib::ROT::none, 920}},
+        evtSNSR02_askdata,
+        evtSNSR02_dataready,
+        evtSNSR02_noreply,
+        0 // 5*embot::core::time1millisec // timeout  
+    };  
 
+    constexpr thePOSreader2::Sensor s3 {
+        thePOSreader2::sensorType::tlv, embot::hw::ANY::three,  // propJ6
+        embot::prot::can::analog::posLABEL::two, // as eobrd_portpos_hand_medium = 2
+        {{true, embot::prot::can::analog::polling::deciDegCalib::ROT::plus180, 1480}},
+        evtSNSR03_askdata,
+        evtSNSR03_dataready,
+        evtSNSR03_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    };  
 
-        constexpr thePOSreader2::Sensor s1 {
-            thePOSreader2::sensorType::tlv, embot::hw::ANY::one, // propJ4
-            embot::prot::can::analog::posLABEL::zero, // as eobrd_portpos_hand_thumb = 0
-            evtSNSR01_askdata,
-            evtSNSR01_dataready,
-            evtSNSR01_noreply,
-            5*embot::core::time1millisec // timeout  
-        };
-        
-        constexpr thePOSreader2::Sensor s2 {
-            thePOSreader2::sensorType::tlv, embot::hw::ANY::two,    // propJ5
-            embot::prot::can::analog::posLABEL::one,  // as eobrd_portpos_hand_index = 1
-            evtSNSR02_askdata,
-            evtSNSR02_dataready,
-            evtSNSR02_noreply,
-            0 // 5*embot::core::time1millisec // timeout  
-        };  
+    constexpr thePOSreader2::Sensor s4 {
+        thePOSreader2::sensorType::tlv, embot::hw::ANY::four,  // propJ7
+        embot::prot::can::analog::posLABEL::three,  // as eobrd_portpos_hand_pinky = 3
+        {{true, embot::prot::can::analog::polling::deciDegCalib::ROT::none, 1650}},
+        evtSNSR04_askdata,
+        evtSNSR04_dataready,
+        evtSNSR04_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    }; 
+    
+    constexpr thePOSreader2::Sensor s5 {
+        thePOSreader2::sensorType::tlv, embot::hw::ANY::five,  // propJ13
+        embot::prot::can::analog::posLABEL::four, // as eobrd_portpos_hand_thumbmetacarpus = 4
+        {embot::prot::can::analog::polling::deciDegCalib({})},
+        evtSNSR05_askdata,
+        evtSNSR05_dataready,
+        evtSNSR05_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    };   
 
-        constexpr thePOSreader2::Sensor s3 {
-            thePOSreader2::sensorType::tlv, embot::hw::ANY::three,  // propJ6
-            embot::prot::can::analog::posLABEL::two, // as eobrd_portpos_hand_medium = 2
-            evtSNSR03_askdata,
-            evtSNSR03_dataready,
-            evtSNSR03_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        };  
+    constexpr thePOSreader2::Sensor s6 {
+        thePOSreader2::sensorType::tlv, embot::hw::ANY::six, // propU27
+        embot::prot::can::analog::posLABEL::six, // as eobrd_portpos_hand_indexadduction = 6
+        {embot::prot::can::analog::polling::deciDegCalib({})},
+        evtSNSR06_askdata,
+        evtSNSR06_dataready,
+        evtSNSR06_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    };     
 
-        constexpr thePOSreader2::Sensor s4 {
-            thePOSreader2::sensorType::tlv, embot::hw::ANY::four,  // propJ7
-            embot::prot::can::analog::posLABEL::three,  // as eobrd_portpos_hand_pinky = 3
-            evtSNSR04_askdata,
-            evtSNSR04_dataready,
-            evtSNSR04_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        }; 
-        
-        constexpr thePOSreader2::Sensor s5 {
-            thePOSreader2::sensorType::tlv, embot::hw::ANY::five,  // propJ13
-            embot::prot::can::analog::posLABEL::four, // as eobrd_portpos_hand_thumbmetacarpus = 4
-            evtSNSR05_askdata,
-            evtSNSR05_dataready,
-            evtSNSR05_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        };   
+    constexpr thePOSreader2::Sensor s7 {
+        thePOSreader2::sensorType::lr17, embot::hw::ANY::one, // absolute encoder on motor on J1
+        embot::prot::can::analog::posLABEL::five,  // as eobrd_portpos_hand_thumbrotation = 5
+        {embot::prot::can::analog::polling::deciDegCalib({})},
+        evtSNSR07_askdata,
+        evtSNSR07_dataready,
+        evtSNSR07_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    };   
 
-        constexpr thePOSreader2::Sensor s6 {
-            thePOSreader2::sensorType::tlv, embot::hw::ANY::six, // propU27
-            embot::prot::can::analog::posLABEL::six, // as eobrd_portpos_hand_indexadduction = 6
-            evtSNSR06_askdata,
-            evtSNSR06_dataready,
-            evtSNSR06_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        };     
+    constexpr thePOSreader2::Sensor s8 {
+        thePOSreader2::sensorType::qe, embot::hw::ANY::one, // incremental linear encoder or motor on J2 (Index Adduction)
+        embot::prot::can::analog::posLABEL::seven,  // not mapped yet to any eObrd_portpos_t item. it is ... linear motor position of Index Adduction
+        {embot::prot::can::analog::polling::deciMilliMeterCalib({false, 0})},
+        evtSNSR08_askdata,
+        evtSNSR08_dataready,
+        evtSNSR08_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    };          
 
-        constexpr thePOSreader2::Sensor s7 {
-            thePOSreader2::sensorType::lr17, embot::hw::ANY::one, // absolute encoder on motor on J1
-            embot::prot::can::analog::posLABEL::five,  // as eobrd_portpos_hand_thumbrotation = 5
-            evtSNSR07_askdata,
-            evtSNSR07_dataready,
-            evtSNSR07_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        };   
-
-        constexpr thePOSreader2::Sensor s8 {
-            thePOSreader2::sensorType::qe, embot::hw::ANY::one, // incremental linear encoder or motor on J2 (Index Adduction)
-            embot::prot::can::analog::posLABEL::seven,  // not mapped yet to any eObrd_portpos_t item. it is ... linear motor position of Index Adduction
-            evtSNSR08_askdata,
-            evtSNSR08_dataready,
-            evtSNSR08_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        };          
-
-        constexpr thePOSreader2::Sensor s9 {
-            thePOSreader2::sensorType::qe, embot::hw::ANY::two, // // incremental linear encoder or motor on J3 (Thumb Metacarpus movement)
-            embot::prot::can::analog::posLABEL::eight,  // not mapped yet to any eObrd_portpos_t item. it is ... linear motor position of Thumb Metacarpus movement
-            evtSNSR09_askdata,
-            evtSNSR09_dataready,
-            evtSNSR09_noreply,
-            0 //5*embot::core::time1millisec // timeout  
-        };          
+    constexpr thePOSreader2::Sensor s9 {
+        thePOSreader2::sensorType::qe, embot::hw::ANY::two, // // incremental linear encoder or motor on J3 (Thumb Metacarpus movement)
+        embot::prot::can::analog::posLABEL::eight,  // not mapped yet to any eObrd_portpos_t item. it is ... linear motor position of Thumb Metacarpus movement
+        {embot::prot::can::analog::polling::deciMilliMeterCalib({false, 0})},
+        evtSNSR09_askdata,
+        evtSNSR09_dataready,
+        evtSNSR09_noreply,
+        0 //5*embot::core::time1millisec // timeout  
+    };          
     
 #if defined(USE_thePOSreader2_qe)      
     constexpr std::array<thePOSreader2::Sensor, thePOSreader2::numberofpositions> sposmod2par { s1, s4, s2, s5, s3, s6, s7, s8, s9 };

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePOSreader2.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePOSreader2.cpp
@@ -992,70 +992,199 @@ bool embot::app::application::thePOSreader2::Impl::acquisition_get(std::vector<e
 
     std::string str;    
     
+//    for(uint8_t i=0; i<validIDpositions.size(); i++)
+//    {
+//        uint8_t n = validIDpositions[i];
+//        
+//        embot::prot::can::analog::periodic::Message_POS msg;
+//        embot::prot::can::analog::periodic::Message_POS::Info info;  
+//    
+//        info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();   
+//        
+//        
+//        sensorType st = config.sensors[n].type;
+//        
+//        if((sensorType::tlv == st) || (sensorType::lr17 == st))
+//        {            
+//            // we have rotational sensor
+//                   
+//            // so far i load one value in one packet ...
+//            
+//    #if !defined(EMBOT_POSREADER2_compensatereadings) || defined(EMBOT_ENABLE_hw_tlv493d_emulatedMODE)
+//             
+//            #warning we DONT compensate values of tlv and lr17 encoders for a given hand
+//            // we dont compensate
+//            int16_t v =  (valueOfPositionACQUISITIONnotvalid == positions[n]) ? +10000 : positions[n]/10;
+//            std::array<embot::prot::can::analog::deciDeg, 3> values = { v, 0, 0};
+//            
+//    #else
+//            
+//            #warning we compensate values of tlv and lr17 encoders for a specific hand to be in range [0, 90]
+//            // this code is tunes for teh first prototype of our hand mk3. 
+//            // we should somehow get the calibration parameters from an xml file.
+//            // they could be applied in here, so that the pos service uses calibrate values that the yarpscope
+//            // show them correctly, or we can apply them to the motion control part (in our case the mc4plus)
+//            constexpr std::array<int16_t, numberofpositions> offsets = { 218, 92, 148, 165, 0, 0, 0, 0, 0 };
+//            constexpr int16_t correction = 10;
+//            constexpr std::array<int16_t, numberofpositions> rotations = { 0, 0, 180, 0, 0, 0, 0, 0, 0 };
+//            //constexpr std::array<Position, numberofpositions> offsets = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+//            
+//            int16_t v = valueOfPositionACQUISITIONnotvalid / 10;
+//            if(valueOfPositionACQUISITIONnotvalid != positions[n])
+//            {
+//                // tlv reads in units of 0.01 deg.
+//                // so i move into deg: positions[n]/100
+//                // then i apply rotation[?] w/: +rotations[embot::core::tointegral(sensor_getPOSlabel(config.sensors[n]))]
+//                // what is ?: is 0, 1, 2, 3, 4, 5, etc whwnre 0 is eobrd_portpos_hand_thumb, 1 is eobrd_portpos_hand_index etc.
+//                // so, the ruke is: i set offsets[] and rotations[] to be zero. 
+//                // i start the pos service and i look at teh ports.
+//                // se il valore associato al thum che ha label = 0 richidere un offset allora metto il valore in offsets[0],
+//                // se richidere una inversione allora metto rotations[0] = 180, altrikenti 0.
+//                // e cosi'via con gli altri index = 1 etc.
+//                // posso fare cosi' perhche rotations e offset sono orfinati a label.
+//                // 
+//                int16_t r = (positions[n]/100+rotations[embot::core::tointegral(sensor_getPOSlabel(config.sensors[n]))]) % 360;
+//                int16_t t = - (r);
+//                v = (720 + t) % 360;
+//                v = v - (offsets[embot::core::tointegral(sensor_getPOSlabel(config.sensors[n]))]-correction);
+//    //            if(v < 0) v = 0;
+//    //            else if (v > 180) v = 180;
+//                v *= 10;
+//                
+//    //            v = transform(positions[n], embot::core::tointegral(sensor_getPOSlabel(config.sensors[n])));
+//    //            v *= 10;
+//            }
+//            
+//            #warning calibration of thumb metacarpus is to be done here
+//            if(config.sensors[n].id == embot::hw::ANY::five)
+//            {
+//                // its our thumb metacarpus
+//                int16_t r = positions[n]/100;
+//                int16_t t = r - 72;
+//                v = 10 * t;
+//            }
+//            
+//            std::array<embot::prot::can::analog::deciDeg, 3> values = { v, 0, 0};
+//            
+//    #endif        
+
+//            str += sensor_to_string(config.sensors[n]);
+//            str += " = ";
+//            str += std::to_string(v/10);
+//            str += " DEG ";
+//            
+//            info.loadDeciDeg(sensor_getPOSlabel(config.sensors[n]), 1, values);
+//               
+//            msg.load(info);
+//            msg.get(frame);
+//            replies.push_back(frame); 
+//        
+//            // in here we manage a wrong measure. in addition to so far we just send a canprint message
+//            // and 
+//            embot::hw::LED led = sensor_to_led(config.sensors[n]);
+//            if(valueOfPositionACQUISITIONnotvalid == positions[n])
+//            {
+//                embot::hw::led::off(led);
+//                embot::app::theCANtracer &tr = embot::app::theCANtracer::getInstance();
+//                tr.print("FAP" + std::to_string(n) + "err", replies);
+//            }
+//            else
+//            {
+//                embot::hw::led::on(led);
+//            }
+//            
+//        }
+//        else if(sensorType::qe == st)
+//        {
+//            
+//            // we have a linear sensor which measure micro-meters (0.001 mm) and we need to convert in 0.1 mm ->
+//            constexpr int convFactor {100};
+//            // we dont compensate
+//            int16_t v =  (valueOfPositionACQUISITIONnotvalid == positions[n]) ? 0xffff : positions[n]/convFactor;
+//            std::array<embot::prot::can::analog::deciMilliMeter, 3> values = { v, 0, 0}; 
+
+//            str += sensor_to_string(config.sensors[n]);
+//            str += " = ";
+//            str += std::to_string(v/10);
+//            str += " mm ";
+//            
+//            info.loadDeciMilliMeter(sensor_getPOSlabel(config.sensors[n]), 1, values);
+//               
+//            msg.load(info);
+//            msg.get(frame);
+//            replies.push_back(frame); 
+//            
+//            embot::hw::LED led = sensor_to_led(config.sensors[n]);
+//            if(valueOfPositionACQUISITIONnotvalid == positions[n])
+//            {
+//                embot::hw::led::off(led);
+//                embot::app::theCANtracer &tr = embot::app::theCANtracer::getInstance();
+//                tr.print("QE" + std::to_string(n) + "err", replies);
+//            }            
+//            else
+//            {
+//                embot::hw::led::on(led);
+//            }            
+//        }        
+//    }
+
+    
     for(uint8_t i=0; i<validIDpositions.size(); i++)
     {
+        embot::prot::can::analog::periodic::Message_POS msg {};
+        embot::prot::can::analog::periodic::Message_POS::Info info {};  
+        info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress(); 
+        
+        // we get the index n from the array<> Config::sensors. we have n = i only if every sensor inside Config::sensors was ok.
         uint8_t n = validIDpositions[i];
-        
-        embot::prot::can::analog::periodic::Message_POS msg;
-        embot::prot::can::analog::periodic::Message_POS::Info info;  
-    
-        info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();   
-        
-        
+        // we gets some properties
         sensorType st = config.sensors[n].type;
+        calibParams cp = config.sensors[n].calibpars;
+        bool isrotational = (sensorType::tlv == st) || (sensorType::lr17 == st);
+        //bool isrotational = (cp.postype == embot::prot::can::analog::posTYPE::angleDeciDeg);
+        Position rawvalue = positions[n];
+                     
         
-        if((sensorType::tlv == st) || (sensorType::lr17 == st))
-        {            
-            // we have rotational sensor
-                   
-            // so far i load one value in one packet ...
+        // now we transform the values        
+        if(true == isrotational)
+        {
+            embot::prot::can::analog::deciDeg v = valueOfPositionACQUISITIONnotvalid / 10;
             
-    #if !defined(EMBOT_POSREADER2_compensatereadings) || defined(EMBOT_ENABLE_hw_tlv493d_emulatedMODE)
-             
+        #if !defined(EMBOT_POSREADER2_compensatereadings) || defined(EMBOT_ENABLE_hw_tlv493d_emulatedMODE)
+                 
             #warning we DONT compensate values of tlv and lr17 encoders for a given hand
             // we dont compensate
-            int16_t v =  (valueOfPositionACQUISITIONnotvalid == positions[n]) ? +10000 : positions[n]/10;
-            std::array<embot::prot::can::analog::deciDeg, 3> values = { v, 0, 0};
+            v = (valueOfPositionACQUISITIONnotvalid == rawvalue) ? +10000 : rawvalue/10;                
+        
             
-    #else
+        #elif defined(EMBOT_POSREADER2_compensatereadings) && !defined(EMBOT_POSREADER2_compensatereadings_mode1)
+            // we compensate in the old legacy way. but we can do better maybe w/ EMBOT_POSREADER2_compensatereadings_mode1
             
-            #warning we compensate values of tlv and lr17 encoders for a specific hand to be in range [0, 90]
-            // this code is tunes for teh first prototype of our hand mk3. 
-            // we should somehow get the calibration parameters from an xml file.
-            // they could be applied in here, so that the pos service uses calibrate values that the yarpscope
-            // show them correctly, or we can apply them to the motion control part (in our case the mc4plus)
-            constexpr std::array<int16_t, numberofpositions> offsets = { 218, 92, 148, 165, 0, 0, 0, 0, 0 };
-            constexpr int16_t correction = 10;
-            constexpr std::array<int16_t, numberofpositions> rotations = { 0, 0, 180, 0, 0, 0, 0, 0, 0 };
-            //constexpr std::array<Position, numberofpositions> offsets = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            //#warning we compensate values of tlv and lr17 encoders for a specific hand to be in range [0, 90]            
             
-            int16_t v = valueOfPositionACQUISITIONnotvalid / 10;
-            if(valueOfPositionACQUISITIONnotvalid != positions[n])
+            if(valueOfPositionACQUISITIONnotvalid != rawvalue)
             {
-                int16_t r = (positions[n]/100+rotations[embot::core::tointegral(sensor_getPOSlabel(config.sensors[n]))]) % 360;
-                int16_t t = - (r);
-                v = (720 + t) % 360;
-                v = v - (offsets[embot::core::tointegral(sensor_getPOSlabel(config.sensors[n]))]-correction);
-    //            if(v < 0) v = 0;
-    //            else if (v > 180) v = 180;
-                v *= 10;
-                
-    //            v = transform(positions[n], embot::core::tointegral(sensor_getPOSlabel(config.sensors[n])));
-    //            v *= 10;
+                // ok, compensate to embot::prot::can::analog::posTYPE::angleDeciDeg
+                // for now i transform everything in degrees. yes, i know i lose resolution
+//                int16_t rawdegrees = rawvalue/100;
+//                int16_t rotationdegrees = (false == cp.decidegdes.rotation) ? 0 : 180;
+//                int16_t offsetdegrees = cp.offset/10;
+//                constexpr int16_t correctiondegrees = 10;
+//                int16_t r = (rawdegrees + rotationdegrees ) % 360;
+//                int16_t t = - (r); // we change direction
+//                v = (720 + t) % 360;
+//                v = v - (offsetdegrees - correctiondegrees);
+//                // transform in decidegrees
+//                v *= 10;
+
+                embot::prot::can::analog::deciDeg decideg_not_compensated = rawvalue/10;                
+                v = cp.decidegcalib.transform(decideg_not_compensated);
             }
             
-            #warning calibration of thumb metacarpus is to be done here
-            if(config.sensors[n].id == embot::hw::ANY::five)
-            {
-                // its our thumb metacarpus
-                int16_t r = positions[n]/100;
-                int16_t t = r - 72;
-                v = 10 * t;
-            }
-            
+        #endif      
+
+            // now we transmit v as a deciDeg
             std::array<embot::prot::can::analog::deciDeg, 3> values = { v, 0, 0};
-            
-    #endif        
 
             str += sensor_to_string(config.sensors[n]);
             str += " = ";
@@ -1068,10 +1197,9 @@ bool embot::app::application::thePOSreader2::Impl::acquisition_get(std::vector<e
             msg.get(frame);
             replies.push_back(frame); 
         
-            // in here we manage a wrong measure. in addition to so far we just send a canprint message
-            // and 
+            // finally, in here we manage a wrong measure. in addition to led off we also send a canprint message
             embot::hw::LED led = sensor_to_led(config.sensors[n]);
-            if(valueOfPositionACQUISITIONnotvalid == positions[n])
+            if(valueOfPositionACQUISITIONnotvalid == rawvalue)
             {
                 embot::hw::led::off(led);
                 embot::app::theCANtracer &tr = embot::app::theCANtracer::getInstance();
@@ -1080,12 +1208,10 @@ bool embot::app::application::thePOSreader2::Impl::acquisition_get(std::vector<e
             else
             {
                 embot::hw::led::on(led);
-            }
-            
+            }            
         }
         else if(sensorType::qe == st)
-        {
-            
+        {            
             // we have a linear sensor which measure micro-meters (0.001 mm) and we need to convert in 0.1 mm ->
             constexpr int convFactor {100};
             // we dont compensate
@@ -1116,7 +1242,7 @@ bool embot::app::application::thePOSreader2::Impl::acquisition_get(std::vector<e
             }            
         }        
     }
-
+    
     print("thePOSreader2 transmits: " + str + embot::core::TimeFormatter(embot::core::now()).to_string());
 
              

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePOSreader2.h
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_thePOSreader2.h
@@ -43,18 +43,32 @@ namespace embot { namespace app { namespace application {
     
         enum class sensorType { tlv = 0, lr17 = 1, qe = 2, none = 255 }; 
         
+        
+        struct calibParams
+        {
+            embot::prot::can::analog::posTYPE postype {embot::prot::can::analog::posTYPE::angleDeciDeg};
+            embot::prot::can::analog::polling::deciDegCalib decidegcalib {};
+            embot::prot::can::analog::polling::deciMilliMeterCalib decimillicalib {};
+            constexpr calibParams() = default;
+            constexpr calibParams(const embot::prot::can::analog::polling::deciDegCalib &ddcal) 
+                                    : postype(embot::prot::can::analog::posTYPE::angleDeciDeg), decidegcalib(ddcal) {}
+            constexpr calibParams(const embot::prot::can::analog::polling::deciMilliMeterCalib &dmcal) 
+                                    : postype(embot::prot::can::analog::posTYPE::linearDeciMilliMeter), decimillicalib(dmcal) {}    
+        };
+
         struct Sensor
         {
             sensorType type {sensorType::none};
             embot::hw::ANY id {embot::hw::ANY::none};
             embot::prot::can::analog::posLABEL label {embot::prot::can::analog::posLABEL::zero};
+            calibParams calibpars {};
             embot::os::Event askdata {0};           // used to ask the thread to begin acquisition from the sensor (in non-blocking mode)
             embot::os::Event dataready {0};         // used by the hw to alert the thread that the data is available
             embot::os::Event noreply {0};           // SO FAR NOT USED: maybe used to alert the waiting thread that there is no reply from the sensor after the specified timeout
             embot::core::relTime timeout {0};       // SO FAR NOT USED: the time allowed for this sensor before we can emit the noreply event. 
             constexpr Sensor() = default;
-            constexpr Sensor(sensorType ty, embot::hw::ANY i, embot::prot::can::analog::posLABEL la, embot::os::Event as, embot::os::Event dr,  embot::os::Event nr = 0, embot::core::relTime to = 0) 
-                    : type(ty), id(i), label(la), askdata(as), dataready(dr), noreply(nr), timeout(to)  {}
+            constexpr Sensor(sensorType ty, embot::hw::ANY i, embot::prot::can::analog::posLABEL la, const calibParams &cp, embot::os::Event as, embot::os::Event dr,  embot::os::Event nr = 0, embot::core::relTime to = 0) 
+                    : type(ty), id(i), label(la), calibpars(cp), askdata(as), dataready(dr), noreply(nr), timeout(to)  {}
             constexpr bool isvalid() const { return type != sensorType::none; }
         };
                    

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.cpp
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.cpp
@@ -1337,7 +1337,6 @@ namespace embot { namespace prot { namespace can { namespace analog { namespace 
     } 
 
 
-    const deciDeg deciDegPOSdescriptor::rotationmap[4] = {0, 1800, 900, -900};    
 
     
     bool Message_POS_CONFIG_SET::load(const embot::prot::can::Frame &inframe)


### PR DESCRIPTION
This PR adds a `embot::app::application::thePOSreader2::calibParams` which simplifies the calibration of the FAP readings in the board `pmc` by using `deciDegCalib` which allows a rotation, a inversion of direction and a zero in the same ways: 

```C++
struct deciDegCalib
{
    enum class ROT : uint8_t { none = 0, plus180 = 1, plus090 = 2, minus090 = 3 };
    constexpr static deciDeg rotmap[4] = {0, 1800, 900, -900};
    bool invertdirection {false};
    ROT rotation {ROT::none};   
    deciDeg zero {0};  
    constexpr deciDegCalib() = default;
    constexpr deciDegCalib(bool inv, ROT rot, deciDeg zer) : invertdirection(inv), rotation(rot), zero(zer) {}
    constexpr deciDeg rotateclip(deciDeg v) const { return ( (v+rotmap[static_cast<uint8_t>(rotation)]) % 3600 ); }
    constexpr deciDeg transform(const deciDeg raw) const
    {
        deciDeg z = rotateclip(raw) - rotateclip(zero);
        return (invertdirection) ? (-z) : (+z);
    }
    void reset()
    {
        rotation = ROT::none; invertdirection = false; zero = 0;
    }
    void load(bool inv, ROT rot, deciDeg zer) 
    {
        invertdirection = inv; rotation = rot; zero = zer; 
    }
};

```

It will be possible w/ later development to change the above parameters in runtime w/ the POS_CONFIG_SET CAN message.

The changes do nor affect the code of any existing board in iCub but only of the `pmc` board which is in an experimental setup and hence can be safely merged. 

cc @simeonedussoni 
