### PR TITLE
Added support for CAN message embot::prot::can::motor::periodic::STATUS

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -22,7 +22,7 @@
   </DaveTm>
 
   <Target>
-    <TargetName>amcbldc-app05-osal-ulpro</TargetName>
+    <TargetName>amcbldc-app06-osal-ulpro</TargetName>
     <ToolsetNumber>0x4</ToolsetNumber>
     <ToolsetName>ARM-ADS</ToolsetName>
     <TargetOption>
@@ -853,7 +853,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1197,7 +1197,7 @@
 
   <Group>
     <GroupName>embot::prot::can</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -7,7 +7,7 @@
 
   <Targets>
     <Target>
-      <TargetName>amcbldc-app05-osal-ulpro</TargetName>
+      <TargetName>amcbldc-app06-osal-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
       <pCCUsed>6160000::V6.16::ARMCLANG</pCCUsed>
@@ -3610,7 +3610,7 @@
         <targetInfos>
           <targetInfo excluded="1" name="amcbldc-app01-cmsisos2-ulpro" versionMatchMode=""/>
           <targetInfo excluded="1" name="amcbldc-app01-osal-stlink" versionMatchMode=""/>
-          <targetInfo excluded="1" name="amcbldc-app05-osal-ulpro" versionMatchMode=""/>
+          <targetInfo excluded="1" name="amcbldc-app06-osal-ulpro" versionMatchMode=""/>
         </targetInfos>
       </component>
     </components>

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.cpp
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.cpp
@@ -56,6 +56,7 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
     CMD convert(std::uint8_t cmd)
     {
         constexpr std::uint16_t mcpermask16 =   (1 << static_cast<std::uint8_t>(CMD::FOC))                              |
+                                                (1 << static_cast<std::uint8_t>(CMD::STATUS))                           |
                                                 (1 << static_cast<std::uint8_t>(CMD::PRINT))                            |
                                                 (1 << static_cast<std::uint8_t>(CMD::EMSTO2FOC_DESIRED_CURRENT))        ;
 
@@ -178,8 +179,33 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
                     
         return true;
     } 
+ 
     
-
+    bool Message_STATUS::load(const Info& inf)
+    {
+        info = inf;  
+        return true;
+    }
+            
+    bool Message_STATUS::get(embot::prot::can::Frame &outframe)
+    {
+        std::uint8_t data08[8] = {0};
+        data08[0] = static_cast<std::uint8_t>(info.controlmode);
+        data08[1] = static_cast<std::uint8_t>(info.quadencoderstate);
+        data08[2] = static_cast<std::uint8_t>((info.pwmfeedback & 0x00ff));
+        data08[3] = static_cast<std::uint8_t>((info.pwmfeedback & 0xff00) >> 8);  
+        data08[4] = static_cast<std::uint8_t>((info.faultstate & 0x000000ff));
+        data08[5] = static_cast<std::uint8_t>((info.faultstate & 0x0000ff00) >> 8);  
+        data08[6] = static_cast<std::uint8_t>((info.faultstate & 0x00ff0000) >> 16);
+        data08[7] = static_cast<std::uint8_t>((info.faultstate & 0xff000000) >> 24);
+        std::uint8_t size = 8;        
+        
+        Message::set(info.canaddress, 0xf, Clas::periodicMotorControl, static_cast<std::uint8_t>(CMD::STATUS), data08, size);
+        std::memmove(&outframe, &canframe, sizeof(embot::prot::can::Frame));
+                    
+        return true;
+    } 
+    
 }}}}} // namespace embot { namespace prot { namespace can { namespace motor { namespace periodic {
     
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.h
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.h
@@ -36,6 +36,7 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
         none = 0xfe, 
         
         FOC = 0,
+        STATUS = 3,
         PRINT = 6,
         EMSTO2FOC_DESIRED_CURRENT = 15        
     };
@@ -126,6 +127,27 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
         bool get(embot::prot::can::Frame &outframe);    
     };        
 
+    
+    class Message_STATUS : public Message
+    {
+        public:
+            
+        struct Info
+        {
+            uint8_t canaddress {0};
+            uint8_t controlmode {0};
+            uint8_t quadencoderstate {0};
+            int16_t pwmfeedback {0};
+            uint32_t faultstate {0};
+            Info() = default;
+        };
+        
+        Info info {};
+        
+        Message_STATUS() = default;       
+        bool load(const Info& inf);            
+        bool get(embot::prot::can::Frame &outframe);    
+    };        
     
 }}}}} // namespace embot { namespace prot { namespace can { namespace motor { namespace periodic {    
 


### PR DESCRIPTION
This PR add support for CAN message` embot::prot::can::motor::periodic::STATUS` for use in `pmc` and `amcbldc` boards

Some sample code (not active for now) is provided for the application06 of the `amcbld` board.
