### PR TITLE
AMC_BLDC: Update the application06 to work with wrist-setup

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -157,6 +157,10 @@
           <Key>ARMDBGFLAGS</Key>
           <Name></Name>
         </SetRegEntry>
+        <SetRegEntry>
+          <Number>0</Number>
+          <Key>DLGUARM</Key>
+        </SetRegEntry>
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <WatchWindow1>
@@ -710,7 +714,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1617,7 +1621,7 @@
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>66</FileNumber>
-      <FileType>8</FileType>
+      <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -1690,7 +1694,7 @@
 
   <Group>
     <GroupName>mbd::can-encoder</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1858,7 +1862,7 @@
 
   <Group>
     <GroupName>mbd::supervisor-rx</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -103,7 +103,7 @@
         <bEvRecOn>1</bEvRecOn>
         <bSchkAxf>0</bSchkAxf>
         <bTchkAxf>0</bTchkAxf>
-        <nTsel>4</nTsel>
+        <nTsel>1</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -114,7 +114,7 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile></tIfile>
-        <pMon>Segger\JL2CM3.dll</pMon>
+        <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
         <SetRegEntry>
@@ -158,7 +158,24 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint/>
+      <Breakpoint>
+        <Bp>
+          <Number>0</Number>
+          <Type>0</Type>
+          <LineNumber>879</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134385606</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\model-based-design\supervisor-rx\SupervisorFSM_RX.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\amcbldc\../src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp\879</Expression>
+        </Bp>
+      </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvoptx
@@ -157,10 +157,6 @@
           <Key>ARMDBGFLAGS</Key>
           <Name></Name>
         </SetRegEntry>
-        <SetRegEntry>
-          <Number>0</Number>
-          <Key>DLGUARM</Key>
-        </SetRegEntry>
       </TargetDriverDllRegistry>
       <Breakpoint/>
       <WatchWindow1>
@@ -1434,7 +1430,7 @@
 
   <Group>
     <GroupName>others</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1621,7 +1617,7 @@
     <File>
       <GroupNumber>16</GroupNumber>
       <FileNumber>66</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -1694,7 +1690,7 @@
 
   <Group>
     <GroupName>mbd::can-encoder</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1862,7 +1858,7 @@
 
   <Group>
     <GroupName>mbd::supervisor-rx</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>1</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -855,7 +855,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>8</FileType>
+              <FileType>1</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
@@ -2043,7 +2043,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>8</FileType>
+              <FileType>1</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
@@ -3231,7 +3231,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>8</FileType>
+              <FileType>1</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/proj/amcbldc-application06.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -313,7 +313,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -855,7 +855,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
@@ -1204,7 +1204,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2043,7 +2043,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>
@@ -2392,7 +2392,7 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.3.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -3231,7 +3231,7 @@
             </File>
             <File>
               <FileName>rtw_enable_disable_motors.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rtw_enable_disable_motors.c</FilePath>
             </File>
             <File>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
@@ -334,17 +334,41 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
         embot::prot::can::Frame frame = inpframes.front();
         // copy it
         frame.copyto(rx_id, rx_size, rx_data);
-        //        embot::core::print(std::string("size = ") + std::to_string(ninputframes) + ", d[0] = " + std::to_string(rx_data[0]) + 
-        //                           ", consumed = " + std::to_string(consumedframes) + " @ " + embot::core::TimeFormatter(embot::core::now()).to_string());     
-
-        if(my_index < 10) 
+        
+        if((rx_data[0] == 0x65) && (rx_id == 0x1))
         {
-            dbg_msg[my_index++] = rx_data[0]; 
+            amc_bldc.AMC_BLDC_U.PacketsRx_available = 0;    // TODO: FIX IN MBD
         }
-        else{
-            my_index = 100;
-            my_index = my_index;
-        }
+        
+//        if(rx_id == 0x10F)
+//        {
+//            static char msg2[64];
+//            static uint32_t counter;
+//            if(counter % 100 == 0)
+//            {
+//                sprintf(msg2, "%x %x", rx_data[1], rx_data[0]);
+//                embot::core::print(msg2);
+//                counter = 0;
+//            }
+//            counter++;
+//        }
+        
+//        static uint32_t cnt = 0;
+//        if((++cnt % 500) == 1)
+//        {
+//            embot::core::print(std::string("size = ") + std::to_string(ninputframes) + ", d[0] = " + std::to_string(rx_data[0]) + 
+//                           ", consumed = " + std::to_string(consumedframes) + " @ " + embot::core::TimeFormatter(embot::core::now()).to_string());
+//        }
+     
+
+//        if(my_index < 10) 
+//        {
+//            dbg_msg[my_index++] = rx_data[0]; 
+//        }
+//        else{
+//            my_index = 100;
+//            my_index = my_index;
+//        }
 
         // clean up the first consumedframes positions
         inpframes.erase(inpframes.begin(), inpframes.begin()+consumedframes);
@@ -456,10 +480,11 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
     
     static char msg2[64];
     static uint32_t counter;
-    if(counter % 10 == 0)
+    if(counter % 1000 == 0)
     {
         //sprintf(msg2, "%d -- %d -- %.3f -- %.3f\n", delta, position, u->SensorsData_motorsensors_angle, y->ControlOutputs_p.Iq_fbk.current);
-        sprintf(msg2, "%d,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f", \
+        sprintf(msg2, "%d %d,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f", \
+                                 impl->amc_bldc.AMC_BLDC_Y.Flags_p.control_mode, \
                                  Vabc0,  \
                                  Vabc1,  \
                                  Vabc2,  \
@@ -494,6 +519,8 @@ uint8_t remapControlMode(uint8_t controlMode)
         case 4: 
             return MCControlModes_Current;
             break;
+        case 6:
+            return MCControlModes_OpenLoop;
         default: 
             return 0x99; // TODO: Fix!
             break;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
@@ -501,6 +501,9 @@ uint8_t remapControlMode(uint8_t controlMode)
             break;
         case 6:
             return MCControlModes_OpenLoop;
+        case ControlModes_HwFaultCM:
+            return 0xa0;
+            break;
         default: 
             return 0x99; // TODO: Fix!
             break;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
@@ -142,8 +142,6 @@ constexpr bool useDUMMYforTICK {true};
 
 struct embot::app::application::theMBDagent::Impl
 {
-    uint8_t dbg_msg[10] {0xFF};
-    volatile int my_index = 0;
     Impl() = default;  
         
     // the initialization code
@@ -359,17 +357,7 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
 //            embot::core::print(std::string("size = ") + std::to_string(ninputframes) + ", d[0] = " + std::to_string(rx_data[0]) + 
 //                           ", consumed = " + std::to_string(consumedframes) + " @ " + embot::core::TimeFormatter(embot::core::now()).to_string());
 //        }
-     
-
-//        if(my_index < 10) 
-//        {
-//            dbg_msg[my_index++] = rx_data[0]; 
-//        }
-//        else{
-//            my_index = 100;
-//            my_index = my_index;
-//        }
-
+        
         // clean up the first consumedframes positions
         inpframes.erase(inpframes.begin(), inpframes.begin()+consumedframes);
     }
@@ -482,7 +470,6 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
     static uint32_t counter;
     if(counter % 1000 == 0)
     {
-        //sprintf(msg2, "%d -- %d -- %.3f -- %.3f\n", delta, position, u->SensorsData_motorsensors_angle, y->ControlOutputs_p.Iq_fbk.current);
         sprintf(msg2, "%d %d,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f", \
                                  impl->amc_bldc.AMC_BLDC_Y.Flags_p.control_mode, \
                                  Vabc0,  \
@@ -494,8 +481,6 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
                                  impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_angle,    \
                                  impl->amc_bldc.AMC_BLDC_B.Targets_n.motorcurrent.current,    \
                                  impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Iq_fbk.current);
-        
-        //sprintf(msg2, "%d,%d,%.3f,%.3f,%.3f", delta, position, y->EstimatedData_p.jointvelocities.velocity, u->SensorsData_motorsensors_angle, y->ControlOutputs_p.Iq_fbk.current);
         embot::core::print(msg2);
         counter = 0;
     }
@@ -545,26 +530,6 @@ bool embot::app::application::theMBDagent::Impl::addMCstatus(std::vector<embot::
     embot::prot::can::Frame frame0;
     msg.get(frame0);
     outframes.push_back(frame0);
-    
-//    static uint32_t counter;
-//    if(counter % 10 == 0)
-//    {        
-//        static char msg2[64];
-//        static uint32_t counter;
-//        sprintf(msg2, "%d,%d,%d,%d,%d,%d,%d,%d,%d", \
-//                                frame0.id,  \
-//                                frame0.data[0],  \
-//                                frame0.data[1],  \
-//                                frame0.data[2],   \
-//                                frame0.data[3],   \
-//                                frame0.data[4],   \
-//                                frame0.data[5],   \
-//                                frame0.data[6],   \
-//                                frame0.data[7]);
-//        embot::core::print(msg2);
-//        counter = 0;
-//    }
-//    counter++;
     
     return true;
 }

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/embot_app_application_theMBDagent.cpp
@@ -333,11 +333,6 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
         // copy it
         frame.copyto(rx_id, rx_size, rx_data);
         
-        if((rx_data[0] == 0x65) && (rx_id == 0x1))
-        {
-            amc_bldc.AMC_BLDC_U.PacketsRx_available = 0;    // TODO: FIX IN MBD
-        }
-        
 //        if(rx_id == 0x10F)
 //        {
 //            static char msg2[64];

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.203
+// Model version                  : 3.204
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -415,12 +415,13 @@ namespace amc_bldc_codegen
     // ModelReference: '<S7>/SupervisorFSM_RX' incorporates:
     //   Outport: '<Root>/ConfigurationParameters'
     //   Outport: '<Root>/EstimatedData'
+    //   Outport: '<Root>/Flags'
 
     SupervisorFSM_RXMDLOBJ7.step(AMC_BLDC_B.CAN_Decoder_o2,
       AMC_BLDC_B.CAN_Decoder_o1, AMC_BLDC_B.CAN_Decoder_o3,
       AMC_BLDC_Y.EstimatedData_p, AMC_BLDC_B.BusConversion_InsertedFor_Super,
       AMC_BLDC_B.RTBInsertedForAdapter_InsertedF, AMC_BLDC_B.Targets_n,
-      AMC_BLDC_Y.ConfigurationParameters_p, AMC_BLDC_B.Flags_k,
+      AMC_BLDC_Y.ConfigurationParameters_p, AMC_BLDC_Y.Flags_p,
       &AMC_BLDC_B.BusConversion_InsertedFor_Sup_j);
 
     // BusCreator generated from: '<S7>/SupervisorFSM_TX'
@@ -463,8 +464,9 @@ namespace amc_bldc_codegen
     // ModelReference: '<Root>/OuterControl' incorporates:
     //   Outport: '<Root>/ConfigurationParameters'
     //   Outport: '<Root>/EstimatedData'
+    //   Outport: '<Root>/Flags'
 
-    OuterControlMDLOBJ6.step(AMC_BLDC_B.Flags_k,
+    OuterControlMDLOBJ6.step(AMC_BLDC_Y.Flags_p,
       AMC_BLDC_Y.ConfigurationParameters_p, AMC_BLDC_B.Targets_n,
       rtb_BusConversion_InsertedFor_O, AMC_BLDC_Y.EstimatedData_p,
       rtb_OuterControl);
@@ -488,7 +490,9 @@ namespace amc_bldc_codegen
     AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[wrBufIdx] = rtb_OuterControl;
     AMC_BLDC_DW.RTBInsertedForAdapter_Insert_p5 = wrBufIdx;
 
-    // RateTransition generated from: '<Root>/Adapter2'
+    // RateTransition generated from: '<Root>/Adapter2' incorporates:
+    //   Outport: '<Root>/Flags'
+
     rtw_mutex_lock();
     wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_hj +
       1);
@@ -504,7 +508,7 @@ namespace amc_bldc_codegen
     }
 
     rtw_mutex_unlock();
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_l[wrBufIdx] = AMC_BLDC_B.Flags_k;
+    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_l[wrBufIdx] = AMC_BLDC_Y.Flags_p;
     AMC_BLDC_DW.RTBInsertedForAdapter_Insert_hj = wrBufIdx;
 
     // RateTransition generated from: '<Root>/Adapter2' incorporates:
@@ -667,8 +671,9 @@ namespace amc_bldc_codegen
 
     // SystemInitialize for ModelReference: '<S7>/SupervisorFSM_RX' incorporates:
     //   Outport: '<Root>/ConfigurationParameters'
+    //   Outport: '<Root>/Flags'
 
-    SupervisorFSM_RXMDLOBJ7.init(&AMC_BLDC_B.Flags_k, &AMC_BLDC_B.Targets_n,
+    SupervisorFSM_RXMDLOBJ7.init(&AMC_BLDC_Y.Flags_p, &AMC_BLDC_B.Targets_n,
       &AMC_BLDC_Y.ConfigurationParameters_p);
 
     // SystemInitialize for ModelReference: '<S7>/SupervisorFSM_TX'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.203
+// Model version                  : 3.204
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -90,7 +90,6 @@ namespace amc_bldc_codegen
       Targets Targets_n;               // '<S7>/SupervisorFSM_RX'
       ControlOutputs RTBInsertedForAdapter_InsertedF;// '<Root>/Adapter1'
       BUS_MESSAGES_TX MessagesTx;      // '<S7>/SupervisorFSM_TX'
-      Flags Flags_k;                   // '<S7>/SupervisorFSM_RX'
       ExternalFlags BusConversion_InsertedFor_Sup_j;
       BUS_EVENTS_TX SupervisorFSM_TX_o2;// '<S7>/SupervisorFSM_TX'
       BUS_EVENTS_RX CAN_Decoder_o2;    // '<S6>/CAN_Decoder'
@@ -154,6 +153,7 @@ namespace amc_bldc_codegen
     struct ExtY_AMC_BLDC_T {
       ControlOutputs ControlOutputs_p; // '<Root>/ControlOutputs'
       ConfigurationParameters ConfigurationParameters_p;// '<Root>/ConfigurationParameters' 
+      Flags Flags_p;                   // '<Root>/Flags'
       EstimatedData EstimatedData_p;   // '<Root>/EstimatedData'
       BUS_CAN PacketsTx;               // '<Root>/PacketsTx'
     };

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.203
+// Model version                  : 3.204
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 3.203
+// Model version                  : 3.204
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:26:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -85,6 +85,7 @@ struct Flags
 {
   // control mode
   ControlModes control_mode;
+  boolean_T DBG;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.85
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:10 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -35,6 +35,31 @@ typedef enum {
   ControlModes_Torque,
   ControlModes_HwFaultCM
 } ControlModes;
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
+#define DEFINED_TYPEDEF_FOR_MotorCurrent_
+
+struct MotorCurrent
+{
+  // motor current
+  real32_T current;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_ControlOutputs_
+#define DEFINED_TYPEDEF_FOR_ControlOutputs_
+
+struct ControlOutputs
+{
+  // control effort
+  real32_T Vabc[3];
+
+  // quadrature current
+  MotorCurrent Iq_fbk;
+};
 
 #endif
 
@@ -85,6 +110,7 @@ struct Flags
 {
   // control mode
   ControlModes control_mode;
+  boolean_T DBG;
 };
 
 #endif
@@ -241,17 +267,6 @@ struct EstimatedData
 
 #endif
 
-#ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
-#define DEFINED_TYPEDEF_FOR_MotorCurrent_
-
-struct MotorCurrent
-{
-  // motor current
-  real32_T current;
-};
-
-#endif
-
 #ifndef DEFINED_TYPEDEF_FOR_MotorVoltage_
 #define DEFINED_TYPEDEF_FOR_MotorVoltage_
 
@@ -299,20 +314,6 @@ struct FOCSlowInputs
   EstimatedData estimateddata;
   Targets targets;
   ControlOuterOutputs controlouteroutputs;
-};
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_ControlOutputs_
-#define DEFINED_TYPEDEF_FOR_ControlOutputs_
-
-struct ControlOutputs
-{
-  // control effort
-  real32_T Vabc[3];
-
-  // quadrature current
-  MotorCurrent Iq_fbk;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.35
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Jan 13 14:10:17 2022
+// C/C++ source code generated on : Fri Jan 14 20:51:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -45,6 +45,7 @@ struct Flags
 {
   // control mode
   ControlModes control_mode;
+  boolean_T DBG;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -184,12 +184,6 @@ namespace amc_bldc_codegen
         SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
           SupervisorFSM_RX_IN_Current;
         arg_Flags->control_mode = ControlModes_Current;
-          
-                    static char msg[64];
-          static uint32_t counter;
-            sprintf(msg, "[SupervisorFSM_RX_Current]: %d", arg_Flags->control_mode);
-          embot::core::print(msg);
-          
       }
     }
   }
@@ -343,14 +337,7 @@ namespace amc_bldc_codegen
 
           // Chart: '<Root>/SupervisorFSM_RX'
           arg_Flags->control_mode = ControlModes_Current;
-            
-          static char msg[64];
-          static uint32_t counter;
-            sprintf(msg, "[SupervisorFSM_RX_IN_Position]: %d", arg_Flags->control_mode);
-          embot::core::print(msg);
-            
-            
-            
+
         } else if (SupervisorFSM_IsNewCtrl_Voltage(arg_MessagesRx)) {
           // Chart: '<Root>/SupervisorFSM_RX'
           arg_Targets->motorvoltage.voltage =
@@ -403,11 +390,6 @@ namespace amc_bldc_codegen
 
             // Chart: '<Root>/SupervisorFSM_RX'
             arg_Flags->control_mode = ControlModes_Current;
-              
-                        static char msg[64];
-          static uint32_t counter;
-            sprintf(msg, "[SupervisorFSM_RX_IN_Velocity]: %d", arg_Flags->control_mode);
-          embot::core::print(msg);
               
           } else if (SupervisorFS_IsNewCtrl_Position(arg_MessagesRx)) {
             SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
@@ -463,14 +445,7 @@ namespace amc_bldc_codegen
               SupervisorFSM_RX_IN_Current;
 
             // Chart: '<Root>/SupervisorFSM_RX'
-            arg_Flags->control_mode = ControlModes_Current;
-              
-              
-                                     static char msg[64];
-          static uint32_t counter;
-            sprintf(msg, "[SupervisorFSM_RX_IN_Voltage]: %d", arg_Flags->control_mode);
-          embot::core::print(msg); 
-              
+            arg_Flags->control_mode = ControlModes_Current; 
               
           } else if (SupervisorFS_IsNewCtrl_Position(arg_MessagesRx)) {
             SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.144
+// Model version                  : 3.145
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
+// C/C++ source code generated on : Fri Jan 14 20:50:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,7 @@
 #include "SupervisorFSM_RX_private.h"
 #include "uMultiWord2Double.h"
 #include "uMultiWordShl.h"
+                        #include "embot_core.h"
 
 // Named constants for Chart: '<Root>/SupervisorFSM_RX'
 const int32_T Supe_event_OutOfBoardFaultEvent = 2;
@@ -183,6 +184,12 @@ namespace amc_bldc_codegen
         SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
           SupervisorFSM_RX_IN_Current;
         arg_Flags->control_mode = ControlModes_Current;
+          
+                    static char msg[64];
+          static uint32_t counter;
+            sprintf(msg, "[SupervisorFSM_RX_Current]: %d", arg_Flags->control_mode);
+          embot::core::print(msg);
+          
       }
     }
   }
@@ -196,7 +203,7 @@ namespace amc_bldc_codegen
   // Function for Chart: '<Root>/SupervisorFSM_RX'
   boolean_T SupervisorFSM_RX::SupervisorFS_isConfigurationSet(void) const
   {
-    return SupervisorFSM_RX_DW.IsCurrentLimitSet;
+    return true; //SupervisorFSM_RX_DW.IsCurrentLimitSet;
   }
 
   // Function for Chart: '<Root>/SupervisorFSM_RX'
@@ -336,6 +343,14 @@ namespace amc_bldc_codegen
 
           // Chart: '<Root>/SupervisorFSM_RX'
           arg_Flags->control_mode = ControlModes_Current;
+            
+          static char msg[64];
+          static uint32_t counter;
+            sprintf(msg, "[SupervisorFSM_RX_IN_Position]: %d", arg_Flags->control_mode);
+          embot::core::print(msg);
+            
+            
+            
         } else if (SupervisorFSM_IsNewCtrl_Voltage(arg_MessagesRx)) {
           // Chart: '<Root>/SupervisorFSM_RX'
           arg_Targets->motorvoltage.voltage =
@@ -388,6 +403,12 @@ namespace amc_bldc_codegen
 
             // Chart: '<Root>/SupervisorFSM_RX'
             arg_Flags->control_mode = ControlModes_Current;
+              
+                        static char msg[64];
+          static uint32_t counter;
+            sprintf(msg, "[SupervisorFSM_RX_IN_Velocity]: %d", arg_Flags->control_mode);
+          embot::core::print(msg);
+              
           } else if (SupervisorFS_IsNewCtrl_Position(arg_MessagesRx)) {
             SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
               SupervisorFSM_RX_IN_Position;
@@ -443,6 +464,14 @@ namespace amc_bldc_codegen
 
             // Chart: '<Root>/SupervisorFSM_RX'
             arg_Flags->control_mode = ControlModes_Current;
+              
+              
+                                     static char msg[64];
+          static uint32_t counter;
+            sprintf(msg, "[SupervisorFSM_RX_IN_Voltage]: %d", arg_Flags->control_mode);
+          embot::core::print(msg); 
+              
+              
           } else if (SupervisorFS_IsNewCtrl_Position(arg_MessagesRx)) {
             SupervisorFSM_RX_DW.is_CONTROL_MODE_HANDLER =
               SupervisorFSM_RX_IN_Position;
@@ -536,6 +565,7 @@ namespace amc_bldc_codegen
     // SystemInitialize for Chart: '<Root>/SupervisorFSM_RX'
     SupervisorFSM_RX_DW.sfEvent = SupervisorFSM_RX_CALL_EVENT;
     arg_Flags->control_mode = ControlModes_NotConfigured;
+    arg_Flags->DBG = false;
     arg_Targets->jointpositions.position = 0.0F;
     arg_Targets->jointvelocities.velocity = 0.0F;
     arg_Targets->motorcurrent.current = 0.0F;
@@ -699,6 +729,7 @@ namespace amc_bldc_codegen
               SupervisorFSM_RX_DW.EventsRx_desired_current_start) {
             arg_Targets.motorcurrent.current =
               arg_MessagesRx.desired_current.current;
+            arg_Flags.DBG = true;
             SupervisorFSM_RX_DW.is_EVENT_DISPATCHER = SupervisorFSM_RX_IN_Home;
           } else if (SupervisorFSM_RX_DW.EventsRx_control_mode_prev !=
                      SupervisorFSM_RX_DW.EventsRx_control_mode_start) {

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -203,7 +203,7 @@ namespace amc_bldc_codegen
   // Function for Chart: '<Root>/SupervisorFSM_RX'
   boolean_T SupervisorFSM_RX::SupervisorFS_isConfigurationSet(void) const
   {
-    return true; //SupervisorFSM_RX_DW.IsCurrentLimitSet;
+    return SupervisorFSM_RX_DW.IsCurrentLimitSet;
   }
 
   // Function for Chart: '<Root>/SupervisorFSM_RX'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.144
+// Model version                  : 3.145
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
+// C/C++ source code generated on : Fri Jan 14 20:50:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.144
+// Model version                  : 3.145
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
+// C/C++ source code generated on : Fri Jan 14 20:50:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application06/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 3.144
+// Model version                  : 3.145
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Jan 14 15:25:19 2022
+// C/C++ source code generated on : Fri Jan 14 20:50:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -293,6 +293,7 @@ struct Flags
 {
   // control mode
   ControlModes control_mode;
+  boolean_T DBG;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -316,12 +316,6 @@ void Motor_config(Motor* o, uint8_t ID, eOmc_motor_config_t* config) //
     o->pos_min = config->limitsofrotor.min;
     o->pos_max = config->limitsofrotor.max;
 
-    // TODO: Fix
-    #ifdef DEBUG_workaround_amcbldc
-    o->pos_min = 0;
-    o->pos_max = 0;
-    #endif
-
     o->vel_max = config->maxvelocityofmotor;
     
     o->Iqq_max = config->pidcurrent.limitonoutput;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -310,8 +310,9 @@ void Motor_config(Motor* o, uint8_t ID, eOmc_motor_config_t* config) //
     
     o->temperature_max = config->temperatureLimit;
 
-    o->pos_min = config->limitsofrotor.min;
-    o->pos_max = config->limitsofrotor.max;    
+    // TODO: Fix
+    o->pos_min = 0; //config->limitsofrotor.min;
+    o->pos_max = 0; //config->limitsofrotor.max;    
     o->vel_max = config->maxvelocityofmotor;
     
     o->Iqq_max = config->pidcurrent.limitonoutput;
@@ -1153,21 +1154,20 @@ void Motor_set_pwm_ref(Motor* o, int32_t pwm_ref)
         //o->outOfLimitsSignaled = FALSE;
     }
 }
-#include <hal_trace.h>
 
 void Motor_set_Iqq_ref(Motor* o, int32_t Iqq_ref)
-{
+{   
     if (o->pos_min != o->pos_max)
     {        
-//        if ((o->pos_raw_cal_fbk < o->pos_min) && (Iqq_ref < 0))           // CHIEDERE A VALE GAGGE
-//        {
-//            o->output = o->Iqq_ref = 0;
-//        }
-//        else if ((o->pos_raw_cal_fbk > o->pos_max) && (Iqq_ref > 0))
-//        {
-//            o->output = o->Iqq_ref = 0;
-//        }
-//        else
+        if ((o->pos_raw_cal_fbk < o->pos_min) && (Iqq_ref < 0))
+        {
+            o->output = o->Iqq_ref = 0;
+        }
+        else if ((o->pos_raw_cal_fbk > o->pos_max) && (Iqq_ref > 0))
+        {
+            o->output = o->Iqq_ref = 0;
+        }
+        else
         {
             o->output = o->Iqq_ref = CUT(Iqq_ref, o->Iqq_max);
         }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -1005,6 +1005,13 @@ void Motor_actuate(Motor* motor, uint8_t N) //
 {
     if (motor->HARDWARE_TYPE == HARDWARE_2FOC)
     {
+        // To be sure that amc_bldc/2foc can process all sent messages, we are sending 1 setpoint every 2ms
+        static uint8_t cnt = 0;
+        if((++cnt % 2) == 1)
+        {
+            return;
+        }
+        
         int16_t output[MAX_JOINTS_PER_BOARD] = {0};
     
         for (int m=0; m<N; ++m)
@@ -1146,20 +1153,21 @@ void Motor_set_pwm_ref(Motor* o, int32_t pwm_ref)
         //o->outOfLimitsSignaled = FALSE;
     }
 }
+#include <hal_trace.h>
 
 void Motor_set_Iqq_ref(Motor* o, int32_t Iqq_ref)
 {
     if (o->pos_min != o->pos_max)
     {        
-        if ((o->pos_raw_cal_fbk < o->pos_min) && (Iqq_ref < 0))
-        {
-            o->output = o->Iqq_ref = 0;
-        }
-        else if ((o->pos_raw_cal_fbk > o->pos_max) && (Iqq_ref > 0))
-        {
-            o->output = o->Iqq_ref = 0;
-        }
-        else
+//        if ((o->pos_raw_cal_fbk < o->pos_min) && (Iqq_ref < 0))           // CHIEDERE A VALE GAGGE
+//        {
+//            o->output = o->Iqq_ref = 0;
+//        }
+//        else if ((o->pos_raw_cal_fbk > o->pos_max) && (Iqq_ref > 0))
+//        {
+//            o->output = o->Iqq_ref = 0;
+//        }
+//        else
         {
             o->output = o->Iqq_ref = CUT(Iqq_ref, o->Iqq_max);
         }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -293,6 +293,9 @@ void Motor_init(Motor* o) //
     //o->outOfLimitsSignaled = FALSE;
 }
 
+// TODO: Fix
+//#define DEBUG_workaround_amcbldc
+
 void Motor_config(Motor* o, uint8_t ID, eOmc_motor_config_t* config) //
 {
     // const init
@@ -310,9 +313,15 @@ void Motor_config(Motor* o, uint8_t ID, eOmc_motor_config_t* config) //
     
     o->temperature_max = config->temperatureLimit;
 
+    o->pos_min = config->limitsofrotor.min;
+    o->pos_max = config->limitsofrotor.max;
+
     // TODO: Fix
-    o->pos_min = 0; //config->limitsofrotor.min;
-    o->pos_max = 0; //config->limitsofrotor.max;    
+    #ifdef DEBUG_workaround_amcbldc
+    o->pos_min = 0;
+    o->pos_max = 0;
+    #endif
+
     o->vel_max = config->maxvelocityofmotor;
     
     o->Iqq_max = config->pidcurrent.limitonoutput;
@@ -1006,12 +1015,15 @@ void Motor_actuate(Motor* motor, uint8_t N) //
 {
     if (motor->HARDWARE_TYPE == HARDWARE_2FOC)
     {
+        // TODO: Fix. Temporary workaround!
+        #ifdef DEBUG_workaround_amcbldc
         // To be sure that amc_bldc/2foc can process all sent messages, we are sending 1 setpoint every 2ms
         static uint8_t cnt = 0;
         if((++cnt % 2) == 1)
         {
             return;
         }
+        #endif
         
         int16_t output[MAX_JOINTS_PER_BOARD] = {0};
     


### PR DESCRIPTION
What's change in this PR:
- In [Motor.c](https://github.com/robotology/icub-firmware/blob/6bfcbffc0203d0a6e2b75dedc9df299074f1da09/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c#L1154-L1162) the check on rotor's position is commented in order to work with `wrist-setup`
- The SET_CURRENT_PID message actually is not processed in order to not override the embedded gains implemented within the `MBD`

**Notes:**
- ⚠️ Now the EMS will send 1 target setpoint every 2ms instead of every 1ms. This workaround allows the AMC_BLDC to consume all its incoming packages. This is a temporary workaround until the multipackage manager will be implemented inside the `mbd`.
- This PR has been tested on wrist setup.
