### PR TITLE
AMC_BLDC: Add support to External Fault 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvoptx
@@ -103,7 +103,7 @@
         <bEvRecOn>1</bEvRecOn>
         <bSchkAxf>0</bSchkAxf>
         <bTchkAxf>0</bTchkAxf>
-        <nTsel>1</nTsel>
+        <nTsel>4</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -114,9 +114,14 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile></tIfile>
-        <pMon>BIN\ULP2CM3.DLL</pMon>
+        <pMon>Segger\JL2CM3.dll</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
+        <SetRegEntry>
+          <Number>0</Number>
+          <Key>JL2CM3</Key>
+          <Name>-U932000551 -O78 -S8 -ZTIFSpeedSel50000 -A0 -C0 -JU1 -JI127.0.0.1 -JP0 -RST0 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO19 -TC168000000 -TP21 -TDS8003 -TDT0 -TDC1F -TIE80000001 -TIP9 -TB1 -TFE0 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
+        </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>ST-LINKIII-KEIL_SWO</Key>
@@ -150,10 +155,26 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>DLGUARM</Key>
-          <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint/>
+      <Breakpoint>
+        <Bp>
+          <Number>0</Number>
+          <Type>0</Type>
+          <LineNumber>180</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134395002</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\..\..\eBcode\arch-arm\embot\hw\embot_hw_button.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../../../../../../eBcode/arch-arm/embot/hw/embot_hw_button.cpp\180</Expression>
+        </Bp>
+      </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -720,7 +741,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -796,7 +817,7 @@
 
   <Group>
     <GroupName>embot::core</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -828,7 +849,7 @@
 
   <Group>
     <GroupName>embot::tools</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -848,7 +869,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1056,7 +1077,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1528,7 +1549,7 @@
 
   <Group>
     <GroupName>mbd</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/proj/amcbldc-application05.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1214,7 +1214,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2412,7 +2412,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application05/src/embot_app_application_theMBDagent.cpp
@@ -31,8 +31,8 @@
 
 //#define TEST_DURATION_FOC
 
-#define EXTFAULT_enabled
-#define EXTFAULT_handler_will_disable_motor
+//#define EXTFAULT_enabled
+//#define EXTFAULT_handler_will_disable_motor
 
 // --------------------------------------------------------------------------------------------------------------------
 // - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
@@ -427,14 +427,14 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
                                  Vabc0,  \
                                  Vabc1,  \
                                  Vabc2,  \
-                                 u->SensorsData_motorsensors_Iabc[0],  \
-                                 u->SensorsData_motorsensors_Iabc[1],  \
-                                 u->SensorsData_motorsensors_Iabc[2],  \
-                                 u->SensorsData_motorsensors_angle,    \
-                                 y->ControlOutputs_p.Iq_fbk.current);
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_Iabc[0],  \
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_Iabc[1],  \
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_Iabc[2],  \
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_angle,    \
+                                 impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Iq_fbk.current);
         
         //sprintf(msg2, "%d,%d,%.3f,%.3f,%.3f", delta, position, y->EstimatedData_p.jointvelocities.velocity, u->SensorsData_motorsensors_angle, y->ControlOutputs_p.Iq_fbk.current);
-        //embot::core::print(msg2);
+        embot::core::print(msg2);
         counter = 0;
     }
     counter++;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -119,6 +119,11 @@
       <TargetDriverDllRegistry>
         <SetRegEntry>
           <Number>0</Number>
+          <Key>DLGUARM</Key>
+          <Name></Name>
+        </SetRegEntry>
+        <SetRegEntry>
+          <Number>0</Number>
           <Key>JL2CM3</Key>
           <Name>-U932000551 -O78 -S2 -ZTIFSpeedSel5000 -A0 -C0 -JU1 -JI127.0.0.1 -JP0 -RST0 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO19 -TC168000000 -TP21 -TDS8003 -TDT0 -TDC1F -TIE80000001 -TIP9 -TB1 -TFE0 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
@@ -151,10 +156,6 @@
           <Number>0</Number>
           <Key>ARMDBGFLAGS</Key>
           <Name></Name>
-        </SetRegEntry>
-        <SetRegEntry>
-          <Number>0</Number>
-          <Key>DLGUARM</Key>
         </SetRegEntry>
       </TargetDriverDllRegistry>
       <Breakpoint/>
@@ -1196,7 +1197,7 @@
 
   <Group>
     <GroupName>embot::prot::can</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1424,7 +1425,7 @@
 
   <Group>
     <GroupName>others</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1611,7 +1612,7 @@
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>66</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -1684,7 +1685,7 @@
 
   <Group>
     <GroupName>mbd::can-encoder</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1852,7 +1853,7 @@
 
   <Group>
     <GroupName>mbd::supervisor-rx</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -155,7 +155,6 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>DLGUARM</Key>
-          <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
       <Breakpoint/>
@@ -705,7 +704,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -725,7 +724,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -801,7 +800,7 @@
 
   <Group>
     <GroupName>embot::core</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -833,7 +832,7 @@
 
   <Group>
     <GroupName>embot::tools</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1061,7 +1060,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1457,7 +1456,7 @@
 
   <Group>
     <GroupName>others::foc</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1477,7 +1476,7 @@
 
   <Group>
     <GroupName>others::motorhal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1544,20 +1543,20 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rt_nonfinite.cpp</PathWithFileName>
-      <FilenameWithoutPath>rt_nonfinite.cpp</FilenameWithoutPath>
+      <PathWithFileName>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</PathWithFileName>
+      <FilenameWithoutPath>rt_hypotf_snf.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>61</FileNumber>
-      <FileType>5</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rt_nonfinite.h</PathWithFileName>
-      <FilenameWithoutPath>rt_nonfinite.h</FilenameWithoutPath>
+      <PathWithFileName>..\src\model-based-design\sharedutils\rt_nonfinite.cpp</PathWithFileName>
+      <FilenameWithoutPath>rt_nonfinite.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1576,18 +1575,6 @@
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>63</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rtGetInf.h</PathWithFileName>
-      <FilenameWithoutPath>rtGetInf.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>64</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1599,25 +1586,37 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>65</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rtGetNaN.h</PathWithFileName>
-      <FilenameWithoutPath>rtGetNaN.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>66</FileNumber>
+      <FileNumber>64</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\src\model-based-design\sharedutils\rtwtypes.h</PathWithFileName>
       <FilenameWithoutPath>rtwtypes.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>65</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\sharedutils\rtw_mutex.h</PathWithFileName>
+      <FilenameWithoutPath>rtw_mutex.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>66</FileNumber>
+      <FileType>1</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</PathWithFileName>
+      <FilenameWithoutPath>rtw_enable_disable_motors.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1664,44 +1663,76 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</PathWithFileName>
-      <FilenameWithoutPath>rt_hypotf_snf.cpp</FilenameWithoutPath>
+      <PathWithFileName>..\src\model-based-design\sharedutils\uMultiWord2Double.cpp</PathWithFileName>
+      <FilenameWithoutPath>uMultiWord2Double.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>71</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rt_hypotf_snf.h</PathWithFileName>
-      <FilenameWithoutPath>rt_hypotf_snf.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>72</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rtw_mutex.h</PathWithFileName>
-      <FilenameWithoutPath>rtw_mutex.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>73</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</PathWithFileName>
-      <FilenameWithoutPath>rtw_enable_disable_motors.c</FilenameWithoutPath>
+      <PathWithFileName>..\src\model-based-design\sharedutils\uMultiWordShl.cpp</PathWithFileName>
+      <FilenameWithoutPath>uMultiWordShl.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>mbd::can-encoder</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>72</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder.cpp</PathWithFileName>
+      <FilenameWithoutPath>can_encoder.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>73</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder.h</PathWithFileName>
+      <FilenameWithoutPath>can_encoder.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>74</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder_private.h</PathWithFileName>
+      <FilenameWithoutPath>can_encoder_private.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>75</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder_types.h</PathWithFileName>
+      <FilenameWithoutPath>can_encoder_types.h</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1714,8 +1745,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>74</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>76</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1726,8 +1757,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>75</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>77</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1738,8 +1769,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>76</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>78</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1750,8 +1781,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>79</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1770,8 +1801,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>80</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1782,8 +1813,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>81</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1794,8 +1825,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>82</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1806,8 +1837,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>83</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1821,13 +1852,13 @@
 
   <Group>
     <GroupName>mbd::supervisor-rx</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>84</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1838,8 +1869,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>85</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1850,8 +1881,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>86</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1862,8 +1893,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>87</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1882,8 +1913,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>88</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1894,8 +1925,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>89</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1906,8 +1937,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>90</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1918,70 +1949,14 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>89</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\supervisor-tx\SupervisorFSM_TX_types.h</PathWithFileName>
-      <FilenameWithoutPath>SupervisorFSM_TX_types.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-  </Group>
-
-  <Group>
-    <GroupName>mbd::can-encoder</GroupName>
-    <tvExp>0</tvExp>
-    <tvExpOptDlg>0</tvExpOptDlg>
-    <cbSel>0</cbSel>
-    <RteFlg>0</RteFlg>
-    <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>90</FileNumber>
-      <FileType>8</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder.cpp</PathWithFileName>
-      <FilenameWithoutPath>can_encoder.cpp</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
       <GroupNumber>21</GroupNumber>
       <FileNumber>91</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder.h</PathWithFileName>
-      <FilenameWithoutPath>can_encoder.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>92</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder_private.h</PathWithFileName>
-      <FilenameWithoutPath>can_encoder_private.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>93</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\src\model-based-design\can-encoder\can_encoder_types.h</PathWithFileName>
-      <FilenameWithoutPath>can_encoder_types.h</FilenameWithoutPath>
+      <PathWithFileName>..\src\model-based-design\supervisor-tx\SupervisorFSM_TX_types.h</PathWithFileName>
+      <FilenameWithoutPath>SupervisorFSM_TX_types.h</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1995,7 +1970,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2007,7 +1982,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2019,7 +1994,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2031,7 +2006,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2051,7 +2026,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2063,7 +2038,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2075,7 +2050,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2087,7 +2062,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>101</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2099,7 +2074,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>102</FileNumber>
+      <FileNumber>100</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2111,7 +2086,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>103</FileNumber>
+      <FileNumber>101</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2131,7 +2106,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <FileNumber>102</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2143,7 +2118,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <FileNumber>103</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2155,7 +2130,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <FileNumber>104</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2167,7 +2142,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <FileNumber>105</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2187,7 +2162,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>108</FileNumber>
+      <FileNumber>106</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2199,7 +2174,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>109</FileNumber>
+      <FileNumber>107</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2211,7 +2186,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>110</FileNumber>
+      <FileNumber>108</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2223,7 +2198,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>111</FileNumber>
+      <FileNumber>109</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -855,7 +855,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
@@ -1204,7 +1204,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2043,7 +2043,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
@@ -2392,7 +2392,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -3231,7 +3231,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>6</Optim>
+            <Optim>1</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -824,14 +824,14 @@
           <GroupName>mbd</GroupName>
           <Files>
             <File>
+              <FileName>rt_hypotf_snf.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</FilePath>
+            </File>
+            <File>
               <FileName>rt_nonfinite.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rt_nonfinite.cpp</FilePath>
-            </File>
-            <File>
-              <FileName>rt_nonfinite.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_nonfinite.h</FilePath>
             </File>
             <File>
               <FileName>rtGetInf.cpp</FileName>
@@ -839,24 +839,24 @@
               <FilePath>..\src\model-based-design\sharedutils\rtGetInf.cpp</FilePath>
             </File>
             <File>
-              <FileName>rtGetInf.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtGetInf.h</FilePath>
-            </File>
-            <File>
               <FileName>rtGetNaN.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtGetNaN.cpp</FilePath>
             </File>
             <File>
-              <FileName>rtGetNaN.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtGetNaN.h</FilePath>
-            </File>
-            <File>
               <FileName>rtwtypes.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtwtypes.h</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_mutex.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_mutex.h</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_enable_disable_motors.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
               <FileName>const_params.cpp</FileName>
@@ -874,24 +874,39 @@
               <FilePath>..\src\model-based-design\sharedutils\zero_crossing_types.h</FilePath>
             </File>
             <File>
-              <FileName>rt_hypotf_snf.cpp</FileName>
+              <FileName>uMultiWord2Double.cpp</FileName>
               <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</FilePath>
+              <FilePath>..\src\model-based-design\sharedutils\uMultiWord2Double.cpp</FilePath>
             </File>
             <File>
-              <FileName>rt_hypotf_snf.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.h</FilePath>
-            </File>
-            <File>
-              <FileName>rtw_mutex.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtw_mutex.h</FilePath>
-            </File>
-            <File>
-              <FileName>rtw_enable_disable_motors.c</FileName>
+              <FileName>uMultiWordShl.cpp</FileName>
               <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
+              <FilePath>..\src\model-based-design\sharedutils\uMultiWordShl.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::can-encoder</GroupName>
+          <Files>
+            <File>
+              <FileName>can_encoder.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder.h</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder_private.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder_private.h</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder_types.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder_types.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -992,31 +1007,6 @@
               <FileName>SupervisorFSM_TX_types.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\supervisor-tx\SupervisorFSM_TX_types.h</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>mbd::can-encoder</GroupName>
-          <Files>
-            <File>
-              <FileName>can_encoder.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder.cpp</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder.h</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder_private.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder_private.h</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder_types.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder_types.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -2022,14 +2012,14 @@
           <GroupName>mbd</GroupName>
           <Files>
             <File>
+              <FileName>rt_hypotf_snf.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</FilePath>
+            </File>
+            <File>
               <FileName>rt_nonfinite.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rt_nonfinite.cpp</FilePath>
-            </File>
-            <File>
-              <FileName>rt_nonfinite.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_nonfinite.h</FilePath>
             </File>
             <File>
               <FileName>rtGetInf.cpp</FileName>
@@ -2037,24 +2027,24 @@
               <FilePath>..\src\model-based-design\sharedutils\rtGetInf.cpp</FilePath>
             </File>
             <File>
-              <FileName>rtGetInf.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtGetInf.h</FilePath>
-            </File>
-            <File>
               <FileName>rtGetNaN.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtGetNaN.cpp</FilePath>
             </File>
             <File>
-              <FileName>rtGetNaN.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtGetNaN.h</FilePath>
-            </File>
-            <File>
               <FileName>rtwtypes.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtwtypes.h</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_mutex.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_mutex.h</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_enable_disable_motors.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
               <FileName>const_params.cpp</FileName>
@@ -2072,24 +2062,39 @@
               <FilePath>..\src\model-based-design\sharedutils\zero_crossing_types.h</FilePath>
             </File>
             <File>
-              <FileName>rt_hypotf_snf.cpp</FileName>
+              <FileName>uMultiWord2Double.cpp</FileName>
               <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</FilePath>
+              <FilePath>..\src\model-based-design\sharedutils\uMultiWord2Double.cpp</FilePath>
             </File>
             <File>
-              <FileName>rt_hypotf_snf.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.h</FilePath>
-            </File>
-            <File>
-              <FileName>rtw_mutex.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtw_mutex.h</FilePath>
-            </File>
-            <File>
-              <FileName>rtw_enable_disable_motors.c</FileName>
+              <FileName>uMultiWordShl.cpp</FileName>
               <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
+              <FilePath>..\src\model-based-design\sharedutils\uMultiWordShl.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::can-encoder</GroupName>
+          <Files>
+            <File>
+              <FileName>can_encoder.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder.h</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder_private.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder_private.h</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder_types.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder_types.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -2190,31 +2195,6 @@
               <FileName>SupervisorFSM_TX_types.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\supervisor-tx\SupervisorFSM_TX_types.h</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>mbd::can-encoder</GroupName>
-          <Files>
-            <File>
-              <FileName>can_encoder.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder.cpp</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder.h</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder_private.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder_private.h</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder_types.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder_types.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -3220,14 +3200,14 @@
           <GroupName>mbd</GroupName>
           <Files>
             <File>
+              <FileName>rt_hypotf_snf.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</FilePath>
+            </File>
+            <File>
               <FileName>rt_nonfinite.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rt_nonfinite.cpp</FilePath>
-            </File>
-            <File>
-              <FileName>rt_nonfinite.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_nonfinite.h</FilePath>
             </File>
             <File>
               <FileName>rtGetInf.cpp</FileName>
@@ -3235,24 +3215,24 @@
               <FilePath>..\src\model-based-design\sharedutils\rtGetInf.cpp</FilePath>
             </File>
             <File>
-              <FileName>rtGetInf.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtGetInf.h</FilePath>
-            </File>
-            <File>
               <FileName>rtGetNaN.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtGetNaN.cpp</FilePath>
             </File>
             <File>
-              <FileName>rtGetNaN.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtGetNaN.h</FilePath>
-            </File>
-            <File>
               <FileName>rtwtypes.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtwtypes.h</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_mutex.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_mutex.h</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_enable_disable_motors.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
               <FileName>const_params.cpp</FileName>
@@ -3270,24 +3250,39 @@
               <FilePath>..\src\model-based-design\sharedutils\zero_crossing_types.h</FilePath>
             </File>
             <File>
-              <FileName>rt_hypotf_snf.cpp</FileName>
+              <FileName>uMultiWord2Double.cpp</FileName>
               <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.cpp</FilePath>
+              <FilePath>..\src\model-based-design\sharedutils\uMultiWord2Double.cpp</FilePath>
             </File>
             <File>
-              <FileName>rt_hypotf_snf.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rt_hypotf_snf.h</FilePath>
-            </File>
-            <File>
-              <FileName>rtw_mutex.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtw_mutex.h</FilePath>
-            </File>
-            <File>
-              <FileName>rtw_enable_disable_motors.c</FileName>
+              <FileName>uMultiWordShl.cpp</FileName>
               <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
+              <FilePath>..\src\model-based-design\sharedutils\uMultiWordShl.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::can-encoder</GroupName>
+          <Files>
+            <File>
+              <FileName>can_encoder.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder.h</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder_private.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder_private.h</FilePath>
+            </File>
+            <File>
+              <FileName>can_encoder_types.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>..\src\model-based-design\can-encoder\can_encoder_types.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -3388,31 +3383,6 @@
               <FileName>SupervisorFSM_TX_types.h</FileName>
               <FileType>5</FileType>
               <FilePath>..\src\model-based-design\supervisor-tx\SupervisorFSM_TX_types.h</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>mbd::can-encoder</GroupName>
-          <Files>
-            <File>
-              <FileName>can_encoder.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder.cpp</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder.h</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder_private.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder_private.h</FilePath>
-            </File>
-            <File>
-              <FileName>can_encoder_types.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\src\model-based-design\can-encoder\can_encoder_types.h</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
@@ -245,6 +245,8 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     // init MBD
     amc_bldc.initialize();
     
+    amc_bldc.AMC_BLDC_U.ExternalFlags_fault_button = EXTFAULTisPRESSED;
+    
     // init motor
     embot::hw::motor::init(embot::hw::MOTOR::one, {});
     
@@ -293,7 +295,9 @@ bool embot::app::application::theMBDagent::Impl::tick(const std::vector<embot::p
     {
         prevEXTFAULTisPRESSED = EXTFAULTisPRESSED;  
         // and manage the transitions [pressed -> unpressed] or vice-versa and use also
-        // EXTFAULTpressedtime and / or EXTFAULTreleasedtime and 
+        // EXTFAULTpressedtime and / or EXTFAULTreleasedtime and
+
+        amc_bldc.AMC_BLDC_U.ExternalFlags_fault_button = EXTFAULTisPRESSED;        
         
         if(true == EXTFAULTisPRESSED)
         {
@@ -457,7 +461,6 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
 
 bool embot::app::application::theMBDagent::Impl::addMCstatus(std::vector<embot::prot::can::Frame> &outframes)
 {
-    #include "embot_prot_can_motor_polling.h"
     embot::prot::can::motor::polling::ControlMode ctrlmode {embot::prot::can::motor::polling::ControlMode::Idle};
     
     embot::prot::can::motor::periodic::Message_STATUS msg {};
@@ -465,6 +468,7 @@ bool embot::app::application::theMBDagent::Impl::addMCstatus(std::vector<embot::
 
     info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
     info.controlmode = embot::prot::can::motor::polling::convert(ctrlmode);
+    info.faultstate = (true == EXTFAULTisPRESSED) ? 0x00000001 : 0x00000000;
     // etc
         
     msg.load(info);

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.174
+// Model version                  : 3.203
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:21 2022
+// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -406,6 +406,12 @@ namespace amc_bldc_codegen
     AMC_BLDC_B.BusConversion_InsertedFor_Super.motorsensors.hallABC =
       rtb_hallABC;
 
+    // BusCreator generated from: '<S7>/SupervisorFSM_RX' incorporates:
+    //   Inport: '<Root>/ExternalFlags_fault_button'
+
+    AMC_BLDC_B.BusConversion_InsertedFor_Sup_j.fault_button =
+      AMC_BLDC_U.ExternalFlags_fault_button;
+
     // ModelReference: '<S7>/SupervisorFSM_RX' incorporates:
     //   Outport: '<Root>/ConfigurationParameters'
     //   Outport: '<Root>/EstimatedData'
@@ -414,7 +420,8 @@ namespace amc_bldc_codegen
       AMC_BLDC_B.CAN_Decoder_o1, AMC_BLDC_B.CAN_Decoder_o3,
       AMC_BLDC_Y.EstimatedData_p, AMC_BLDC_B.BusConversion_InsertedFor_Super,
       AMC_BLDC_B.RTBInsertedForAdapter_InsertedF, AMC_BLDC_B.Targets_n,
-      AMC_BLDC_Y.ConfigurationParameters_p, AMC_BLDC_B.Flags_k);
+      AMC_BLDC_Y.ConfigurationParameters_p, AMC_BLDC_B.Flags_k,
+      &AMC_BLDC_B.BusConversion_InsertedFor_Sup_j);
 
     // BusCreator generated from: '<S7>/SupervisorFSM_TX'
     rtb_BusConversion_InsertedFor_S.jointpositions.position = rtb_position;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.174
+// Model version                  : 3.203
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:21 2022
+// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -91,6 +91,7 @@ namespace amc_bldc_codegen
       ControlOutputs RTBInsertedForAdapter_InsertedF;// '<Root>/Adapter1'
       BUS_MESSAGES_TX MessagesTx;      // '<S7>/SupervisorFSM_TX'
       Flags Flags_k;                   // '<S7>/SupervisorFSM_RX'
+      ExternalFlags BusConversion_InsertedFor_Sup_j;
       BUS_EVENTS_TX SupervisorFSM_TX_o2;// '<S7>/SupervisorFSM_TX'
       BUS_EVENTS_RX CAN_Decoder_o2;    // '<S6>/CAN_Decoder'
       BUS_CAN_RX_ERRORS CAN_Decoder_o3;// '<S6>/CAN_Decoder'
@@ -142,6 +143,7 @@ namespace amc_bldc_codegen
       real32_T SensorsData_motorsensors_voltag;// '<Root>/B_-1_-1'
       real32_T SensorsData_motorsensors_curren;// '<Root>/B_-1_-1'
       uint8_T SensorsData_motorsensors_hallAB;// '<Root>/B_-1_-1'
+      boolean_T ExternalFlags_fault_button;// '<Root>/B_-1_-1'
       uint8_T PacketsRx_available;     // '<Root>/B_-1_-1'
       uint8_T PacketsRx_lengths;       // '<Root>/B_-1_-1'
       uint16_T PacketsRx_packets_ID;   // '<Root>/B_-1_-1'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.174
+// Model version                  : 3.203
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:21 2022
+// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.174
+// Model version                  : 3.203
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:21 2022
+// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -317,16 +317,13 @@ struct ControlOutputs
 
 #endif
 
-#ifndef DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
-#define DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
+#ifndef DEFINED_TYPEDEF_FOR_ExternalFlags_
+#define DEFINED_TYPEDEF_FOR_ExternalFlags_
 
-// Aggregate of all events specifying types of received messages.
-struct BUS_EVENTS_RX
+struct ExternalFlags
 {
-  boolean_T control_mode;
-  boolean_T current_limit;
-  boolean_T desired_current;
-  boolean_T current_pid;
+  // External Fault Button (1 == pressed)
+  boolean_T fault_button;
 };
 
 #endif
@@ -425,6 +422,20 @@ struct BUS_MESSAGES_RX
   BUS_MSG_CURRENT_LIMIT current_limit;
   BUS_MSG_DESIRED_CURRENT desired_current;
   BUS_MSG_CURRENT_PID current_pid;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
+#define DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
+
+// Aggregate of all events specifying types of received messages.
+struct BUS_EVENTS_RX
+{
+  boolean_T control_mode;
+  boolean_T current_limit;
+  boolean_T desired_current;
+  boolean_T current_pid;
 };
 
 #endif
@@ -579,8 +590,8 @@ struct BUS_CAN_PAYLOAD_RX
   uint8_T LEN;
   BUS_CAN_CMD CMD;
 
-  // 7 bytes for the command argument.
-  uint8_T ARG[7];
+  // 8 bytes for the command argument in order to account also message of type streaming. 
+  uint8_T ARG[8];
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-decoder/can_decoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 2.27
+// Model version                  : 2.40
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:42 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -72,8 +72,8 @@ namespace amc_bldc_codegen
       uint8_T is_active_SET_CONTROL_MODE;// '<S1>/Decoding Logic'
       uint8_T is_DESIRED_CURRENT;      // '<S1>/Decoding Logic'
       uint8_T is_active_DESIRED_CURRENT;// '<S1>/Decoding Logic'
-      uint8_T is_SET_CURRENT;          // '<S1>/Decoding Logic'
-      uint8_T is_active_SET_CURRENT;   // '<S1>/Decoding Logic'
+      uint8_T is_SET_CURRENT_OPTIONS;  // '<S1>/Decoding Logic'
+      uint8_T is_active_SET_CURRENT_OPTIONS;// '<S1>/Decoding Logic'
       uint8_T is_ERROR_HANDLING;       // '<S1>/Decoding Logic'
       uint8_T is_active_ERROR_HANDLING;// '<S1>/Decoding Logic'
       boolean_T ev_async;              // '<S1>/Decoding Logic'
@@ -114,10 +114,10 @@ namespace amc_bldc_codegen
    private:
     // private member function(s) for subsystem '<Root>/TmpModelReferenceSubsystem'
     int32_T can_de_safe_cast_to_MCStreaming(int32_T input);
-    int16_T can_decoder_merge_2bytes_signed(uint16_T bl, uint16_T bh);
     void can_decoder_ERROR_HANDLING(const BUS_CAN_RX *arg_pck_rx);
     boolean_T can_d_is_controlmode_recognized(int32_T mode);
     int32_T can_safe_cast_to_MCControlModes(int32_T input);
+    int16_T can_decoder_merge_2bytes_signed(uint16_T bl, uint16_T bh);
     uint16_T can_decod_merge_2bytes_unsigned(uint16_T bl, uint16_T bh);
 
     // Real-Time Model

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-decoder/can_decoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 2.27
+// Model version                  : 2.40
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:42 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-decoder/can_decoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 2.27
+// Model version                  : 2.40
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:42 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -76,8 +76,8 @@ struct BUS_CAN_PAYLOAD_RX
   uint8_T LEN;
   BUS_CAN_CMD CMD;
 
-  // 7 bytes for the command argument.
-  uint8_T ARG[7];
+  // 8 bytes for the command argument in order to account also message of type streaming. 
+  uint8_T ARG[8];
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 15:52:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -118,12 +118,10 @@ namespace amc_bldc_codegen
     // MATLAB Function: '<S1>/format_can_id' incorporates:
     //   Constant: '<S1>/Constant'
     //   Constant: '<S1>/Motor Control Streaming'
-    //   Constant: '<S1>/TYPE2FOC'
 
     arg_pck_tx.packets.ID = 256U;
     arg_pck_tx.packets.ID = static_cast<uint16_T>(CAN_ID_AMC << 4 |
       arg_pck_tx.packets.ID);
-    arg_pck_tx.packets.ID = static_cast<uint16_T>(arg_pck_tx.packets.ID | 15);
 
     // DataTypeConversion: '<S1>/Data Type Conversion' incorporates:
     //   RelationalOperator: '<S2>/FixPt Relational Operator'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 15:52:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 15:52:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-encoder/can_encoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 15:52:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 2.5
+// Model version                  : 2.7
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:51 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -43,8 +43,6 @@ namespace amc_bldc_codegen
   void CAN_RX_raw2struct::step(const BUS_CAN &arg_pck_rx_raw, BUS_CAN_RX &
     arg_pck_rx_struct)
   {
-    int32_T i;
-    uint32_T qY;
     uint8_T minval;
 
     // Outputs for Atomic SubSystem: '<Root>/CAN_RX_RAW2STRUCT'
@@ -71,19 +69,9 @@ namespace amc_bldc_codegen
       & 128U) != 0U);
     arg_pck_rx_struct.packets.PAYLOAD.CMD.OPC = static_cast<uint8_T>
       (arg_pck_rx_raw.packets.PAYLOAD[0] & 127);
-    for (i = 0; i < 7; i++) {
-      arg_pck_rx_struct.packets.PAYLOAD.ARG[i] = 0U;
-    }
-
-    qY = arg_pck_rx_struct.packets.PAYLOAD.LEN - 1U;
-    if (arg_pck_rx_struct.packets.PAYLOAD.LEN - 1U >
-        arg_pck_rx_struct.packets.PAYLOAD.LEN) {
-      qY = 0U;
-    }
-
-    for (i = 1; i - 1 < static_cast<uint8_T>(qY); i++) {
-      arg_pck_rx_struct.packets.PAYLOAD.ARG[static_cast<uint8_T>(i) - 1] =
-        arg_pck_rx_raw.packets.PAYLOAD[static_cast<uint8_T>(i)];
+    for (int32_T i = 0; i < 8; i++) {
+      arg_pck_rx_struct.packets.PAYLOAD.ARG[i] =
+        arg_pck_rx_raw.packets.PAYLOAD[i];
     }
 
     // End of MATLAB Function: '<S1>/RAW2STRUCT Decoding Logic'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 2.5
+// Model version                  : 2.7
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:51 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 2.5
+// Model version                  : 2.7
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:51 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/can-raw2struct/can_rx_raw2struct_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_rx_raw2struct'.
 //
-// Model version                  : 2.5
+// Model version                  : 2.7
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:51 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -104,8 +104,8 @@ struct BUS_CAN_PAYLOAD_RX
   uint8_T LEN;
   BUS_CAN_CMD CMD;
 
-  // 7 bytes for the command argument.
-  uint8_T ARG[7];
+  // 8 bytes for the command argument in order to account also message of type streaming. 
+  uint8_T ARG[8];
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:04 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:04 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:04 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:04 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:10 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:10 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:10 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:10 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/const_params.cpp
@@ -9,7 +9,7 @@
 //
 //  Model version              : 2.35
 //  Simulink Coder version : 9.6 (R2021b) 14-May-2021
-//  C++ source code generated on : Mon Jan 10 17:05:10 2022
+//  C++ source code generated on : Thu Jan 13 14:10:25 2022
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/multiword_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/multiword_types.h
@@ -1,0 +1,50 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: multiword_types.h
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 3.139
+// Simulink Coder version         : 9.6 (R2021b) 14-May-2021
+// C/C++ source code generated on : Thu Jan 13 14:09:31 2022
+//
+#ifndef MULTIWORD_TYPES_H
+#define MULTIWORD_TYPES_H
+#include "rtwtypes.h"
+
+//
+//  MultiWord supporting definitions
+
+typedef long int long_T;
+
+//
+//  MultiWord types
+
+typedef struct {
+  uint32_T chunks[2];
+} int64m_T;
+
+typedef struct {
+  int64m_T re;
+  int64m_T im;
+} cint64m_T;
+
+typedef struct {
+  uint32_T chunks[2];
+} uint64m_T;
+
+typedef struct {
+  uint64m_T re;
+  uint64m_T im;
+} cuint64m_T;
+
+#endif                                 // MULTIWORD_TYPES_H
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:57 2022
 //
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetInf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:57 2022
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:57 2022
 //
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtGetNaN.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:57 2022
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:10 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:25 2022
 //
 #include "rtwtypes.h"
 #include <cmath>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_hypotf_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_hypotf_snf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:05:10 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:25 2022
 //
 #ifndef RTW_HEADER_rt_hypotf_snf_h_
 #define RTW_HEADER_rt_hypotf_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:57 2022
 //
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.6
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:47 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:57 2022
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.125
+// Model version                  : 3.139
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:29 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:31 2022
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWord2Double.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWord2Double.cpp
@@ -1,0 +1,36 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: uMultiWord2Double.cpp
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 3.139
+// Simulink Coder version         : 9.6 (R2021b) 14-May-2021
+// C/C++ source code generated on : Thu Jan 13 14:09:31 2022
+//
+#include "rtwtypes.h"
+#include <cmath>
+#include "uMultiWord2Double.h"
+
+real_T uMultiWord2Double(const uint32_T u1[], int32_T n1, int32_T e1)
+{
+  real_T y;
+  int32_T exp_0;
+  y = 0.0;
+  exp_0 = e1;
+  for (int32_T i = 0; i < n1; i++) {
+    y += std::ldexp(static_cast<real_T>(u1[i]), exp_0);
+    exp_0 += 32;
+  }
+
+  return y;
+}
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWord2Double.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWord2Double.h
@@ -1,0 +1,26 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: uMultiWord2Double.h
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 3.139
+// Simulink Coder version         : 9.6 (R2021b) 14-May-2021
+// C/C++ source code generated on : Thu Jan 13 14:09:31 2022
+//
+#ifndef RTW_HEADER_uMultiWord2Double_h_
+#define RTW_HEADER_uMultiWord2Double_h_
+#include "rtwtypes.h"
+
+extern real_T uMultiWord2Double(const uint32_T u1[], int32_T n1, int32_T e1);
+
+#endif                                 // RTW_HEADER_uMultiWord2Double_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWordShl.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWordShl.cpp
@@ -1,0 +1,73 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: uMultiWordShl.cpp
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 3.139
+// Simulink Coder version         : 9.6 (R2021b) 14-May-2021
+// C/C++ source code generated on : Thu Jan 13 14:09:31 2022
+//
+#include "rtwtypes.h"
+#include "uMultiWordShl.h"
+
+void uMultiWordShl(const uint32_T u1[], int32_T n1, uint32_T n2, uint32_T y[],
+                   int32_T n)
+{
+  int32_T i;
+  int32_T nb;
+  int32_T nc;
+  uint32_T u1i;
+  uint32_T ys;
+  nb = static_cast<int32_T>(n2 >> 5);
+  ys = (u1[n1 - 1] & 2147483648U) != 0U ? MAX_uint32_T : 0U;
+  nc = nb > n ? n : nb;
+  u1i = 0U;
+  for (i = 0; i < nc; i++) {
+    y[i] = 0U;
+  }
+
+  if (nb < n) {
+    uint32_T nl;
+    nl = n2 - (static_cast<uint32_T>(nb) << 5);
+    nb += n1;
+    if (nb > n) {
+      nb = n;
+    }
+
+    nb -= i;
+    if (nl > 0U) {
+      for (nc = 0; nc < nb; nc++) {
+        uint32_T yi;
+        yi = u1i >> (32U - nl);
+        u1i = u1[nc];
+        y[i] = u1i << nl | yi;
+        i++;
+      }
+
+      if (i < n) {
+        y[i] = u1i >> (32U - nl) | ys << nl;
+        i++;
+      }
+    } else {
+      for (nc = 0; nc < nb; nc++) {
+        y[i] = u1[nc];
+        i++;
+      }
+    }
+  }
+
+  while (i < n) {
+    y[i] = ys;
+    i++;
+  }
+}
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWordShl.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/uMultiWordShl.h
@@ -1,0 +1,27 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: uMultiWordShl.h
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 3.139
+// Simulink Coder version         : 9.6 (R2021b) 14-May-2021
+// C/C++ source code generated on : Thu Jan 13 14:09:31 2022
+//
+#ifndef RTW_HEADER_uMultiWordShl_h_
+#define RTW_HEADER_uMultiWordShl_h_
+#include "rtwtypes.h"
+
+extern void uMultiWordShl(const uint32_T u1[], int32_T n1, uint32_T n2, uint32_T
+  y[], int32_T n);
+
+#endif                                 // RTW_HEADER_uMultiWordShl_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:57 2022
+// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.125
+// Model version                  : 3.144
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:29 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -23,6 +23,9 @@
 #include <stddef.h>
 #include "rtwtypes.h"
 #include "SupervisorFSM_RX_types.h"
+
+// Shared type includes
+#include "multiword_types.h"
 #include <stddef.h>
 
 // user code (top of header file)
@@ -52,9 +55,11 @@ namespace amc_bldc_codegen
       uint8_T is_active_FAULT_HANDLER; // '<Root>/SupervisorFSM_RX'
       uint8_T is_OverCurrent;          // '<Root>/SupervisorFSM_RX'
       uint8_T is_active_OverCurrent;   // '<Root>/SupervisorFSM_RX'
-      uint8_T is_FaultBottomPressed;   // '<Root>/SupervisorFSM_RX'
-      uint8_T is_active_FaultBottomPressed;// '<Root>/SupervisorFSM_RX'
+      uint8_T is_FaultButtonPressed;   // '<Root>/SupervisorFSM_RX'
+      uint8_T is_active_FaultButtonPressed;// '<Root>/SupervisorFSM_RX'
       boolean_T IsCurrentLimitSet;     // '<Root>/SupervisorFSM_RX'
+      boolean_T isFaultButtonPressed;  // '<Root>/SupervisorFSM_RX'
+      boolean_T isInOverCurrent;       // '<Root>/SupervisorFSM_RX'
       boolean_T EventsRx_control_mode_prev;// '<Root>/SupervisorFSM_RX'
       boolean_T EventsRx_control_mode_start;// '<Root>/SupervisorFSM_RX'
       boolean_T EventsRx_current_pid_prev;// '<Root>/SupervisorFSM_RX'
@@ -65,6 +70,8 @@ namespace amc_bldc_codegen
       boolean_T EventsRx_desired_current_start;// '<Root>/SupervisorFSM_RX'
       boolean_T EventsRx_current_limit_prev;// '<Root>/SupervisorFSM_RX'
       boolean_T EventsRx_current_limit_start;// '<Root>/SupervisorFSM_RX'
+      boolean_T ExternalFlags_fault_button_prev;// '<Root>/SupervisorFSM_RX'
+      boolean_T ExternalFlags_fault_button_star;// '<Root>/SupervisorFSM_RX'
     };
 
     // Real-time Model Data Structure
@@ -82,7 +89,7 @@ namespace amc_bldc_codegen
               EstimatedData &arg_EstimatedData, const SensorsData &
               arg_SensorsData, const ControlOutputs &arg_ControlOutputs, Targets
               &arg_Targets, ConfigurationParameters &arg_Output, Flags &
-              arg_Flags);
+              arg_Flags, ExternalFlags *arg_SensorsData1);
 
     // Real-Time Model get method
     amc_bldc_codegen::SupervisorFSM_RX::RT_MODEL_SupervisorFSM_RX_T * getRTM();
@@ -117,10 +124,12 @@ namespace amc_bldc_codegen
       BUS_MESSAGES_RX *arg_MessagesRx, Flags *arg_Flags, Targets *arg_Targets);
     boolean_T SupervisorFSM_RX_IsBoardReady(void) const;
     boolean_T SupervisorFS_isConfigurationSet(void) const;
+    boolean_T SupervisorFSM_IsInHardwareFault(void) const;
     void Supervisor_CONTROL_MODE_HANDLER(const SensorsData *arg_SensorsData,
       const ControlOutputs *arg_ControlOutputs, const BUS_MESSAGES_RX
       *arg_MessagesRx, Flags *arg_Flags, Targets *arg_Targets);
     boolean_T SupervisorFSM_isBoardConfigured(void);
+    real32_T SupervisorFSM_RX_ConvertPid(real32_T in, uint8_T shift);
 
     // Real-Time Model
     RT_MODEL_SupervisorFSM_RX_T SupervisorFSM_RX_M;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.125
+// Model version                  : 3.144
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:29 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,6 +19,7 @@
 #ifndef RTW_HEADER_SupervisorFSM_RX_private_h_
 #define RTW_HEADER_SupervisorFSM_RX_private_h_
 #include "rtwtypes.h"
+#include "multiword_types.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.125
+// Model version                  : 3.144
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:29 2022
+// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -61,6 +61,17 @@ struct SensorsData
 
 #endif
 
+#ifndef DEFINED_TYPEDEF_FOR_ExternalFlags_
+#define DEFINED_TYPEDEF_FOR_ExternalFlags_
+
+struct ExternalFlags
+{
+  // External Fault Button (1 == pressed)
+  boolean_T fault_button;
+};
+
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
 #define DEFINED_TYPEDEF_FOR_MotorCurrent_
 
@@ -82,42 +93,6 @@ struct ControlOutputs
 
   // quadrature current
   MotorCurrent Iq_fbk;
-};
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_JointVelocities_
-#define DEFINED_TYPEDEF_FOR_JointVelocities_
-
-struct JointVelocities
-{
-  // joint velocities
-  real32_T velocity;
-};
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
-#define DEFINED_TYPEDEF_FOR_EstimatedData_
-
-struct EstimatedData
-{
-  // velocities
-  JointVelocities jointvelocities;
-};
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
-#define DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
-
-// Aggregate of all events specifying types of received messages.
-struct BUS_EVENTS_RX
-{
-  boolean_T control_mode;
-  boolean_T current_limit;
-  boolean_T desired_current;
-  boolean_T current_pid;
 };
 
 #endif
@@ -216,6 +191,42 @@ struct BUS_MESSAGES_RX
   BUS_MSG_CURRENT_LIMIT current_limit;
   BUS_MSG_DESIRED_CURRENT desired_current;
   BUS_MSG_CURRENT_PID current_pid;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_JointVelocities_
+#define DEFINED_TYPEDEF_FOR_JointVelocities_
+
+struct JointVelocities
+{
+  // joint velocities
+  real32_T velocity;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
+#define DEFINED_TYPEDEF_FOR_EstimatedData_
+
+struct EstimatedData
+{
+  // velocities
+  JointVelocities jointvelocities;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
+#define DEFINED_TYPEDEF_FOR_BUS_EVENTS_RX_
+
+// Aggregate of all events specifying types of received messages.
+struct BUS_EVENTS_RX
+{
+  boolean_T control_mode;
+  boolean_T current_limit;
+  boolean_T desired_current;
+  boolean_T current_pid;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.15
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:36 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.15
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:36 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.15
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:36 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.15
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 10 17:04:36 2022
+// C/C++ source code generated on : Thu Jan 13 14:09:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -1005,7 +1005,7 @@ void Motor_actuate(Motor* motor, uint8_t N) //
 {
     if (motor->HARDWARE_TYPE == HARDWARE_2FOC)
     {
-        int16_t output[MAX_JOINTS_PER_BOARD];
+        int16_t output[MAX_JOINTS_PER_BOARD] = {0};
     
         for (int m=0; m<N; ++m)
         {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -225,7 +225,7 @@ namespace embot { namespace hw { namespace motor {
         }
         
         // if we are faulted we cannot enable, so i force on to false    
-        if(false == faulted(h))
+        if(true == faulted(h))
         {
             on = false;
         }


### PR DESCRIPTION
What's changed in this PR:

- Updated the generated code in `Application06` with encoder/decoder updates applied on `mbd`
- Bug Fix where targets setpoint were uninitialized in `emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c` 
- `Application06` now supports the external fault signal. Glue code has been added to connect the low-level signal with the mbd input managed then by Supervisor.
- Disabled ExternalFault macros in Application05

**Notes:**
Tests performed with `Application06`:

| Command Sequence | set limits | set current mode | set target |  | set idle mode | set current mode | set target | set idle mode | set current mode | set target |  |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| Fault Button State | OFF | OFF | OFF | ON | ON | ON | ON | OFF | OFF | OFF | ON |

The above test has been repeated many times with either the Fault Button initially pushed or released.
On each execution, the results are as expected: every time the fault button is pressed the PWM signal stops. Every time the Fault Button is released we can always send a new target after we sent a set control mode idle and then go back to the current control mode.

Furthermore, I can confirm that the External Fault is correctly detected and managed by the Supervisor:

![image](https://user-images.githubusercontent.com/18039045/149573380-0a55a144-b366-4c84-95d2-4b2686ae1341.png)

⚠️ In order to run Application05 on LEGO-Setup, the `External-Faults` macros have been disabled otherwise the `External-Fault` will result always be pressed regardless the physical button is attached or not ( 🐞 ).

cc @marcoaccame @pattacini @valegagge @GrmanRodriguez @ale-git