### PR TITLE
Support of EXT FAULT on board amcbldc

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
@@ -153,40 +153,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>172</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134397648</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\embot_app_application_theMBDagent.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/embot_app_application_theMBDagent.cpp\172</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>174</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\embot_app_application_theMBDagent.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -881,7 +848,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1089,7 +1056,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
@@ -24,7 +24,7 @@
 #include "embot_hw_sys.h"
 #include <array>
 
-// include mdb 
+// mdb components
 #include "AMC_BLDC.h"
 
 
@@ -156,10 +156,16 @@ struct embot::app::application::theMBDagent::Impl
     Measure *measureFOC {nullptr};
     Measure *measureTick {nullptr}; 
     
-    // the MBD generated class. it can stay non static.
+    // the MBD generated classes + other glue code.
+    // MBD-gen-begin ->
+    
     amc_bldc_codegen::AMC_BLDC amc_bldc {};  
     
                 
+    // <- MBD-gen-end
+    //
+
+
     // all the rest, which may or may not be required anymore
     Config config {};
     bool initted {false};
@@ -203,7 +209,8 @@ bool embot::app::application::theMBDagent::Impl::initialise()
         measureTick = new MeasureHisto({0, 400*embot::core::time1microsec, 1});
     }
     
-    // init the external fault. we use a hw::button because we dont have a hw::switch
+    // init the external fault. 
+    // we use a hw::button because we dont have a hw::switch
     // if the HW is well filtered and the push is clean, then we can just 
     // call cbkOnEXTfault_pressed.execute() if the button is pressed.
     // in the callback we set the FAULT on and in the ::tick() we must somehow set it off w/ polling
@@ -215,7 +222,7 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     embot::hw::button::init(buttonEXTfault, {embot::hw::button::Mode::TriggeredOnPress, cbkOnEXTFAULT_pressed, 0});
 #endif
     
-    // init control
+    // init MBD
     amc_bldc.initialize();
     
     // init motor
@@ -224,9 +231,9 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     // assign the callback to the current availability
     embot::hw::motor::setCallbackOnCurrents(embot::hw::MOTOR::one, Impl::onCurrents_FOC_innerloop, this);
     
-    initted = true;
     already_enabled = false;
 
+    initted = true;
     return initted;
 }
 
@@ -344,7 +351,7 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
    
 #if defined(TEST_DURATION_FOC)        
     embot::hw::sys::delay(25);
-#else   
+#else
     
     // remember to manage impl->EXTFAULTisPRESSED ............
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h
@@ -26,6 +26,7 @@
     #define EMBOT_ENABLE_hw_led
     #define EMBOT_ENABLE_hw_can
     #define EMBOT_ENABLE_hw_motor
+    #define EMBOT_ENABLE_hw_button
 
     //#define EMBOT_ENABLE_hw_i2c    
     //#define EMBOT_ENABLE_hw_pwm ?

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -87,6 +87,7 @@ namespace embot { namespace hw { namespace motor {
               
     // initialised mask       
     static std::uint32_t initialisedmask = 0;
+    static std::uint32_t enabledmask = 0;
     
     bool supported(MOTOR h)
     {
@@ -98,7 +99,15 @@ namespace embot { namespace hw { namespace motor {
         return embot::core::binary::bit::check(initialisedmask, embot::core::tointegral(h));
     }    
     
-         
+    bool enabled(MOTOR h)
+    {
+        return embot::core::binary::bit::check(enabledmask, embot::core::tointegral(h));
+    }
+    
+    result_t enable(MOTOR h, bool on)
+    {
+        return (true == on) ? motorEnable(h) : motorDisable(h);
+    }
 
     struct TBDef
     {
@@ -150,8 +159,7 @@ namespace embot { namespace hw { namespace motor {
         {
             return resOK;
         }
-        
-        
+                
         std::uint8_t index = embot::core::tointegral(h);
                
         
@@ -181,20 +189,24 @@ namespace embot { namespace hw { namespace motor {
 
     result_t motorEnable(MOTOR h)
     {
-        if(false == supported(h))
+        if(false == initialised(h))
         {
             return resNOK;
         }
+        
+        embot::core::binary::bit::set(enabledmask, embot::core::tointegral(h));
         
         return s_hw_motorEnable(h);
     }
     
     result_t motorDisable(MOTOR h)
     {
-        if(false == supported(h))
+        if(false == initialised(h))
         {
             return resNOK;
         }
+        
+        embot::core::binary::bit::clear(enabledmask, embot::core::tointegral(h));
         
         return s_hw_motorDisable(h);
     }
@@ -251,12 +263,7 @@ namespace embot { namespace hw { namespace motor {
     {
         return s_hw_setpwmUVW(h, u, v, w);
     }
-    
-//    result_t setADCcallback(MOTOR h, void (*fn_cb)(void *, int16_t[3], void*, void*), void * owner, void* rtu, void* rty)
-//    {
-//        return s_hw_setADCcallback(h, fn_cb, owner, rtu, rty);
-//    }
-    
+       
     result_t setCallbackOnCurrents(MOTOR h, fpOnCurrents callback, void *owner)
     {
         return s_hw_setCallbackOnCurrents(h, callback, owner);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
@@ -32,9 +32,11 @@ namespace embot { namespace hw { namespace motor {
             
     bool supported(embot::hw::MOTOR h);    
     bool initialised(embot::hw::MOTOR h);    
-    result_t init(embot::hw::MOTOR h, const Config &config);
+    result_t init(embot::hw::MOTOR h, const Config &config);        
+    
+    bool enabled(MOTOR h);
+    result_t enable(MOTOR h, bool on);
         
- 
     // whatever else we shall need
     
     // Position and Pwm are to be defined yet.
@@ -48,7 +50,7 @@ namespace embot { namespace hw { namespace motor {
         
     result_t gethallstatus(embot::hw::MOTOR h, uint8_t &hs);
     result_t setpwmUVW(MOTOR h, Pwm u, Pwm v, Pwm w);
-//    result_t setADCcallback(MOTOR h, void (*fn_cb)(void *, int16_t[3], void*, void*), void *owner, void* rtu, void* rty);
+
     result_t motorEnable(MOTOR h);
     result_t motorDisable(MOTOR h);
     


### PR DESCRIPTION
This PR adds support of the EXT FAULT emergency button on the `amcbldc` board for `application04` and `application05`.

This is a first basic implementation which gives to object `embot::app::application::theMBDagent` the button pressed information w/ a `bool EXTFAULTisPRESSED` variable which is set to `true` by a IRQ mechanism and must be manually reset to `false` by the `theMBDagent`. 

The IRQ mechanism is configured by the object `embot::hw::button` which is configured to trigger a callback at a `embot::hw::button::Mode::TriggeredOnPress` action on the pin `SDA` on connector `J2`. The release of the button must be manually checked when `true == EXTFAULTisPRESSED` using function `bool embot::hw::button::pressed()` to see when it returns false again. 

The mechanism is now disabled by definition of macro `DISABLE_EXTFAULT`.

This PR touches only code used by  `application04` and `application05` of the `amcbldc` board and does not interfere with their existing behaviour because of the macro `DISABLE_EXTFAULT` being defined.

On the other hand the changes can be used for further development by others (cc @sgiraz) who need the EXT FAULT.

So it can be safely merged into robotology. 
