### PR TITLE
AMCBLDC: get CAN address from the cached CANBoardInfo

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
@@ -237,6 +237,8 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     
     already_enabled = false;
 
+    CAN_ID_AMC = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
+
     initted = true;
     return initted;
 }


### PR DESCRIPTION
In this PR the firmware uses the CAN address stored in ROM instead of the constant fixed in the model (its value is 3)