### PR TITLE
amcbldc: now application06 correctly consumes one can frame every 1 ms

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -125,7 +125,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>JL2CM3</Key>
-          <Name>-U932000551 -O78 -S2 -ZTIFSpeedSel5000 -A0 -C0 -JU1 -JI127.0.0.1 -JP0 -RST0 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO19 -TC168000000 -TP21 -TDS8003 -TDT0 -TDC1F -TIE80000001 -TIP9 -TB1 -TFE0 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
+          <Name>-U752001923 -O78 -S8 -ZTIFSpeedSel50000 -A0 -C0 -JU1 -JI127.0.0.1 -JP0 -RST0 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO3 -TC168000000 -TP21 -TDS8003 -TDT0 -TDC1F -TIE80000001 -TIP9 -TB1 -TFE0 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -174,6 +174,11 @@
           <count>2</count>
           <WinNumber>1</WinNumber>
           <ItemText>vals,0x0A</ItemText>
+        </Ww>
+        <Ww>
+          <count>3</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>last_frame</ItemText>
         </Ww>
       </WatchWindow1>
       <MemoryWindow1>
@@ -705,7 +710,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -853,7 +858,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1425,7 +1430,7 @@
 
   <Group>
     <GroupName>others</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1204,7 +1204,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2392,7 +2392,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/amcbldc-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/amcbldc-main.cpp
@@ -396,8 +396,8 @@ std::vector<embot::prot::can::Frame> inputframes {};
 void tCTRL_startup(embot::os::Thread *t, void *param)
 {
     
-    outctrlframes.reserve(5);
-    inputframes.reserve(5);
+    outctrlframes.reserve(8);
+    inputframes.reserve(16);
 
     // init agent of mc. it also init motor
     embot::app::application::theMBDagent &thembdagent = embot::app::application::theMBDagent::getInstance();
@@ -500,40 +500,10 @@ void mbd_mc_canparse(const embot::prot::can::Frame &rxframe,
 // the status of the control
 void mbd_mc_tick(std::vector<embot::prot::can::Frame> &inpframes, std::vector<embot::prot::can::Frame> &outframes)
 { 
-    // now we use the c++ agent to tick control and get an output 
-    // vector of frames to transmit  
 
-//    size_t num = shared->sizeofrx();
-//    
-//    for(int i=0; i<num; i++)
-//    {
-//        size_t remaining {0};
-//        embot::prot::can::Frame frame {};
-//        if(true == shared->getrx(frame, remaining))
-//        {
-//            mbd_mc_canparse(frame, outctrlframes);
-//            //embot::app::application::theCANparserMC::getInstance().process(frame, outctrlframes);
-//        }
-//    }
-//    
-//    std::vector<embot::prot::can::Frame> inpframes {};
-
-//    size_t num = shared->sizeofrx();
-//    
-//    for(int i=0; i<num; i++)
-//    {
-//        size_t remaining {0};
-//        embot::prot::can::Frame frame {};
-//        if(true == shared->getrx(frame, remaining))
-//        {
-//            inpframes.push_back(frame);
-//        }
-//    }
-   
-        
+    size_t consumedframes {0};    
     embot::app::application::theMBDagent::getInstance().tick(inpframes, outframes);
-    inputframes.clear();
-    
+    // the vector inpframes is cleared inside 
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.h
@@ -31,7 +31,7 @@ namespace embot { namespace app { namespace application {
         };
                 
         bool initialise(const Config &config);   
-        bool tick(const std::vector<embot::prot::can::Frame> &inpframes, std::vector<embot::prot::can::Frame> &outframes);
+        bool tick(std::vector<embot::prot::can::Frame> &inpframes, std::vector<embot::prot::can::Frame> &outframes);
                 
         // interface to CANagentMBD
         virtual bool onrecognisedframe(void *p); 


### PR DESCRIPTION
This PR fixes the case when the `amcbldc` receives bursts of CAN frames. Now the `theMBDagent` object is able to consume the burst one CAN frame every 1 ms w/out losing anyone.

cc @sgiraz 