### PR TITLE
Enhancement of `embot::hw::motor`

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application04/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application04/src/amcbldc-main.cpp
@@ -257,8 +257,8 @@ void mySYS::userdefInit_Extra(embot::os::EventThread* evthr, void *initparam) co
     theleds.get(embot::hw::LED::one).pulse(embot::core::time1second); 
 
        
-    embot::app::LEDwaveT<64> ledwave(100*embot::core::time1millisec, 30, std::bitset<64>(0b000001));
-    theleds.get(embot::hw::LED::two).wave(&ledwave);     
+//    embot::app::LEDwaveT<64> ledwave(100*embot::core::time1millisec, 30, std::bitset<64>(0b000001));
+//    theleds.get(embot::hw::LED::two).wave(&ledwave);     
 
     
     // init of can basic paser

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
@@ -1691,7 +1691,7 @@
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>73</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -890,7 +890,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
           </Files>
@@ -1214,7 +1214,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2088,7 +2088,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
           </Files>
@@ -2412,7 +2412,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -3286,7 +3286,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
           </Files>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
@@ -229,10 +229,14 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     
     if(true == EXTFAULTisPRESSED)
     {
+#if defined(EXTFAULT_handler_will_disable_motor)         
+        embot::hw::motor::fault(embot::hw::MOTOR::one, true);
+#endif        
         embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).on();
     }
     else 
     {
+        embot::hw::motor::fault(embot::hw::MOTOR::one, false);
         embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).off();
     }
     
@@ -268,12 +272,12 @@ void embot::app::application::theMBDagent::Impl::onEXTFAULTpressedreleased(void 
     {
         impl->EXTFAULTpressedtime = embot::core::now();
 #if defined(EXTFAULT_handler_will_disable_motor) 
-        embot::hw::motor::setpwmUVW(embot::hw::MOTOR::one, 0, 0, 0); 
-        embot::hw::motor::enable(embot::hw::MOTOR::one, false);   
+        embot::hw::motor::fault(embot::hw::MOTOR::one, true);
 #endif         
     }
     else
     {
+        embot::hw::motor::fault(embot::hw::MOTOR::one, false);
         impl->EXTFAULTreleasedtime = embot::core::now();
     }
 }
@@ -409,7 +413,7 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
     int32_T Vabc1 = static_cast<int32_T>(impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Vabc[1] * 163.83F);
     int32_T Vabc2 = static_cast<int32_T>(impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Vabc[2] * 163.83F);
     
-    embot::hw::motor::setpwmUVW(embot::hw::MOTOR::one, Vabc0, Vabc1, Vabc2);
+    embot::hw::motor::setpwm(embot::hw::MOTOR::one, Vabc0, Vabc1, Vabc2);
    
 //#define DEBUG_PARAMS // TODO: remove
 #ifdef DEBUG_PARAMS

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_enable_disable_motors.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/model-based-design/sharedutils/rtw_enable_disable_motors.c
@@ -16,18 +16,28 @@
 */
 
 #include "rtw_enable_disable_motors.h"
+
 #ifdef STM32HAL_BOARD_AMCBLDC
-#include "pwm.h"
+
+#ifndef __cplusplus
+    #error this file must be compiled in C++ mode when deployed on the amcbldc target
+#endif
+// we use embot::hw
+#include "embot_hw_motor.h"
 #endif /* STM32HAL_BOARD_AMCBLDC */
 
-void rtw_enableMotor(){
-    #ifdef STM32HAL_BOARD_AMCBLDC
-    pwmPhaseEnable(PWM_PHASE_ALL);
-    #endif /* STM32HAL_BOARD_AMCBLDC */
+void rtw_enableMotor()
+{
+#ifdef STM32HAL_BOARD_AMCBLDC
+    embot::hw::motor::enable(embot::hw::MOTOR::one, true);
+#endif /* STM32HAL_BOARD_AMCBLDC */
 }
 
-void rtw_disableMotor(){
-    #ifdef STM32HAL_BOARD_AMCBLDC
-    pwmPhaseDisable(PWM_PHASE_ALL);
-    #endif /* STM32HAL_BOARD_AMCBLDC */
+void rtw_disableMotor()
+{
+#ifdef STM32HAL_BOARD_AMCBLDC
+    embot::hw::motor::enable(embot::hw::MOTOR::one, false);
+#endif /* STM32HAL_BOARD_AMCBLDC */
 }
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -1533,7 +1533,7 @@
 
   <Group>
     <GroupName>mbd</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1696,7 +1696,7 @@
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>73</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -890,7 +890,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
           </Files>
@@ -1214,7 +1214,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2088,7 +2088,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
           </Files>
@@ -2412,7 +2412,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -3286,7 +3286,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
           </Files>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/amcbldc-main.cpp
@@ -13,7 +13,7 @@
 
 constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
 { 
-    embot::prot::can::versionOfAPPLICATION {1, 0, 5},    
+    embot::prot::can::versionOfAPPLICATION {1, 0, 6},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0}    
 };
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
@@ -229,10 +229,14 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     
     if(true == EXTFAULTisPRESSED)
     {
+#if defined(EXTFAULT_handler_will_disable_motor)         
+        embot::hw::motor::fault(embot::hw::MOTOR::one, true);
+#endif        
         embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).on();
     }
     else 
     {
+        embot::hw::motor::fault(embot::hw::MOTOR::one, false);
         embot::app::theLEDmanager::getInstance().get(embot::hw::LED::two).off();
     }
     
@@ -268,12 +272,12 @@ void embot::app::application::theMBDagent::Impl::onEXTFAULTpressedreleased(void 
     {
         impl->EXTFAULTpressedtime = embot::core::now();
 #if defined(EXTFAULT_handler_will_disable_motor) 
-        embot::hw::motor::setpwmUVW(embot::hw::MOTOR::one, 0, 0, 0); 
-        embot::hw::motor::enable(embot::hw::MOTOR::one, false);   
+        embot::hw::motor::fault(embot::hw::MOTOR::one, true);
 #endif         
     }
     else
     {
+        embot::hw::motor::fault(embot::hw::MOTOR::one, false);
         impl->EXTFAULTreleasedtime = embot::core::now();
     }
 }
@@ -409,7 +413,7 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
     int32_T Vabc1 = static_cast<int32_T>(impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Vabc[1] * 163.83F);
     int32_T Vabc2 = static_cast<int32_T>(impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Vabc[2] * 163.83F);
     
-    embot::hw::motor::setpwmUVW(embot::hw::MOTOR::one, Vabc0, Vabc1, Vabc2);
+    embot::hw::motor::setpwm(embot::hw::MOTOR::one, Vabc0, Vabc1, Vabc2);
    
 //#define DEBUG_PARAMS // TODO: remove
 #ifdef DEBUG_PARAMS

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtw_enable_disable_motors.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtw_enable_disable_motors.c
@@ -16,18 +16,28 @@
 */
 
 #include "rtw_enable_disable_motors.h"
+
 #ifdef STM32HAL_BOARD_AMCBLDC
-#include "pwm.h"
+
+#ifndef __cplusplus
+    #error this file must be compiled in C++ mode when deployed on the amcbldc target
+#endif
+// we use embot::hw
+#include "embot_hw_motor.h"
 #endif /* STM32HAL_BOARD_AMCBLDC */
 
-void rtw_enableMotor(){
-    #ifdef STM32HAL_BOARD_AMCBLDC
-    pwmPhaseEnable(PWM_PHASE_ALL);
-    #endif /* STM32HAL_BOARD_AMCBLDC */
+void rtw_enableMotor()
+{
+#ifdef STM32HAL_BOARD_AMCBLDC
+    embot::hw::motor::enable(embot::hw::MOTOR::one, true);
+#endif /* STM32HAL_BOARD_AMCBLDC */
 }
 
-void rtw_disableMotor(){
-    #ifdef STM32HAL_BOARD_AMCBLDC
-    pwmPhaseDisable(PWM_PHASE_ALL);
-    #endif /* STM32HAL_BOARD_AMCBLDC */
+void rtw_disableMotor()
+{
+#ifdef STM32HAL_BOARD_AMCBLDC
+    embot::hw::motor::enable(embot::hw::MOTOR::one, false);
+#endif /* STM32HAL_BOARD_AMCBLDC */
 }
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
@@ -18,42 +18,11 @@
 
 
 namespace embot { namespace hw { namespace motor {
-           
-    struct Config
-    { 
-        uint32_t tbd {0};        
-        constexpr Config() = default;         
-        constexpr Config(uint32_t t) : tbd(t) {} 
-        constexpr bool isvalid() const { return true; }
-    };
-       
     
-    std::string to_string(embot::hw::MOTOR id);
-            
-    bool supported(embot::hw::MOTOR h);    
-    bool initialised(embot::hw::MOTOR h);    
-    result_t init(embot::hw::MOTOR h, const Config &config);        
-    
-    bool enabled(MOTOR h);
-    result_t enable(MOTOR h, bool on);
-        
-    // whatever else we shall need
-    
-    // Position and Pwm are to be defined yet.
+    // we manage: pwm, current, position. so far we use int32_t w/out a specific measurement unit
     using Position = std::int32_t;
     using Pwm = std::int32_t;
-    
-    result_t getencoder(embot::hw::MOTOR h, Position &position);
-    result_t gethallcounter(embot::hw::MOTOR h, Position &position);
-    
-    result_t setpwm(MOTOR h, Pwm v);
-        
-    result_t gethallstatus(embot::hw::MOTOR h, uint8_t &hs);
-    result_t setpwmUVW(MOTOR h, Pwm u, Pwm v, Pwm w);
-
-    result_t motorEnable(MOTOR h);
-    result_t motorDisable(MOTOR h);
-    
+    using HallStatus = std::uint8_t;
     
     // so far, we keep int32_t as it is more general. even if lower levels may propagate them as int16_t
     struct Currents
@@ -62,10 +31,41 @@ namespace embot { namespace hw { namespace motor {
         std::int32_t v {0};
         std::int32_t w {0};
         constexpr Currents() = default;
-    };
-    
+    };  
+        
     using fpOnCurrents = void (*)(void *owner, const Currents * const currents);
+      
     
+    struct Config
+    { 
+        uint32_t tbd {0};        
+        constexpr Config() = default;         
+        constexpr Config(uint32_t t) : tbd(t) {} 
+        constexpr bool isvalid() const { return true; }
+    };
+           
+    std::string to_string(embot::hw::MOTOR id);
+            
+    bool supported(embot::hw::MOTOR h);   
+    bool faulted(MOTOR h);    
+    bool initialised(embot::hw::MOTOR h);
+    bool enabled(MOTOR h);  
+    
+    result_t fault(MOTOR h, bool on);
+    result_t init(embot::hw::MOTOR h, const Config &config);   
+    // enable(h, true) is effective only if(false == faulted(h))    
+    result_t enable(MOTOR h, bool on);
+    
+    // the pwm can be effectively applied only if(true == enabled(h)), so it also must be: (false == faulted(h))
+    result_t setpwm(MOTOR h, Pwm v);
+    result_t setpwm(MOTOR h, Pwm u, Pwm v, Pwm w);
+    
+    // values of encoders and hall sensors can be read if(true == initialised(h))
+    result_t getencoder(embot::hw::MOTOR h, Position &position);
+    result_t gethallcounter(embot::hw::MOTOR h, Position &position);            
+    result_t gethallstatus(embot::hw::MOTOR h, HallStatus &hs);
+          
+    // imposes a callback on end of measurement of the currents
     result_t setCallbackOnCurrents(MOTOR h, fpOnCurrents callback, void *owner);
     
 }}} // namespace embot { namespace hw { namespace motor {


### PR DESCRIPTION
This PR improves the APIs of `embot::hw::motor` so that **operations on the motor PWM are effective only when the motor is not faulted and is enabled**.

In particular, here is the new behaviour.

The motor `embot::hw::MOTOR::one` by default is not faulted. 

We can implement a safety mechanism by association of the changes of status of a push button to a `bool EXTfaultISpressed` and to the call of a function `embot::hw::motor::fault(embot::hw::MOTOR::one, EXTfaultISpressed)`.

The call of `embot::hw::motor::fault()` function is possible even before the initialization of the motor.

But it is only after we initialize the motor `embot::hw::MOTOR::one` w/ `embot::hw::motor::init(embot::hw::MOTOR::one, cfg)` that we can attempt to enable it and apply PWM to it w/ `embot::hw::motor::enable(embot::hw::MOTOR::one, true)` and `embot::hw::motor::setpwm(embot::hw::MOTOR::one, u, v, w)`

At this stage we have two possibilities:
- if the motor `embot::hw::MOTOR::one` is **not faulted**, then we can successfully enable and move it;
- if the motor `embot::hw::MOTOR::one` is **faulted**, the above calls do not have any effect.

When the motor `embot::hw::MOTOR::one` is enabled and w/ applied PWM and it **is faulted** by a call to `embot::hw::motor::fault(embot::hw::MOTOR::one, true)` then:
- it is automatically disabled w/ an internal call to `embot::hw::motor::setpwm(embot::hw::MOTOR::one, 0, 0, 0)` and `embot::hw::motor::enable(embot::hw::MOTOR::one, false)`;
- from this point, any further call to `embot::hw::motor::enable(embot::hw::MOTOR::one, true)` or `embot::hw::motor::setpwm(embot::hw::MOTOR::one, u, v, w)` do not have any effect.

If the motor is faulted, we need an explicit call to `embot::hw::motor::fault(embot::hw::MOTOR::one, false)` followed by another explicit call to any call to  `embot::hw::motor::enable(embot::hw::MOTOR::one, true)` before the application of a non zero PWM can have affect on the motor.

This PR contains also adaptation of the projects of the `amcbldc` which use the API of `embot::hw::motor`. 
