### PR TITLE
Full support of SPI in amc board + driver for AS5045 chip

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc.cpp
@@ -45,59 +45,16 @@ using namespace embot::core::binary;
 // - specialize the bsp
 // --------------------------------------------------------------------------------------------------------------------
 
-#if defined(EMBOT_ENABLE_hw_spi_123)    
+#if defined(EMBOT_ENABLE_hw_spi_123_atstartup)    
 #include "embot_hw_gpio.h"
-// it select spi1 / spi2 / spi3 in connector J5
+// it selects spi1 / spi2 / spi3 in connector J5
 void prepare_connector_j5_spi123()
 {
-    constexpr embot::hw::gpio::Config out 
-    {
-        embot::hw::gpio::Mode::OUTPUTpushpull, 
-        embot::hw::gpio::Pull::nopull,
-        embot::hw::gpio::Speed::medium
-    };
-    
-    constexpr embot::hw::gpio::State stateSPI[2] = {embot::hw::gpio::State::RESET, embot::hw::gpio::State::SET};
-    
-    constexpr embot::hw::GPIO X1ENspi1[2] = 
-    {
-        {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::zero},
-        {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::eight}
-    };
-
-    constexpr embot::hw::GPIO X2ENspi2[2] = 
-    {
-        {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::one},
-        {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::nine}
-    };    
-    
-    constexpr embot::hw::GPIO X3ENspi3[2] = 
-    {
-        {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::two},
-        {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::ten}
-    };     
-       
-    // spi1
-    for(uint8_t i=0; i<2; i++)
-    {
-        embot::hw::gpio::init(X1ENspi1[i], out);
-        embot::hw::gpio::set(X1ENspi1[i], stateSPI[i]);
-    }  
-    
-    // spi2
-    for(uint8_t i=0; i<2; i++)
-    {
-        embot::hw::gpio::init(X2ENspi2[i], out);
-        embot::hw::gpio::set(X2ENspi2[i], stateSPI[i]);
-    }  
-    
-    // spi3
-    for(uint8_t i=0; i<2; i++)
-    {
-        embot::hw::gpio::init(X3ENspi3[i], out);
-        embot::hw::gpio::set(X3ENspi3[i], stateSPI[i]);
-    }  
-    
+    // ok, i know it does not compile... because:
+    // todo: if we define EMBOT_ENABLE_hw_spi_123_atstartup then we must not call s_J5_SPIpinout() in runtime
+    s_J5_SPIpinout(embot::hw::SPI::one, true);
+    s_J5_SPIpinout(embot::hw::SPI::two, true);
+    s_J5_SPIpinout(embot::hw::SPI::three, true);
 }
 #endif
 
@@ -111,8 +68,7 @@ bool embot::hw::bsp::specialize() { return true; }
     bool embot::hw::bsp::specialize()
     {
 
-#if defined(EMBOT_ENABLE_hw_spi_123)        
-        // 1. prepare spi1, spi2, spi3
+#if defined(EMBOT_ENABLE_hw_spi_123_atstartup)        
         prepare_connector_j5_spi123();
 #endif        
         return true;
@@ -735,12 +691,15 @@ namespace embot { namespace hw { namespace spi { namespace bsp {
     
     #if defined(STM32HAL_BOARD_AMC)
     
-//    SPI_HandleTypeDef hspi1;
-//    SPI_HandleTypeDef hspi2;
-//    SPI_HandleTypeDef hspi3;
+    SPI_Device* getDEVICE(embot::hw::SPI h)
+    {
+        static SPI_Device * spiDEVICE[6] = {SPI1, SPI2, SPI3, SPI4, SPI5, SPI6};
+        return embot::hw::spi::supported(h) ? spiDEVICE[embot::core::tointegral(h)] : nullptr;        
+    }
+    
     
     SPI_HandleTypeDef hspi1;
-    constexpr std::array<embot::hw::GPIO, NumberOfSignals> pinoutspi1 = { {
+    constexpr std::array<embot::hw::GPIO, SignalsNumberOf> pinoutspi1 = { {
         {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::nine},     // miso
         {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::seven},    // mosi
         {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::eleven},   // sckl
@@ -748,12 +707,30 @@ namespace embot { namespace hw { namespace spi { namespace bsp {
     } };
     constexpr PROP spi1p = { &hspi1, 50*1000*1000, pinoutspi1 }; 
     
-//    constexpr PROP spi2p = { &hspi2, 50*1000*1000, { {{}, {}, {}} } };
-//    constexpr PROP spi3p = { &hspi3, 50*1000*1000, { {{}, {}, {}} } };
-//    constexpr PROP spi4p = { &hspi4, 100*1000*1000};
+    
+    SPI_HandleTypeDef hspi2;
+    constexpr std::array<embot::hw::GPIO, SignalsNumberOf> pinoutspi2 = { {
+        {embot::hw::GPIO::PORT::B, embot::hw::GPIO::PIN::fourteen}, // miso
+        {embot::hw::GPIO::PORT::B, embot::hw::GPIO::PIN::fifteen},  // mosi
+        {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::three},    // sckl
+        {embot::hw::GPIO::PORT::B, embot::hw::GPIO::PIN::nine}      // ssel
+    } };
+    constexpr PROP spi2p = { &hspi2, 50*1000*1000, pinoutspi2 };     
+    
+    SPI_HandleTypeDef hspi3;
+    constexpr std::array<embot::hw::GPIO, SignalsNumberOf> pinoutspi3 = { {
+        {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::eleven},   // miso
+        {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::six},      // mosi
+        {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::ten},      // sckl
+        {embot::hw::GPIO::PORT::A, embot::hw::GPIO::PIN::four}      // ssel
+    } };
+    constexpr PROP spi3p = { &hspi3, 50*1000*1000, pinoutspi3 };       
+    
 
-    constexpr PROP spi5p = { &hspi5, 100*1000*1000, { {{}, {}, {}} } };   
-    constexpr std::array<embot::hw::GPIO, NumberOfSignals> pinoutspi6 = { {
+    constexpr std::array<embot::hw::GPIO, SignalsNumberOf> pinoutspi5 = { { {}, {}, {}, {} } };
+    constexpr PROP spi5p = { &hspi5, 100*1000*1000, pinoutspi5 };   
+    
+    constexpr std::array<embot::hw::GPIO, SignalsNumberOf> pinoutspi6 = { {
         {embot::hw::GPIO::PORT::B, embot::hw::GPIO::PIN::four},     // miso
         {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::fourteen}, // mosi
         {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::thirteen}, // sckl
@@ -766,16 +743,16 @@ namespace embot { namespace hw { namespace spi { namespace bsp {
     
     constexpr BSP thebsp {        
         // maskofsupported
-        mask::pos2mask<uint32_t>(SPI::one) |
+        mask::pos2mask<uint32_t>(SPI::one) | mask::pos2mask<uint32_t>(SPI::two) | mask::pos2mask<uint32_t>(SPI::three) |
         mask::pos2mask<uint32_t>(SPI::five) | mask::pos2mask<uint32_t>(SPI::six),        
         // properties
         {{
-            &spi1p, nullptr, nullptr, nullptr, &spi5p, &spi6p            
+            &spi1p, &spi2p, &spi3p, nullptr, &spi5p, &spi6p            
         }}        
     };
  
  
-    void s_J5configure(embot::hw::SPI h, bool enable)
+    void s_J5_SPIpinout(embot::hw::SPI h, bool enable)
     {
         static constexpr embot::hw::gpio::Config out { embot::hw::gpio::Mode::OUTPUTpushpull, embot::hw::gpio::Pull::nopull, embot::hw::gpio::Speed::medium };    
         static constexpr embot::hw::gpio::State stateSPI[2] = {embot::hw::gpio::State::RESET, embot::hw::gpio::State::SET};
@@ -808,119 +785,130 @@ namespace embot { namespace hw { namespace spi { namespace bsp {
                 embot::hw::gpio::set(X1ENspi[x][i], enable ? stateSPI[i] : stateNONE[i]);
             }  
         }
+    }  
 
-    }        
-    
+    // we need this extconfig because we wamt to pass information to HAL_SPI_MspInit() and HAL_SPI_MspDeInit()
     utils::ExtendedConfig extconfig {};
+        
+    void s_SPIinit(embot::hw::SPI h, const Config &config)
+    {
+        embot::hw::spi::bsp::SPI_Handle * hspi = embot::hw::spi::bsp::getBSP().getPROP(h)->handle;
+        
+        // prepare and then call HAL_SPI_Init()
+        hspi->Instance = getDEVICE(h);
+        hspi->Init.Mode = SPI_MODE_MASTER;
+        hspi->Init.Direction = SPI_DIRECTION_2LINES;
+        hspi->Init.DataSize = embot::hw::spi::bsp::utils::stm32::todatasize(config.datasize);;
+        hspi->Init.CLKPolarity = embot::hw::spi::bsp::utils::stm32::toCLKpolarity(config.mode);
+        hspi->Init.CLKPhase = embot::hw::spi::bsp::utils::stm32::toCLKphase(config.mode);
+        hspi->Init.NSS = SPI_NSS_SOFT;
+        hspi->Init.BaudRatePrescaler = embot::hw::spi::bsp::utils::stm32::tobaudrateprescaler(config.prescaler);
+        hspi->Init.FirstBit = SPI_FIRSTBIT_MSB;
+        hspi->Init.TIMode = SPI_TIMODE_DISABLE;
+        hspi->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+        hspi->Init.CRCPolynomial = 0x0;
+        hspi->Init.NSSPMode = SPI_NSS_PULSE_ENABLE;
+        hspi->Init.NSSPolarity = SPI_NSS_POLARITY_LOW;
+        hspi->Init.FifoThreshold = SPI_FIFO_THRESHOLD_01DATA;
+        hspi->Init.TxCRCInitializationPattern = SPI_CRC_INITIALIZATION_ALL_ZERO_PATTERN;
+        hspi->Init.RxCRCInitializationPattern = SPI_CRC_INITIALIZATION_ALL_ZERO_PATTERN;
+        hspi->Init.MasterSSIdleness = SPI_MASTER_SS_IDLENESS_00CYCLE;
+        hspi->Init.MasterInterDataIdleness = SPI_MASTER_INTERDATA_IDLENESS_00CYCLE;
+        hspi->Init.MasterReceiverAutoSusp = SPI_MASTER_RX_AUTOSUSP_DISABLE;
+        hspi->Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_DISABLE;
+        hspi->Init.IOSwap = SPI_IO_SWAP_DISABLE;
+        
+        // load config and pinout into extconfig so that whatever HAL_SPI_Init() calls can use it
+        extconfig.load(h, config);
+        HAL_SPI_Init(hspi);         
+        // clear extconfig
+        extconfig.clear();
+    }  
+    
+
+    void s_SPIdeinit(embot::hw::SPI h)
+    {
+        embot::hw::spi::bsp::SPI_Handle * hspi = embot::hw::spi::bsp::getBSP().getPROP(h)->handle;    
+        
+        // load pinout into extconfig so that whatever HAL_SPI_DeInit() calls can use it
+        extconfig.load(h, {});
+        HAL_SPI_DeInit(hspi); 
+        // clear extconfig
+        extconfig.clear();            
+    }      
+    
     
     bool BSP::init(embot::hw::SPI h, const Config &config) const
-    {
-        extconfig.load(h, config);
-        
-        // marco.accame: in here ... MX_SPI6_Ini() calls HAL_SPI_Init() and imposes the speed 
-        // and the low level configuration specified inside cube-mx. 
-        // it is quick and easy BUT: if we want to attach to the same bus more than one type 
-        // of spi sensors (e.g., aea, aea3, AksIM-2, ...) then we must be able to call HAL_SPI_Init()
-        // with the parameters we want.
-        // conclusion: we shall move HAL_SPI_Init() out of BSP::init() and inside embot::hw::spi::init()
-        if(h == SPI::one)
+    {        
+        switch(h)
         {
-            // enable the port x1
-            s_J5configure(h, true);
+            case SPI::one:
+            case SPI::two:
+            case SPI::three:
+            {
+                // we are on J5: enable the port x1
+                s_J5_SPIpinout(h, true); 
+                // and call SPI init              
+                s_SPIinit(h, config);                
+            } break;
             
-            // call HAL_SPI_Init()
-            hspi1.Instance = SPI1;
-            hspi1.Init.Mode = SPI_MODE_MASTER;
-            hspi1.Init.Direction = SPI_DIRECTION_2LINES;
-            hspi1.Init.DataSize = embot::hw::spi::bsp::utils::stm32::todatasize(config.datasize);;
-            hspi1.Init.CLKPolarity = embot::hw::spi::bsp::utils::stm32::toCLKpolarity(config.mode);
-            hspi1.Init.CLKPhase = embot::hw::spi::bsp::utils::stm32::toCLKphase(config.mode);
-            hspi1.Init.NSS = SPI_NSS_SOFT;
-            hspi1.Init.BaudRatePrescaler = embot::hw::spi::bsp::utils::stm32::tobaudrateprescaler(config.prescaler);
-            hspi1.Init.FirstBit = SPI_FIRSTBIT_MSB;
-            hspi1.Init.TIMode = SPI_TIMODE_DISABLE;
-            hspi1.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
-            hspi1.Init.CRCPolynomial = 0x0;
-            hspi1.Init.NSSPMode = SPI_NSS_PULSE_ENABLE;
-            hspi1.Init.NSSPolarity = SPI_NSS_POLARITY_LOW;
-            hspi1.Init.FifoThreshold = SPI_FIFO_THRESHOLD_01DATA;
-            hspi1.Init.TxCRCInitializationPattern = SPI_CRC_INITIALIZATION_ALL_ZERO_PATTERN;
-            hspi1.Init.RxCRCInitializationPattern = SPI_CRC_INITIALIZATION_ALL_ZERO_PATTERN;
-            hspi1.Init.MasterSSIdleness = SPI_MASTER_SS_IDLENESS_00CYCLE;
-            hspi1.Init.MasterInterDataIdleness = SPI_MASTER_INTERDATA_IDLENESS_00CYCLE;
-            hspi1.Init.MasterReceiverAutoSusp = SPI_MASTER_RX_AUTOSUSP_DISABLE;
-            hspi1.Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_DISABLE;
-            hspi1.Init.IOSwap = SPI_IO_SWAP_DISABLE;
-            HAL_SPI_Init(&hspi1);             
+            case SPI::four:
+            {
+                // nothing to do
+            } break;
+            
+            case SPI::five:
+            {
+                // ETH ... use what cube-mx has chosen
+                MX_SPI5_Init();
+            } break;
+            
+            case SPI::six:
+            {
+                // eeprom: just call SPI init
+                s_SPIinit(h, config);
+            } break;
+            
+            default: {} break;                            
         }
-        else if(h == SPI::five)
-        { 
-            MX_SPI5_Init();
-        }
-        else if(h == SPI::six)
-        { 
-            if(false == config.isvalid())
-            {                
-                MX_SPI6_Init();
-                // HAL_SPI_MspInit(&hspi6); // it is called inside HAL_SPI_Init()
-            }
-            else
-            {                                
-                hspi6.Instance = SPI6;
-                hspi6.Init.Mode = SPI_MODE_MASTER;
-                hspi6.Init.Direction = SPI_DIRECTION_2LINES;
-                hspi6.Init.DataSize = embot::hw::spi::bsp::utils::stm32::todatasize(config.datasize);;
-                hspi6.Init.CLKPolarity = embot::hw::spi::bsp::utils::stm32::toCLKpolarity(config.mode);
-                hspi6.Init.CLKPhase = embot::hw::spi::bsp::utils::stm32::toCLKphase(config.mode);
-                hspi6.Init.NSS = SPI_NSS_SOFT;
-                hspi6.Init.BaudRatePrescaler = embot::hw::spi::bsp::utils::stm32::tobaudrateprescaler(config.prescaler);
-                hspi6.Init.FirstBit = SPI_FIRSTBIT_MSB;
-                hspi6.Init.TIMode = SPI_TIMODE_DISABLE;
-                hspi6.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
-                hspi6.Init.CRCPolynomial = 0x0;
-                hspi6.Init.NSSPMode = SPI_NSS_PULSE_ENABLE;
-                hspi6.Init.NSSPolarity = SPI_NSS_POLARITY_LOW;
-                hspi6.Init.FifoThreshold = SPI_FIFO_THRESHOLD_01DATA;
-                hspi6.Init.TxCRCInitializationPattern = SPI_CRC_INITIALIZATION_ALL_ZERO_PATTERN;
-                hspi6.Init.RxCRCInitializationPattern = SPI_CRC_INITIALIZATION_ALL_ZERO_PATTERN;
-                hspi6.Init.MasterSSIdleness = SPI_MASTER_SS_IDLENESS_00CYCLE;
-                hspi6.Init.MasterInterDataIdleness = SPI_MASTER_INTERDATA_IDLENESS_00CYCLE;
-                hspi6.Init.MasterReceiverAutoSusp = SPI_MASTER_RX_AUTOSUSP_DISABLE;
-                hspi6.Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_DISABLE;
-                hspi6.Init.IOSwap = SPI_IO_SWAP_DISABLE;
-                HAL_SPI_Init(&hspi6);                             
-            }
-
-        } 
-
-        extconfig.clear();
-
-        return true;
-        // the new rule could be:
-        // if we return true .... non extra init is required inside embot::hw::spi
-        // else ... we call HAL_SPI_Init() inside embot::hw::spi::init()
-        // w/ SPI_InitTypeDef values from embot::hw::spi::Config. we dont need to 
-        // have the pins in there as they are initted by HAL_SPI_MspInit.       
+        
+        return true; 
     }
 
     bool BSP::deinit(embot::hw::SPI h) const
-    {
-        extconfig.load(h, {});
-        if(h == SPI::one)
-        { 
-            HAL_SPI_DeInit(&hspi1);
-        }
-        if(h == SPI::five)
-        { 
-            HAL_SPI_DeInit(&hspi5);
-        }
-        else if(h == SPI::six)
+    {       
+        switch(h)
         {
-            HAL_SPI_DeInit(&hspi6);
-        }  
+            case SPI::one:
+            case SPI::two:
+            case SPI::three:
+            {
+                // call SPI deinit              
+                s_SPIdeinit(h);  
+                // we are on J5: disable port x1
+                s_J5_SPIpinout(h, false);                
+            } break;
+            
+            case SPI::four:
+            {
+                // nothing to do
+            } break;
+            
+            case SPI::five:
+            {
+                // ETH ... use what cube-mx has chosen
+                HAL_SPI_DeInit(&hspi5);
+            } break;
+            
+            case SPI::six:
+            {
+                // eeprom: just call SPI deinit
+                s_SPIdeinit(h);
+            } break;
+            
+            default: {} break;                            
+        }        
         
-        extconfig.clear();
-
         return true;        
     }
     
@@ -939,6 +927,8 @@ extern "C"
 {
     void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
     {
+       embot::hw::spi::bsp::utils::ExtendedConfig * extcfg = nullptr;
+       extcfg = &embot::hw::spi::bsp::extconfig;   
 
       GPIO_InitTypeDef GPIO_InitStruct = {0};
       RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
@@ -955,7 +945,7 @@ extern "C"
         /* SPI1 clock enable */
         __HAL_RCC_SPI1_CLK_ENABLE();
 
-        // must prepare the clocks of the sckl, mosi, miso, (ssel ?): G and D in our case
+        // must prepare the clocks of the sckl, mosi, miso, (ssel ?): D and G in our case
         __HAL_RCC_GPIOD_CLK_ENABLE();
         __HAL_RCC_GPIOG_CLK_ENABLE();
         
@@ -964,31 +954,113 @@ extern "C"
         PG11     ------> SPI1_SCK
         PD7     ------>  SPI1_MOSI
         */
-        GPIO_InitStruct.Pin = embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::MISO, GPIO_PIN_9);
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MISO, 0);
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = embot::hw::spi::bsp::extconfig.pull(embot::hw::spi::Signal::MISO, GPIO_NOPULL);
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MISO, GPIO_NOPULL);
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI1;
-        HAL_GPIO_Init(embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::MISO, GPIOG), &GPIO_InitStruct);
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MISO, nullptr), &GPIO_InitStruct);
 
-        GPIO_InitStruct.Pin = embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::MOSI, GPIO_PIN_7);
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MOSI, 0);
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = embot::hw::spi::bsp::extconfig.pull(embot::hw::spi::Signal::MOSI, GPIO_NOPULL);
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MOSI, GPIO_NOPULL);
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI1;
-        HAL_GPIO_Init(embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::MOSI, GPIOD), &GPIO_InitStruct);
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MOSI, nullptr), &GPIO_InitStruct);
         
-        GPIO_InitStruct.Pin = embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::SCLK, GPIO_PIN_11); 
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::SCLK, 0); 
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = embot::hw::spi::bsp::extconfig.pull(embot::hw::spi::Signal::SCLK, GPIO_NOPULL);;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::SCLK, GPIO_NOPULL);;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI1;
-        HAL_GPIO_Init(embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::SCLK, GPIOG), &GPIO_InitStruct);        
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::SCLK, nullptr), &GPIO_InitStruct);        
 
         /* SPI1 interrupt Init */
         HAL_NVIC_SetPriority(SPI1_IRQn, 0, 0);
         HAL_NVIC_EnableIRQ(SPI1_IRQn);          
       }
+      else if(spiHandle->Instance == SPI2)
+      {
+        PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI2;
+        PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_CLKP;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+        {
+          Error_Handler();
+        }
+
+        /* SPI2 clock enable */
+        __HAL_RCC_SPI2_CLK_ENABLE();
+
+        // must prepare the clocks of the sckl, mosi, miso, (ssel ?): B and D in our case
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOD_CLK_ENABLE();
+        
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MISO, 0);
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MISO, GPIO_NOPULL);
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MISO, nullptr), &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MOSI, 0);
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MOSI, GPIO_NOPULL);
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MOSI, nullptr), &GPIO_InitStruct);
+        
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::SCLK, 0); 
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::SCLK, GPIO_NOPULL);;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::SCLK, nullptr), &GPIO_InitStruct);        
+
+        /* SPI2 interrupt Init */
+        HAL_NVIC_SetPriority(SPI2_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(SPI2_IRQn);          
+      }  
+      else if(spiHandle->Instance == SPI3)
+      {
+        PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI3;
+        PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_CLKP;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+        {
+          Error_Handler();
+        }
+
+        /* SPI3 clock enable */
+        __HAL_RCC_SPI3_CLK_ENABLE();
+
+        // must prepare the clocks of the sckl, mosi, miso, (ssel ?): C and D in our case
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        __HAL_RCC_GPIOD_CLK_ENABLE();
+        
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MISO, 0);
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MISO, GPIO_NOPULL);
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF6_SPI3;
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MISO, nullptr), &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MOSI, 0);
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MOSI, GPIO_NOPULL);
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI3;
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MOSI, nullptr), &GPIO_InitStruct);
+        
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::SCLK, 0); 
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::SCLK, GPIO_NOPULL);;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF6_SPI3;
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::SCLK, nullptr), &GPIO_InitStruct);        
+
+        /* SPI3 interrupt Init */
+        HAL_NVIC_SetPriority(SPI3_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(SPI3_IRQn);          
+      }        
       else if(spiHandle->Instance==SPI5)
       {
       /* USER CODE BEGIN SPI5_MspInit 0 */
@@ -1066,29 +1138,29 @@ extern "C"
         PG13     ------> SPI6_SCK
         PG14     ------> SPI6_MOSI
         */
-        GPIO_InitStruct.Pin = embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::MISO, EE_MISO_Pin); //EE_MISO_Pin;
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MISO, EE_MISO_Pin); //EE_MISO_Pin;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = embot::hw::spi::bsp::extconfig.pull(embot::hw::spi::Signal::MISO, GPIO_NOPULL);
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MISO, GPIO_NOPULL);
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF8_SPI6;
         //HAL_GPIO_Init(EE_MISO_GPIO_Port, &GPIO_InitStruct);
-        HAL_GPIO_Init(embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::MISO, EE_MISO_GPIO_Port), &GPIO_InitStruct);
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MISO, EE_MISO_GPIO_Port), &GPIO_InitStruct);
 
-        GPIO_InitStruct.Pin = embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::MOSI, EE_MOSI_Pin);//EE_MOSI_Pin;
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::MOSI, EE_MOSI_Pin);//EE_MOSI_Pin;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = embot::hw::spi::bsp::extconfig.pull(embot::hw::spi::Signal::MOSI, GPIO_NOPULL);
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::MOSI, GPIO_NOPULL);
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI6;
         //HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
-        HAL_GPIO_Init(embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::MOSI, GPIOG), &GPIO_InitStruct);
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::MOSI, GPIOG), &GPIO_InitStruct);
         
-        GPIO_InitStruct.Pin = embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::SCLK, EE_SCLK_Pin); //EE_SCLK_Pin;
+        GPIO_InitStruct.Pin = extcfg->pin(embot::hw::spi::Signal::SCLK, EE_SCLK_Pin); //EE_SCLK_Pin;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = embot::hw::spi::bsp::extconfig.pull(embot::hw::spi::Signal::SCLK, GPIO_NOPULL);;
+        GPIO_InitStruct.Pull = extcfg->pull(embot::hw::spi::Signal::SCLK, GPIO_NOPULL);;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI6;
         //HAL_GPIO_Init(GPIOG, &GPIO_InitStruct); 
-        HAL_GPIO_Init(embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::SCLK, GPIOG), &GPIO_InitStruct);        
+        HAL_GPIO_Init(extcfg->port(embot::hw::spi::Signal::SCLK, GPIOG), &GPIO_InitStruct);        
 
         /* SPI6 interrupt Init */
         HAL_NVIC_SetPriority(SPI6_IRQn, 0, 0);
@@ -1102,17 +1174,39 @@ extern "C"
 
     void HAL_SPI_MspDeInit(SPI_HandleTypeDef* spiHandle)
     {
+       embot::hw::spi::bsp::utils::ExtendedConfig * extcfg = nullptr;
+       extcfg = &embot::hw::spi::bsp::extconfig;  
+        
         if(spiHandle->Instance == SPI1)
         {
             __HAL_RCC_SPI1_CLK_DISABLE();
             
-            embot::hw::gpio::deinit(embot::hw::spi::bsp::extconfig.gpio(embot::hw::spi::Signal::SCLK));
-            embot::hw::gpio::deinit(embot::hw::spi::bsp::extconfig.gpio(embot::hw::spi::Signal::MOSI));
-            embot::hw::gpio::deinit(embot::hw::spi::bsp::extconfig.gpio(embot::hw::spi::Signal::MISO));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::MISO));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::MOSI));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::SCLK));
 
             HAL_NVIC_DisableIRQ(SPI1_IRQn);            
         }
+        else if(spiHandle->Instance == SPI2)
+        {
+            __HAL_RCC_SPI2_CLK_DISABLE();
+            
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::MISO));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::MOSI));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::SCLK));
 
+            HAL_NVIC_DisableIRQ(SPI2_IRQn);            
+        }
+        else if(spiHandle->Instance == SPI3)
+        {
+            __HAL_RCC_SPI3_CLK_DISABLE();
+            
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::MISO));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::MOSI));
+            embot::hw::gpio::deinit(extcfg->gpio(embot::hw::spi::Signal::SCLK));
+
+            HAL_NVIC_DisableIRQ(SPI3_IRQn);            
+        }        
       else if(spiHandle->Instance==SPI5)
       {
       /* USER CODE BEGIN SPI5_MspDeInit 0 */
@@ -1153,12 +1247,12 @@ extern "C"
         //HAL_GPIO_DeInit(GPIOG, EE_MOSI_Pin);
         //HAL_GPIO_DeInit(GPIOG, EE_SCLK_Pin);
           
-        HAL_GPIO_DeInit(    embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::MISO, EE_MISO_GPIO_Port), 
-                            embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::MISO, EE_MISO_Pin));
-        HAL_GPIO_DeInit(    embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::MOSI, GPIOG), 
-                            embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::MOSI, EE_MOSI_Pin));
-        HAL_GPIO_DeInit(    embot::hw::spi::bsp::extconfig.port(embot::hw::spi::Signal::SCLK, GPIOG),
-                            embot::hw::spi::bsp::extconfig.pin(embot::hw::spi::Signal::SCLK, EE_SCLK_Pin)); ///EE_SCLK_Pin);
+        HAL_GPIO_DeInit(    extcfg->port(embot::hw::spi::Signal::MISO, EE_MISO_GPIO_Port), 
+                            extcfg->pin(embot::hw::spi::Signal::MISO, EE_MISO_Pin));
+        HAL_GPIO_DeInit(    extcfg->port(embot::hw::spi::Signal::MOSI, GPIOG), 
+                            extcfg->pin(embot::hw::spi::Signal::MOSI, EE_MOSI_Pin));
+        HAL_GPIO_DeInit(    extcfg->port(embot::hw::spi::Signal::SCLK, GPIOG),
+                            extcfg->pin(embot::hw::spi::Signal::SCLK, EE_SCLK_Pin)); ///EE_SCLK_Pin);
 
         //HAL_GPIO_DeInit(GPIOG, EE_SCLK_Pin|EE_MOSI_Pin);
 
@@ -1177,6 +1271,16 @@ extern "C"
     void SPI1_IRQHandler(void)
     {
         HAL_SPI_IRQHandler(&embot::hw::spi::bsp::hspi1);
+    }
+
+    void SPI2_IRQHandler(void)
+    {
+        HAL_SPI_IRQHandler(&embot::hw::spi::bsp::hspi2);
+    }
+ 
+    void SPI3_IRQHandler(void)
+    {
+        HAL_SPI_IRQHandler(&embot::hw::spi::bsp::hspi3);
     }
     
     void SPI6_IRQHandler(void)

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
@@ -411,24 +411,7 @@
           <Name>(105=-1,-1,-1,-1,0)</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>81</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134242064</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\h7disco\../../../../../embot/hw/embot_hw_chip_M95512DF.cpp\81</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -459,6 +442,11 @@
           <count>5</count>
           <WinNumber>1</WinNumber>
           <ItemText>ciao</ItemText>
+        </Ww>
+        <Ww>
+          <count>6</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>this</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
@@ -411,7 +411,40 @@
           <Name>(105=-1,-1,-1,-1,0)</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint/>
+      <Breakpoint>
+        <Bp>
+          <Number>0</Number>
+          <Type>0</Type>
+          <LineNumber>244</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134240112</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\src\main-embot-os-hw.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\h7disco\../src/main-embot-os-hw.cpp\244</Expression>
+        </Bp>
+        <Bp>
+          <Number>1</Number>
+          <Type>0</Type>
+          <LineNumber>55</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134244282</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\h7disco\../../../../../embot/hw/embot_hw_chip_AS5045.cpp\55</Expression>
+        </Bp>
+      </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -447,6 +480,16 @@
           <count>6</count>
           <WinNumber>1</WinNumber>
           <ItemText>this</ItemText>
+        </Ww>
+        <Ww>
+          <count>7</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>spirxdata</ItemText>
+        </Ww>
+        <Ww>
+          <count>8</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>s_privatedata</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -1482,7 +1525,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1730,6 +1773,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>6</GroupNumber>
+      <FileNumber>23</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_chip_AS5045.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1740,7 +1795,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1752,7 +1807,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1764,7 +1819,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1776,7 +1831,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1788,7 +1843,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1800,7 +1855,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1812,7 +1867,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1826,13 +1881,13 @@
 
   <Group>
     <GroupName>embot-app</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1852,7 +1907,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
@@ -588,6 +588,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_chip_AS5045.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1233,6 +1238,11 @@
               <FileName>embot_hw_chip_M95512DF.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_AS5045.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -1931,6 +1941,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_chip_AS5045.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2627,6 +2642,11 @@
               <FileName>embot_hw_chip_M95512DF.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_AS5045.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3325,6 +3345,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_chip_AS5045.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3970,6 +3995,11 @@
               <FileName>embot_hw_chip_M95512DF.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_M95512DF.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_AS5045.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_AS5045.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
@@ -959,7 +959,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>6</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os/proj/amc-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os/proj/amc-embot-os.uvoptx
@@ -1585,7 +1585,7 @@
 
   <Group>
     <GroupName>embot-hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1697,6 +1697,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>6</GroupNumber>
+      <FileNumber>19</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_spi.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1707,7 +1719,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1719,7 +1731,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1731,7 +1743,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1743,7 +1755,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1755,7 +1767,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1767,7 +1779,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1779,7 +1791,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1791,7 +1803,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1811,7 +1823,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1831,7 +1843,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os/proj/amc-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os/proj/amc-embot-os.uvprojx
@@ -568,6 +568,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1198,6 +1203,11 @@
               <FileName>embot_hw_flash.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -1881,6 +1891,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2562,6 +2577,11 @@
               <FileName>embot_hw_flash.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3245,6 +3265,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3875,6 +3900,11 @@
               <FileName>embot_hw_flash.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/udpdemobasic/proj/amc-udpdemo-basic.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/udpdemobasic/proj/amc-udpdemo-basic.uvoptx
@@ -1573,7 +1573,7 @@
 
   <Group>
     <GroupName>embot-hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1685,6 +1685,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>6</GroupNumber>
+      <FileNumber>19</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_spi.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1695,7 +1707,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1707,7 +1719,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1719,7 +1731,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1731,7 +1743,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1743,7 +1755,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1755,7 +1767,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1767,7 +1779,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1779,7 +1791,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1799,7 +1811,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1819,7 +1831,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1839,7 +1851,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1859,7 +1871,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1879,7 +1891,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1891,7 +1903,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/udpdemobasic/proj/amc-udpdemo-basic.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/udpdemobasic/proj/amc-udpdemo-basic.uvprojx
@@ -568,6 +568,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1234,6 +1239,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1899,6 +1909,11 @@
               <FileName>embot_hw_flash.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -2617,6 +2632,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3334,6 +3354,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -4050,6 +4075,11 @@
               <FileName>embot_hw_flash.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/udpdemoipnet/proj/amc-ipnet.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/udpdemoipnet/proj/amc-ipnet.uvoptx
@@ -1034,6 +1034,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>6</GroupNumber>
+      <FileNumber>19</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_spi.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1044,7 +1056,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1056,7 +1068,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1068,7 +1080,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1080,7 +1092,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1092,7 +1104,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1104,7 +1116,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1116,7 +1128,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1128,7 +1140,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1148,7 +1160,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1168,7 +1180,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1180,7 +1192,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1200,7 +1212,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1212,7 +1224,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1224,7 +1236,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1236,7 +1248,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>33</FileNumber>
+      <FileNumber>34</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1248,7 +1260,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>34</FileNumber>
+      <FileNumber>35</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1260,7 +1272,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>35</FileNumber>
+      <FileNumber>36</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1272,7 +1284,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>36</FileNumber>
+      <FileNumber>37</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1284,7 +1296,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>37</FileNumber>
+      <FileNumber>38</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1296,7 +1308,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>38</FileNumber>
+      <FileNumber>39</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1308,7 +1320,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>39</FileNumber>
+      <FileNumber>40</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1320,7 +1332,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>40</FileNumber>
+      <FileNumber>41</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1332,7 +1344,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>41</FileNumber>
+      <FileNumber>42</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1344,7 +1356,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>42</FileNumber>
+      <FileNumber>43</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1356,7 +1368,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>43</FileNumber>
+      <FileNumber>44</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1368,7 +1380,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>44</FileNumber>
+      <FileNumber>45</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1380,7 +1392,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>45</FileNumber>
+      <FileNumber>46</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1392,7 +1404,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>46</FileNumber>
+      <FileNumber>47</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1404,7 +1416,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>47</FileNumber>
+      <FileNumber>48</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1416,7 +1428,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>48</FileNumber>
+      <FileNumber>49</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1428,7 +1440,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>49</FileNumber>
+      <FileNumber>50</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1440,7 +1452,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>50</FileNumber>
+      <FileNumber>51</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1452,7 +1464,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>51</FileNumber>
+      <FileNumber>52</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1464,7 +1476,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>52</FileNumber>
+      <FileNumber>53</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1484,7 +1496,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>53</FileNumber>
+      <FileNumber>54</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1496,7 +1508,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>54</FileNumber>
+      <FileNumber>55</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1508,7 +1520,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>55</FileNumber>
+      <FileNumber>56</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1520,7 +1532,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>56</FileNumber>
+      <FileNumber>57</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1532,7 +1544,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>57</FileNumber>
+      <FileNumber>58</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1552,7 +1564,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>58</FileNumber>
+      <FileNumber>59</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1564,7 +1576,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>59</FileNumber>
+      <FileNumber>60</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1576,7 +1588,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>60</FileNumber>
+      <FileNumber>61</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1588,7 +1600,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>61</FileNumber>
+      <FileNumber>62</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1608,7 +1620,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>62</FileNumber>
+      <FileNumber>63</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1628,7 +1640,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>63</FileNumber>
+      <FileNumber>64</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1648,7 +1660,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>64</FileNumber>
+      <FileNumber>65</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1660,7 +1672,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>65</FileNumber>
+      <FileNumber>66</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/udpdemoipnet/proj/amc-ipnet.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/udpdemoipnet/proj/amc-ipnet.uvprojx
@@ -619,6 +619,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1996,6 +2001,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3015,6 +3025,11 @@
                   </Cads>
                 </FileArmAds>
               </FileOption>
+            </File>
+            <File>
+              <FileName>embot_hw_spi.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_spi.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_AS5045.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_AS5045.cpp
@@ -1,0 +1,235 @@
+
+/*
+ * Copyright (C) 2022 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_chip_AS5045.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - test code. i place this section in here because .... we just need the .h file
+// --------------------------------------------------------------------------------------------------------------------
+  
+#if defined(EMBOT_HW_CHIP_AS5045_enable_test)    
+
+// it tests the chip and offers an example of use
+bool embot::hw::chip::testof_AS5045()
+{    
+    // this configuration tells about which spi bus to use, which are the control pins
+    // and their low level GPIO configuration
+    // some extra info:
+    // 1. this configuration is typically used by the embot::hw::eeprom and defined
+    //    inside embot::hw::eeprom::thebsp located inside mbot_hw_bsp_nameofboard.cpp
+    // 2. the spi bus in here specified is initted by AS5045 code w/ a 
+    //    call to embot::hw::spi::init() in a way that is specified by
+    //    embot::hw::spi::thebsp typically placed inside embot_hw_bsp_nameofboard.cpp
+    // 3. the control pins are initialised / deinitialised inside AS5045 only if
+    //    embot::hw::chip::AS5045::Config::PinControl::config.isvalid()
+    constexpr embot::hw::chip::AS5045::Config cfg 
+    {
+        embot::hw::SPI::one,  // the spi bus
+        { 
+            embot::hw::spi::Prescaler::eight, 
+            embot::hw::spi::DataSize::eight, 
+            embot::hw::spi::Mode::zero,
+            { {embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::none} }
+        }
+    };
+    
+    embot::hw::chip::AS5045::Data data {};
+        
+    // step 01: create the object
+    embot::hw::chip::AS5045 *chipAS5045 = new embot::hw::chip::AS5045;
+    
+    bool ok {false};
+    
+    // step 02: initialise it (for extra check i also deinit and init it again)   
+    chipAS5045->init(cfg);
+    chipAS5045->deinit();
+    if(true == chipAS5045->init(cfg))
+    {  
+        // step 03: read an angle
+        if(true == chipAS5045->read(data, 5*embot::core::time1millisec))
+        {
+            ok = true;
+        }                   
+    }
+
+    // step 06: print result
+    embot::core::print(ok ? "dummy test chipAS5045: OK" : "dummy test chipAS5045: KO");   
+    
+    // step 07: delete the object: the destructor also deinits
+    delete chipAS5045;
+    
+    return ok;
+}
+
+
+#endif
+  
+  
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------    
+
+// we dont actually need stm32hal in here ... just embot::hw gpio and spi
+//#if defined(USE_STM32HAL)
+//    #include "stm32hal.h"
+//#else
+//    #warning this implementation is only for stm32hal
+//#endif
+
+#include "embot_hw_gpio.h"
+#include "embot_hw_spi.h"
+
+
+using namespace std;
+
+using namespace embot::hw;
+
+
+   
+struct embot::hw::chip::AS5045::Impl
+{                
+    bool _initted {false};
+    Config _config {};
+    uint8_t _databuffer[3] = {0, 0, 0};
+    
+    Data *_tmpdata {nullptr};
+    embot::core::Callback _tmponcompletion {};
+    
+    Impl() = default;    
+    ~Impl() { deinit(); }
+    
+    bool init(const Config &cfg);   
+    bool deinit();
+    bool read(Data &data, embot::core::relTime timeout);
+    bool read(Data &data, const embot::core::Callback &oncompletion);
+    
+private:
+
+    static void onCompletion(void *p);
+    
+};    
+
+
+bool embot::hw::chip::AS5045::Impl::init(const Config &cfg)
+{    
+    if((true == _initted) && (false == cfg.isvalid()))
+    {
+        return false;
+    }
+    
+    _config = cfg;
+
+    if(resOK == embot::hw::spi::init(_config.spi, _config.spicfg))
+    {
+        _initted =  true;
+    }
+    
+    return _initted; 
+}
+
+bool embot::hw::chip::AS5045::Impl::deinit()
+{  
+    if(_initted)
+    {
+        embot::hw::spi::deinit(_config.spi);
+        _initted = false;
+    }
+    
+    return !_initted; 
+}
+
+
+bool embot::hw::chip::AS5045::Impl::read(Data &data, embot::core::relTime timeout)
+{   
+    bool r {false};
+    
+    embot::core::Data da {_databuffer, sizeof(_databuffer)};
+    if(resOK == embot::hw::spi::read(_config.spi, da, timeout))
+    {
+        data.position = _databuffer[0] | (_databuffer[1] & 0x0f); // to be verified ....
+        data.status.ok = true;
+        r = true;
+    }
+    
+    return r;
+} 
+   
+   
+void embot::hw::chip::AS5045::Impl::onCompletion(void *p)
+{
+    embot::hw::chip::AS5045::Impl *pimpl = reinterpret_cast<embot::hw::chip::AS5045::Impl*>(p);
+    if(nullptr != pimpl->_tmpdata)
+    {
+       pimpl->_tmpdata->position = pimpl->_databuffer[0] | (pimpl->_databuffer[1] & 0x0f); // to be verified ....
+       pimpl->_tmpdata->status.ok = true;
+    }
+    pimpl->_tmponcompletion.execute();
+    pimpl->_tmponcompletion.clear();
+    pimpl->_tmpdata = nullptr;
+}
+   
+   
+bool embot::hw::chip::AS5045::Impl::read(Data &data, const embot::core::Callback &oncompletion)
+{   
+    bool r {false};
+    
+    _tmponcompletion = oncompletion;
+    _tmpdata = &data;
+    embot::core::Data da {_databuffer, sizeof(_databuffer)};
+    if(resOK == embot::hw::spi::read(_config.spi, da, {onCompletion, this}))
+    {
+        r = true;
+    }
+    
+    return r;
+}    
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - interface to the pimpl
+// --------------------------------------------------------------------------------------------------------------------
+    
+    
+embot::hw::chip::AS5045::AS5045()
+: pImpl(new Impl)
+{ 
+
+}
+
+embot::hw::chip::AS5045::~AS5045()
+{   
+    delete pImpl;
+}
+
+bool embot::hw::chip::AS5045::init(const Config &config)
+{
+    return pImpl->init(config);
+}
+
+bool embot::hw::chip::AS5045::deinit()
+{
+    return pImpl->deinit();
+}
+
+bool embot::hw::chip::AS5045::read(Data &data, embot::core::relTime timeout)
+{
+    return pImpl->read(data, timeout);
+}
+
+bool embot::hw::chip::AS5045::read(Data &data, const embot::core::Callback &oncompletion)
+{
+    return pImpl->read(data, oncompletion);
+}
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_AS5045.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_AS5045.h
@@ -1,0 +1,120 @@
+
+/*
+ * Copyright (C) 2022 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_HW_CHIP_AS5045_H_
+#define __EMBOT_HW_CHIP_AS5045_H_
+
+#include "embot_core.h"
+#include "embot_hw_types.h"
+#include "embot_hw_spi.h"
+#include "embot_hw_gpio.h"
+
+    
+#if 0
+## Description
+
+tbd
+
+
+
+## Basic usage
+
+You can use the following code, as long as the settings for SPI are specified by the bsp of the board.
+
+```c++
+#include "embot_hw_chip_AS5045.h"
+
+bool ok = embot::hw::chip::AS5045::testof_AS5045();
+
+```
+
+Code listing. Usage of the class
+
+
+## Caveat Emptor
+
+The interface of the device driver is kept intentionally simple and some features are left (for now) inside the private implementation.    
+
+## References
+[1] tbd
+
+#endif    
+
+
+namespace embot { namespace hw { namespace chip {
+    
+    class AS5045
+    {
+      
+    public:
+        
+        using POS = uint16_t;
+        
+        struct Status
+        {
+            uint32_t todedone {0};
+            bool ok {false};
+            Status() = default;           
+        };
+        
+        struct Data
+        {
+            POS position {0};
+            Status status {};
+            Data() = default;
+            bool isvalid() const { return status.ok; }
+        }; 
+
+                                
+        struct Config
+        {   // contains: spi bus and ... tbd            
+            embot::hw::SPI spi {embot::hw::SPI::none};
+            embot::hw::spi::Config spicfg {};
+            constexpr Config() = default;
+            constexpr Config(embot::hw::SPI s, const embot::hw::spi::Config &sc) 
+                : spi(s), spicfg(sc) {}   
+            constexpr bool isvalid() const { 
+                return embot::hw::spi::supported(spi); 
+            }
+        }; 
+        
+        AS5045();
+        ~AS5045();
+
+        bool isinitted() const;
+        bool init(const Config &config);  
+        bool deinit();
+               
+        bool read(Data &data, embot::core::relTime timeout);  
+        bool read(Data &data, const embot::core::Callback &oncompletion);        
+
+    private:        
+        struct Impl;
+        Impl *pImpl;    
+    };
+    
+    
+}}} // namespace embot { namespace hw { namespace chip {
+
+
+#define EMBOT_HW_CHIP_AS5045_enable_test   
+#if defined(EMBOT_HW_CHIP_AS5045_enable_test)    
+namespace embot { namespace hw { namespace chip {
+    // it tests the chip and offers an example of use
+    bool testof_AS5045();
+}}}
+#endif
+
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.cpp
@@ -35,7 +35,12 @@ bool embot::hw::chip::testof_M95512DF()
     {
         embot::hw::SPI::six,  // the spi bus
         //{}, // dummy spi config
-        {embot::hw::spi::Prescaler::eight, embot::hw::spi::DataSize::eight, embot::hw::spi::Mode::zero},
+        { 
+            embot::hw::spi::Prescaler::eight, 
+            embot::hw::spi::DataSize::eight, 
+            embot::hw::spi::Mode::zero,
+            { {embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::none} }
+        },
         {   // the control pins
             {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::eight},    // nS
             {embot::hw::GPIO::PORT::F, embot::hw::GPIO::PIN::twelve},   // nW
@@ -50,7 +55,7 @@ bool embot::hw::chip::testof_M95512DF()
     
     // address in EEPROM, data to write, destination for data to read
     constexpr embot::hw::chip::M95512DF::ADR adr {64};
-    static constexpr uint8_t bytes2write[8] {1, 2, 3, 4, 5, 6, 7, 8};
+    static uint8_t bytes2write[8] {1, 2, 3, 4, 5, 6, 7, 8};
     constexpr embot::core::Data data2write {bytes2write, sizeof(bytes2write)};
     uint8_t bytes2read[4] {0};
     embot::core::Data data2read {bytes2read, sizeof(bytes2read)}; 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_gpio.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_gpio.cpp
@@ -202,6 +202,8 @@ namespace embot { namespace hw { namespace gpio {
 
         g.clockenable();
         
+#warning evaluate to use HAL_GPIO_Init() for all modes ...
+    
         // caveat: for pins HAL_GPIO_* use u16, and all macros are u16, whereas LL_GPIO_* use u32 
         if(m == Mode::OUTPUTopendrain)
         {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi.cpp
@@ -45,6 +45,33 @@ using namespace embot::hw;
 // - all the rest
 // --------------------------------------------------------------------------------------------------------------------
 
+namespace embot { namespace hw { namespace spi {
+    
+//    constexpr bool mode2clockprops(const Mode m, ClockPolarity &polarity, ClockPhase &phase)
+//    {
+////        if(Mode::none == m) { return false; }
+//        phase = (false == embot::core::binary::bit::check(embot::core::tointegral(m), 0)) ? ClockPhase::edge1 : ClockPhase::edge2;
+//        polarity = (false == embot::core::binary::bit::check(embot::core::tointegral(m), 1)) ? ClockPolarity::low : ClockPolarity::high;
+//        return true;
+//    }
+
+    constexpr Mode clockprops2mode(ClockPolarity polarity, ClockPhase phase)
+    {
+        constexpr Mode map[2][2] = { {Mode::zero, Mode::one}, {Mode::two, Mode::three} };  
+        return map[embot::core::tointegral(polarity)][embot::core::tointegral(phase)];
+    } 
+    
+    constexpr ClockPolarity mode2clockpolarity(const Mode m)
+    {
+        return (false == embot::core::binary::bit::check(embot::core::tointegral(m), 1)) ? ClockPolarity::low : ClockPolarity::high;
+    }
+    
+    constexpr ClockPhase mode2clockphase(const Mode m)
+    {
+        return (false == embot::core::binary::bit::check(embot::core::tointegral(m), 0)) ? ClockPhase::edge1 : ClockPhase::edge2;
+    }
+    
+}}}
 
 #if !defined(HAL_SPI_MODULE_ENABLED) || !defined(EMBOT_ENABLE_hw_spi)
 
@@ -116,7 +143,7 @@ namespace embot { namespace hw { namespace spi {
     
     bool supported(embot::hw::SPI p)
     {
-        return embot::hw::spi::getBSP().supported(p);
+        return embot::hw::spi::bsp::getBSP().supported(p);
     }
 
     
@@ -144,7 +171,7 @@ namespace embot { namespace hw { namespace spi {
         }
         
         
-        bool bspinit = embot::hw::spi::getBSP().init(b, config);
+        bool bspinit = embot::hw::spi::bsp::getBSP().init(b, config);
         if(false == bspinit)
         {
             // do init in here
@@ -152,7 +179,7 @@ namespace embot { namespace hw { namespace spi {
         
         std::uint8_t index = embot::core::tointegral(b);
         s_privatedata.config[index] = config;
-        s_privatedata.handles[index] = embot::hw::spi::getBSP().getPROP(b)->handle;
+        s_privatedata.handles[index] = embot::hw::spi::bsp::getBSP().getPROP(b)->handle;
         
         // set callbacks on rx and tx and error
         HAL_SPI_RegisterCallback(s_privatedata.handles[index], HAL_SPI_TX_COMPLETE_CB_ID, s_SPI_TX_completed);
@@ -184,7 +211,7 @@ namespace embot { namespace hw { namespace spi {
         s_privatedata.config[index] = {};
         s_privatedata.handles[index] = nullptr;
             
-        bool bspdeinit = embot::hw::spi::getBSP().deinit(b);
+        bool bspdeinit = embot::hw::spi::bsp::getBSP().deinit(b);
         if(false == bspdeinit)
         {
             // do deinit in here
@@ -531,7 +558,7 @@ namespace embot { namespace hw { namespace spi {
 
     void s_SPI_TX_completed(SPI_HandleTypeDef *hspi)
     {
-        embot::hw::SPI id = embot::hw::spi::getBSP().toID({hspi});
+        embot::hw::SPI id = embot::hw::spi::bsp::getBSP().toID({hspi});
         if(embot::hw::SPI::none == id)
         {
             return;
@@ -542,7 +569,7 @@ namespace embot { namespace hw { namespace spi {
     
     void s_SPI_rx_completed(SPI_HandleTypeDef *hspi)
     {   
-        embot::hw::SPI id = embot::hw::spi::getBSP().toID({hspi});
+        embot::hw::SPI id = embot::hw::spi::bsp::getBSP().toID({hspi});
         if(embot::hw::SPI::none == id)
         {
             return;
@@ -553,7 +580,7 @@ namespace embot { namespace hw { namespace spi {
 
     void s_SPI_TXrx_completed(SPI_HandleTypeDef *hspi)
     {
-        embot::hw::SPI id = embot::hw::spi::getBSP().toID({hspi});
+        embot::hw::SPI id = embot::hw::spi::bsp::getBSP().toID({hspi});
         if(embot::hw::SPI::none == id)
         {
             return;

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi.h
@@ -67,8 +67,9 @@ CKL idles high        |___|             |___|
 
 namespace embot { namespace hw { namespace spi {
     
+    // note: SSEL is in here defined but ... is not initialised or used (yet) in this driver.
     enum class Signal { MISO = 0, MOSI = 1, SCLK = 2, SSEL = 3, NumberOf = 4 };
-    constexpr size_t NumberOfSignals {embot::core::tointegral(Signal::NumberOf)};
+    constexpr size_t SignalsNumberOf {embot::core::tointegral(Signal::NumberOf)};
        
     // speed is expressed by an integer in bps. it depends on the used prescaler.
     using Speed = uint32_t;
@@ -102,17 +103,15 @@ namespace embot { namespace hw { namespace spi {
         zero = 0,   // (polarity, phase) = (0, 0) = (SPI_POLARITY_LOW, SPI_PHASE_1EDGE)
         one = 1,    // (polarity, phase) = (0, 1) = (SPI_POLARITY_LOW, SPI_PHASE_2EDGE)
         two = 2,    // (polarity, phase) = (1, 0) = (SPI_POLARITY_HIGH, SPI_PHASE_1EDGE)
-        three = 3,  // (polarity, phase) = (1, 1) = (SPI_POLARITY_HIGH, SPI_PHASE_2EDGE) 
-//        none = 255 
+        three = 3   // (polarity, phase) = (1, 1) = (SPI_POLARITY_HIGH, SPI_PHASE_2EDGE) 
     };
           
-
     struct GPIOspecials
     {
-        std::array<embot::hw::gpio::Pull, NumberOfSignals> pulls {  embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull, 
+        std::array<embot::hw::gpio::Pull, SignalsNumberOf> pulls {  embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull, 
                                                                     embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull };
         constexpr GPIOspecials() = default;
-        constexpr GPIOspecials(const std::array<embot::hw::gpio::Pull, NumberOfSignals> &p) : pulls(p) {}
+        constexpr GPIOspecials(const std::array<embot::hw::gpio::Pull, SignalsNumberOf> &p) : pulls(p) {}
         void clear() { for( auto &v : pulls) v = embot::hw::gpio::Pull::none; } 
     };
           
@@ -126,17 +125,15 @@ namespace embot { namespace hw { namespace spi {
         constexpr Config(Prescaler p, DataSize d, Mode m, const GPIOspecials &g) : prescaler(p), datasize(d), mode(m), gpiospecials(g) {};
         constexpr Config(Prescaler p, DataSize d, Mode m) : prescaler(p), datasize(d), mode(m) {};
         constexpr bool isvalid() const { return (Prescaler::none != prescaler) && (DataSize::none != datasize); }
-        //constexpr bool isvalid() const { return (Prescaler::none != prescaler) && (DataSize::none != datasize) && (Mode::none != mode); }
         void clear() { prescaler = Prescaler::none; datasize = DataSize::none; mode = Mode::zero; gpiospecials.clear(); } 
     };
     
     // utilities
-//    constexpr bool mode2clockprops(const Mode m, ClockPolarity &polarity, ClockPhase &phase);    
-    constexpr Mode clockprops2mode(ClockPolarity polarity, ClockPhase phase);
-    
+    constexpr Mode clockprops2mode(ClockPolarity polarity, ClockPhase phase);    
     constexpr ClockPolarity mode2clockpolarity(const Mode m);
     constexpr ClockPhase mode2clockphase(const Mode m);
-        
+
+    // standard api
     bool supported(embot::hw::SPI b);    
     bool initialised(embot::hw::SPI b);    
     result_t init(embot::hw::SPI b, const Config &config);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi_bsp.h
@@ -22,17 +22,18 @@ namespace embot { namespace hw { namespace spi { namespace bsp {
     
 #if   defined(HAL_SPI_MODULE_ENABLED)        
     using SPI_Handle = SPI_HandleTypeDef;
+    using SPI_Device = SPI_TypeDef;
 #else
     using SPI_Handle = void;
 #endif
         
     struct PROP
-    {     
+    {
         SPI_Handle* handle {nullptr}; 
         uint32_t clockrate {0};
-        std::array<embot::hw::GPIO, NumberOfSignals> pinout { {} };
+        std::array<embot::hw::GPIO, SignalsNumberOf> pinout { {} };
         constexpr PROP() = default;
-        constexpr PROP(SPI_Handle *h, uint32_t c, std::array<embot::hw::GPIO, NumberOfSignals> p) : handle(h), clockrate(c), pinout(p) {}
+        constexpr PROP(SPI_Handle *h, uint32_t c, std::array<embot::hw::GPIO, SignalsNumberOf> p) : handle(h), clockrate(c), pinout(p) {}
         constexpr PROP(SPI_Handle *h) : handle(h) {} 
         constexpr Speed prescalertospeed(Prescaler p) const { return clockrate >> (1+embot::core::tointegral(p)); } 
         constexpr Prescaler speedtoprescaler(Speed s) const
@@ -66,13 +67,15 @@ namespace embot { namespace hw { namespace spi { namespace bsp {
     
     const BSP& getBSP();
     
-    
+    // sadly I cannot put a SPI_TypeDef* inside a constexpr data staructure, so i need this funtion to get SPI1 / SPI2 etc
+    SPI_Device* getDEVICE(embot::hw::SPI h);
+        
 namespace utils {
         
     struct ExtendedConfig
     {
-        std::array<embot::hw::gpio::Pull, NumberOfSignals> _pulls { embot::hw::gpio::Pull::none, embot::hw::gpio::Pull::none, embot::hw::gpio::Pull::none };
-        std::array<embot::hw::GPIO, NumberOfSignals> _pinout {};
+        std::array<embot::hw::gpio::Pull, SignalsNumberOf> _pulls { embot::hw::gpio::Pull::none, embot::hw::gpio::Pull::none, embot::hw::gpio::Pull::none };
+        std::array<embot::hw::GPIO, SignalsNumberOf> _pinout {};
         ExtendedConfig() = default;
         
         void load(embot::hw::SPI h, const Config &cfg)
@@ -87,9 +90,9 @@ namespace utils {
             for(auto &g : _pinout) g = {};
         }
         
-        uint32_t pull(const embot::hw::spi::Signal s, const uint32_t defvalue) const
+        uint32_t pull(const embot::hw::spi::Signal s, const uint32_t defvalue = 0) const
         {
-            if(embot::core::tointegral(s) >= NumberOfSignals)
+            if(embot::core::tointegral(s) >= SignalsNumberOf)
             {
                 return defvalue;
             }                   
@@ -97,9 +100,9 @@ namespace utils {
             return (embot::hw::gpio::Pull::none != pu) ? embot::core::tointegral(pu) : defvalue;
         }
         
-        uint32_t pin(const embot::hw::spi::Signal s, const uint32_t defvalue) const
+        uint32_t pin(const embot::hw::spi::Signal s, const uint32_t defvalue = 0) const
         {
-            if(embot::core::tointegral(s) >= NumberOfSignals)
+            if(embot::core::tointegral(s) >= SignalsNumberOf)
             {
                 return defvalue;
             }              
@@ -107,9 +110,9 @@ namespace utils {
             return (gg.isvalid()) ? gg.stmpin : defvalue;
         }
 
-        embot::hw::gpio::GPIO_t* port(const embot::hw::spi::Signal s, embot::hw::gpio::GPIO_t* defvalue) const
+        embot::hw::gpio::GPIO_t* port(const embot::hw::spi::Signal s, embot::hw::gpio::GPIO_t* defvalue = nullptr) const
         {
-            if(embot::core::tointegral(s) >= NumberOfSignals)
+            if(embot::core::tointegral(s) >= SignalsNumberOf)
             {
                 return defvalue;
             }              
@@ -119,7 +122,7 @@ namespace utils {
         
         embot::hw::GPIO gpio(const embot::hw::spi::Signal s) const
         {
-            if(embot::core::tointegral(s) >= NumberOfSignals)
+            if(embot::core::tointegral(s) >= SignalsNumberOf)
             {
                 return {};
             }  

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_spi_bsp.h
@@ -16,47 +16,23 @@
 #include "embot_hw_types.h"
 #include "embot_hw_bsp.h"
 #include "embot_hw_spi.h"
+#include "embot_hw_gpio_bsp.h"
 
-namespace embot { namespace hw { namespace spi {
+namespace embot { namespace hw { namespace spi { namespace bsp {
     
-#if   defined(HAL_SPI_MODULE_ENABLED)    
-    
+#if   defined(HAL_SPI_MODULE_ENABLED)        
     using SPI_Handle = SPI_HandleTypeDef;
-    
-    constexpr uint32_t mode2stm32clkpolarity(const Mode m)
-    {
-        if(Mode::none == m) { return SPI_POLARITY_LOW; }
-        bool polhigh = embot::core::binary::bit::check(embot::core::tointegral(m), 1);
-        return (true == polhigh) ? SPI_POLARITY_HIGH : SPI_POLARITY_LOW;
-    }
-    
-    constexpr uint32_t mode2stm32clkphase(const Mode m)
-    {
-        if(Mode::none == m) { return SPI_PHASE_1EDGE; }
-        bool phaedge2 = embot::core::binary::bit::check(embot::core::tointegral(m), 0);
-        return (true == phaedge2) ? SPI_PHASE_2EDGE : SPI_PHASE_1EDGE;;
-    }
-    
-    constexpr uint32_t datasize2stm32(DataSize d)
-    {
-        return embot::core::tointegral(d);
-    }
-    
-    constexpr uint32_t prescaler2stm32baudrateprescaler(Prescaler p)
-    {
-        return static_cast<uint32_t>(p) << 28;
-    }
-    
 #else
     using SPI_Handle = void;
 #endif
-    
+        
     struct PROP
     {     
         SPI_Handle* handle {nullptr}; 
         uint32_t clockrate {0};
+        std::array<embot::hw::GPIO, NumberOfSignals> pinout { {} };
         constexpr PROP() = default;
-        constexpr PROP(SPI_Handle *h, uint32_t c) : handle(h), clockrate(c) {}
+        constexpr PROP(SPI_Handle *h, uint32_t c, std::array<embot::hw::GPIO, NumberOfSignals> p) : handle(h), clockrate(c), pinout(p) {}
         constexpr PROP(SPI_Handle *h) : handle(h) {} 
         constexpr Speed prescalertospeed(Prescaler p) const { return clockrate >> (1+embot::core::tointegral(p)); } 
         constexpr Prescaler speedtoprescaler(Speed s) const
@@ -70,13 +46,16 @@ namespace embot { namespace hw { namespace spi {
     struct BSP : public embot::hw::bsp::SUPP
     {
         constexpr static std::uint8_t maxnumberof = embot::core::tointegral(embot::hw::SPI::maxnumberof);
+        std::array<const PROP*, maxnumberof> properties {}; 
+        
         constexpr BSP(std::uint32_t msk, std::array<const PROP*, maxnumberof> pro) : SUPP(msk), properties(pro) {} 
         constexpr BSP() : SUPP(0), properties({0}) {}
-            
-        std::array<const PROP*, maxnumberof> properties;    
+               
         constexpr const PROP * getPROP(embot::hw::SPI h) const { return supported(h) ? properties[embot::core::tointegral(h)] : nullptr; }
+        
         bool init(embot::hw::SPI h, const Config &config) const;
         bool deinit(embot::hw::SPI h) const;
+        
         constexpr embot::hw::SPI toID(const PROP& p) const
         { 
             if(nullptr == p.handle) { return embot::hw::SPI::none; }
@@ -86,8 +65,103 @@ namespace embot { namespace hw { namespace spi {
     };
     
     const BSP& getBSP();
-                                            
-}}} // namespace embot { namespace hw { namespace spi 
+    
+    
+namespace utils {
+        
+    struct ExtendedConfig
+    {
+        std::array<embot::hw::gpio::Pull, NumberOfSignals> _pulls { embot::hw::gpio::Pull::none, embot::hw::gpio::Pull::none, embot::hw::gpio::Pull::none };
+        std::array<embot::hw::GPIO, NumberOfSignals> _pinout {};
+        ExtendedConfig() = default;
+        
+        void load(embot::hw::SPI h, const Config &cfg)
+        {
+            _pulls = cfg.gpiospecials.pulls;   
+            _pinout = embot::hw::spi::bsp::getBSP().getPROP(h)->pinout;           
+        }
+        
+        void clear() 
+        {
+            for(auto &v : _pulls) v = embot::hw::gpio::Pull::none;
+            for(auto &g : _pinout) g = {};
+        }
+        
+        uint32_t pull(const embot::hw::spi::Signal s, const uint32_t defvalue) const
+        {
+            if(embot::core::tointegral(s) >= NumberOfSignals)
+            {
+                return defvalue;
+            }                   
+            embot::hw::gpio::Pull pu = _pulls[embot::core::tointegral(s)];
+            return (embot::hw::gpio::Pull::none != pu) ? embot::core::tointegral(pu) : defvalue;
+        }
+        
+        uint32_t pin(const embot::hw::spi::Signal s, const uint32_t defvalue) const
+        {
+            if(embot::core::tointegral(s) >= NumberOfSignals)
+            {
+                return defvalue;
+            }              
+            embot::hw::gpio::PROP gg = embot::hw::gpio::getBSP().getPROP(_pinout[embot::core::tointegral(s)]);
+            return (gg.isvalid()) ? gg.stmpin : defvalue;
+        }
+
+        embot::hw::gpio::GPIO_t* port(const embot::hw::spi::Signal s, embot::hw::gpio::GPIO_t* defvalue) const
+        {
+            if(embot::core::tointegral(s) >= NumberOfSignals)
+            {
+                return defvalue;
+            }              
+            embot::hw::gpio::PROP gg = embot::hw::gpio::getBSP().getPROP(_pinout[embot::core::tointegral(s)]);
+            return (gg.isvalid()) ? gg.stmport : defvalue;
+        } 
+        
+        embot::hw::GPIO gpio(const embot::hw::spi::Signal s) const
+        {
+            if(embot::core::tointegral(s) >= NumberOfSignals)
+            {
+                return {};
+            }  
+            return _pinout[embot::core::tointegral(s)];
+        }            
+    }; 
+
+#if defined(HAL_SPI_MODULE_ENABLED)    
+
+namespace stm32 {  
+    
+    constexpr uint32_t toCLKpolarity(const Mode m)
+    {
+//        if(Mode::none == m) { return SPI_POLARITY_LOW; }
+        bool polhigh = embot::core::binary::bit::check(embot::core::tointegral(m), 1);
+        return (true == polhigh) ? SPI_POLARITY_HIGH : SPI_POLARITY_LOW;
+    }
+    
+    constexpr uint32_t toCLKphase(const Mode m)
+    {
+//        if(Mode::none == m) { return SPI_PHASE_1EDGE; }
+        bool phaedge2 = embot::core::binary::bit::check(embot::core::tointegral(m), 0);
+        return (true == phaedge2) ? SPI_PHASE_2EDGE : SPI_PHASE_1EDGE;;
+    }
+    
+    constexpr uint32_t todatasize(DataSize d)
+    {
+        return embot::core::tointegral(d);
+    }
+    
+    constexpr uint32_t tobaudrateprescaler(Prescaler p)
+    {
+        return static_cast<uint32_t>(p) << 28;
+    }    
+} // namespace stm32 {  
+
+#endif // #if defined(HAL_SPI_MODULE_ENABLED)     
+    
+} // namespace utils {    
+
+    
+}}}} //namespace embot { namespace hw { namespace spi { namespace bsp {
 
 
 

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/amc/v1A0/src/spi.c
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/amc/v1A0/src/spi.c
@@ -112,161 +112,161 @@ void MX_SPI6_Init(void)
 
 }
 
-void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
-{
+//void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
+//{
 
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
-  if(spiHandle->Instance==SPI5)
-  {
-  /* USER CODE BEGIN SPI5_MspInit 0 */
+//  GPIO_InitTypeDef GPIO_InitStruct = {0};
+//  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
+//  if(spiHandle->Instance==SPI5)
+//  {
+//  /* USER CODE BEGIN SPI5_MspInit 0 */
 
-  /* USER CODE END SPI5_MspInit 0 */
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI5;
-    PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_D2PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
-    {
-      Error_Handler();
-    }
+//  /* USER CODE END SPI5_MspInit 0 */
+//  /** Initializes the peripherals clock
+//  */
+//    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI5;
+//    PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_D2PCLK1;
+//    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+//    {
+//      Error_Handler();
+//    }
 
-    /* SPI5 clock enable */
-    __HAL_RCC_SPI5_CLK_ENABLE();
+//    /* SPI5 clock enable */
+//    __HAL_RCC_SPI5_CLK_ENABLE();
 
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    __HAL_RCC_GPIOH_CLK_ENABLE();
-    /**SPI5 GPIO Configuration
-    PF8     ------> SPI5_MISO
-    PF11     ------> SPI5_MOSI
-    PH6     ------> SPI5_SCK
-    */
-    GPIO_InitStruct.Pin = ETH_MISO_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF5_SPI5;
-    HAL_GPIO_Init(ETH_MISO_GPIO_Port, &GPIO_InitStruct);
+//    __HAL_RCC_GPIOF_CLK_ENABLE();
+//    __HAL_RCC_GPIOH_CLK_ENABLE();
+//    /**SPI5 GPIO Configuration
+//    PF8     ------> SPI5_MISO
+//    PF11     ------> SPI5_MOSI
+//    PH6     ------> SPI5_SCK
+//    */
+//    GPIO_InitStruct.Pin = ETH_MISO_Pin;
+//    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+//    GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+//    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+//    GPIO_InitStruct.Alternate = GPIO_AF5_SPI5;
+//    HAL_GPIO_Init(ETH_MISO_GPIO_Port, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin = ETH_MOSI_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF5_SPI5;
-    HAL_GPIO_Init(ETH_MOSI_GPIO_Port, &GPIO_InitStruct);
+//    GPIO_InitStruct.Pin = ETH_MOSI_Pin;
+//    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+//    GPIO_InitStruct.Pull = GPIO_PULLUP;
+//    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+//    GPIO_InitStruct.Alternate = GPIO_AF5_SPI5;
+//    HAL_GPIO_Init(ETH_MOSI_GPIO_Port, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin = ETH_SCLK_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF5_SPI5;
-    HAL_GPIO_Init(ETH_SCLK_GPIO_Port, &GPIO_InitStruct);
+//    GPIO_InitStruct.Pin = ETH_SCLK_Pin;
+//    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+//    GPIO_InitStruct.Pull = GPIO_NOPULL;
+//    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+//    GPIO_InitStruct.Alternate = GPIO_AF5_SPI5;
+//    HAL_GPIO_Init(ETH_SCLK_GPIO_Port, &GPIO_InitStruct);
 
-    /* SPI5 interrupt Init */
-    HAL_NVIC_SetPriority(SPI5_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(SPI5_IRQn);
-  /* USER CODE BEGIN SPI5_MspInit 1 */
+//    /* SPI5 interrupt Init */
+//    HAL_NVIC_SetPriority(SPI5_IRQn, 0, 0);
+//    HAL_NVIC_EnableIRQ(SPI5_IRQn);
+//  /* USER CODE BEGIN SPI5_MspInit 1 */
 
-  /* USER CODE END SPI5_MspInit 1 */
-  }
-  else if(spiHandle->Instance==SPI6)
-  {
-  /* USER CODE BEGIN SPI6_MspInit 0 */
+//  /* USER CODE END SPI5_MspInit 1 */
+//  }
+//  else if(spiHandle->Instance==SPI6)
+//  {
+//  /* USER CODE BEGIN SPI6_MspInit 0 */
 
-  /* USER CODE END SPI6_MspInit 0 */
+//  /* USER CODE END SPI6_MspInit 0 */
 
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI6;
-    PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_D3PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
-    {
-      Error_Handler();
-    }
+//  /** Initializes the peripherals clock
+//  */
+//    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI6;
+//    PeriphClkInitStruct.Spi6ClockSelection = RCC_SPI6CLKSOURCE_D3PCLK1;
+//    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+//    {
+//      Error_Handler();
+//    }
 
-    /* SPI6 clock enable */
-    __HAL_RCC_SPI6_CLK_ENABLE();
+//    /* SPI6 clock enable */
+//    __HAL_RCC_SPI6_CLK_ENABLE();
 
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-    __HAL_RCC_GPIOG_CLK_ENABLE();
-    /**SPI6 GPIO Configuration
-    PB4 (NJTRST)     ------> SPI6_MISO
-    PG13     ------> SPI6_SCK
-    PG14     ------> SPI6_MOSI
-    */
-    GPIO_InitStruct.Pin = EE_MISO_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF8_SPI6;
-    HAL_GPIO_Init(EE_MISO_GPIO_Port, &GPIO_InitStruct);
+//    __HAL_RCC_GPIOB_CLK_ENABLE();
+//    __HAL_RCC_GPIOG_CLK_ENABLE();
+//    /**SPI6 GPIO Configuration
+//    PB4 (NJTRST)     ------> SPI6_MISO
+//    PG13     ------> SPI6_SCK
+//    PG14     ------> SPI6_MOSI
+//    */
+//    GPIO_InitStruct.Pin = EE_MISO_Pin;
+//    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+//    GPIO_InitStruct.Pull = GPIO_NOPULL;
+//    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+//    GPIO_InitStruct.Alternate = GPIO_AF8_SPI6;
+//    HAL_GPIO_Init(EE_MISO_GPIO_Port, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin = EE_SCLK_Pin|EE_MOSI_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF5_SPI6;
-    HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
+//    GPIO_InitStruct.Pin = EE_SCLK_Pin|EE_MOSI_Pin;
+//    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+//    GPIO_InitStruct.Pull = GPIO_NOPULL;
+//    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+//    GPIO_InitStruct.Alternate = GPIO_AF5_SPI6;
+//    HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
 
-    /* SPI6 interrupt Init */
-    HAL_NVIC_SetPriority(SPI6_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(SPI6_IRQn);
-  /* USER CODE BEGIN SPI6_MspInit 1 */
+//    /* SPI6 interrupt Init */
+//    HAL_NVIC_SetPriority(SPI6_IRQn, 0, 0);
+//    HAL_NVIC_EnableIRQ(SPI6_IRQn);
+//  /* USER CODE BEGIN SPI6_MspInit 1 */
 
-  /* USER CODE END SPI6_MspInit 1 */
-  }
-}
+//  /* USER CODE END SPI6_MspInit 1 */
+//  }
+//}
 
-void HAL_SPI_MspDeInit(SPI_HandleTypeDef* spiHandle)
-{
+//void HAL_SPI_MspDeInit(SPI_HandleTypeDef* spiHandle)
+//{
 
-  if(spiHandle->Instance==SPI5)
-  {
-  /* USER CODE BEGIN SPI5_MspDeInit 0 */
+//  if(spiHandle->Instance==SPI5)
+//  {
+//  /* USER CODE BEGIN SPI5_MspDeInit 0 */
 
-  /* USER CODE END SPI5_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_SPI5_CLK_DISABLE();
+//  /* USER CODE END SPI5_MspDeInit 0 */
+//    /* Peripheral clock disable */
+//    __HAL_RCC_SPI5_CLK_DISABLE();
 
-    /**SPI5 GPIO Configuration
-    PF8     ------> SPI5_MISO
-    PF11     ------> SPI5_MOSI
-    PH6     ------> SPI5_SCK
-    */
-    HAL_GPIO_DeInit(GPIOF, ETH_MISO_Pin|ETH_MOSI_Pin);
+//    /**SPI5 GPIO Configuration
+//    PF8     ------> SPI5_MISO
+//    PF11     ------> SPI5_MOSI
+//    PH6     ------> SPI5_SCK
+//    */
+//    HAL_GPIO_DeInit(GPIOF, ETH_MISO_Pin|ETH_MOSI_Pin);
 
-    HAL_GPIO_DeInit(ETH_SCLK_GPIO_Port, ETH_SCLK_Pin);
+//    HAL_GPIO_DeInit(ETH_SCLK_GPIO_Port, ETH_SCLK_Pin);
 
-    /* SPI5 interrupt Deinit */
-    HAL_NVIC_DisableIRQ(SPI5_IRQn);
-  /* USER CODE BEGIN SPI5_MspDeInit 1 */
+//    /* SPI5 interrupt Deinit */
+//    HAL_NVIC_DisableIRQ(SPI5_IRQn);
+//  /* USER CODE BEGIN SPI5_MspDeInit 1 */
 
-  /* USER CODE END SPI5_MspDeInit 1 */
-  }
-  else if(spiHandle->Instance==SPI6)
-  {
-  /* USER CODE BEGIN SPI6_MspDeInit 0 */
+//  /* USER CODE END SPI5_MspDeInit 1 */
+//  }
+//  else if(spiHandle->Instance==SPI6)
+//  {
+//  /* USER CODE BEGIN SPI6_MspDeInit 0 */
 
-  /* USER CODE END SPI6_MspDeInit 0 */
-    /* Peripheral clock disable */
-    __HAL_RCC_SPI6_CLK_DISABLE();
+//  /* USER CODE END SPI6_MspDeInit 0 */
+//    /* Peripheral clock disable */
+//    __HAL_RCC_SPI6_CLK_DISABLE();
 
-    /**SPI6 GPIO Configuration
-    PB4 (NJTRST)     ------> SPI6_MISO
-    PG13     ------> SPI6_SCK
-    PG14     ------> SPI6_MOSI
-    */
-    HAL_GPIO_DeInit(EE_MISO_GPIO_Port, EE_MISO_Pin);
+//    /**SPI6 GPIO Configuration
+//    PB4 (NJTRST)     ------> SPI6_MISO
+//    PG13     ------> SPI6_SCK
+//    PG14     ------> SPI6_MOSI
+//    */
+//    HAL_GPIO_DeInit(EE_MISO_GPIO_Port, EE_MISO_Pin);
 
-    HAL_GPIO_DeInit(GPIOG, EE_SCLK_Pin|EE_MOSI_Pin);
+//    HAL_GPIO_DeInit(GPIOG, EE_SCLK_Pin|EE_MOSI_Pin);
 
-    /* SPI6 interrupt Deinit */
-    HAL_NVIC_DisableIRQ(SPI6_IRQn);
-  /* USER CODE BEGIN SPI6_MspDeInit 1 */
+//    /* SPI6 interrupt Deinit */
+//    HAL_NVIC_DisableIRQ(SPI6_IRQn);
+//  /* USER CODE BEGIN SPI6_MspDeInit 1 */
 
-  /* USER CODE END SPI6_MspDeInit 1 */
-  }
-}
+//  /* USER CODE END SPI6_MspDeInit 1 */
+//  }
+//}
 
 /* USER CODE BEGIN 1 */
 


### PR DESCRIPTION
This PR much improves the `embot::hw::spi` driver by giving runtime configurability which matches our needs for the SPI-based absolute encoders we use.

The SPI driver was tested w/ read and write operations on the onboard EEPROM and w/ dummy read operations on SPI1 / SPI2 / SPI3 which are exposed by connector `J5`.

I have also developed a driver for the chip `AS5045` which is the one used in our `AEA2 ` absolute encoder.
The driver will be fully tested with a true `AEA2`  attached to all the three ports of the `J5` connector.

This driver is meant to be used as a template for the future development of drivers other SPI-based encoders.