### PR TITLE
amcbldc: enabled the EXT fault on application05

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/amcbldc-main.cpp
@@ -257,8 +257,8 @@ void mySYS::userdefInit_Extra(embot::os::EventThread* evthr, void *initparam) co
     theleds.get(embot::hw::LED::one).pulse(embot::core::time1second); 
 
        
-    embot::app::LEDwaveT<64> ledwave(100*embot::core::time1millisec, 30, std::bitset<64>(0b000001));
-    theleds.get(embot::hw::LED::two).wave(&ledwave);     
+//    embot::app::LEDwaveT<64> ledwave(100*embot::core::time1millisec, 30, std::bitset<64>(0b000001));
+//    theleds.get(embot::hw::LED::two).wave(&ledwave);     
 
     
     // init of can basic paser

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
@@ -22,6 +22,7 @@
 #include "embot_app_theCANboardInfo.h"
 #include "embot_app_scope.h"
 #include "embot_hw_sys.h"
+#include "embot_app_theLEDmanager.h"
 #include <array>
 
 // mdb components
@@ -30,7 +31,7 @@
 
 //#define TEST_DURATION_FOC
 
-//#define EXTFAULT_enabled
+#define EXTFAULT_enabled
 #define EXTFAULT_handler_will_disable_motor
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -226,6 +227,15 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     prevEXTFAULTisPRESSED = EXTFAULTisPRESSED = false;    
 #endif
     
+    if(true == EXTFAULTisPRESSED)
+    {
+        embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).on();
+    }
+    else 
+    {
+        embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).off();
+    }
+    
     // init MBD
     amc_bldc.initialize();
     
@@ -278,6 +288,15 @@ bool embot::app::application::theMBDagent::Impl::tick(const std::vector<embot::p
         prevEXTFAULTisPRESSED = EXTFAULTisPRESSED;  
         // and manage the transitions [pressed -> unpressed] or vice-versa and use also
         // EXTFAULTpressedtime and / or EXTFAULTreleasedtime and 
+        
+        if(true == EXTFAULTisPRESSED)
+        {
+            embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).on();
+        }
+        else
+        {
+            embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).off();
+        }
     }
     
     uint8_t rx_data[8] {0};


### PR DESCRIPTION
This PR enables the EXT fault on aplication05 of the `amcbldc`.

The code is tested on our setup and it works fine. When the EXT fault is pressed the red LED gets ON otherwise gets off
CAVEAT: the fault button pressed also disable the motor but unpressing it does not enable it back.