### PR TITLE
AMC_BLDC: Update codegen with the last changes on architectural model

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
@@ -481,19 +481,28 @@ void embot::app::application::theMBDagent::Impl::onCurrents_FOC_innerloop(void *
     
     static char msg2[64];
     static uint32_t counter;
-    if(counter % 1000 == 0)
+    if(counter % 10 == 0)
     {
-        sprintf(msg2, "%d %d,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f", \
-                                 impl->amc_bldc.AMC_BLDC_Y.Flags_p.control_mode, \
+        sprintf(msg2, "%d,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f", \
                                  Vabc0,  \
                                  Vabc1,  \
                                  Vabc2,  \
-                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_Iabc[0],  \
-                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_Iabc[1],  \
-                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_Iabc[2],  \
-                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_motorsensors_angle,    \
-                                 impl->amc_bldc.AMC_BLDC_B.Targets_n.motorcurrent.current,    \
-                                 impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Iq_fbk.current);
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.Iabc[0],       \
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.Iabc[1],       \
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.Iabc[2],       \
+                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.angle,         \
+                                 impl->amc_bldc.AMC_BLDC_Y.EstimatedData_p.jointvelocities.velocity, \
+                                 impl->amc_bldc.AMC_BLDC_B.Targets_n.motorcurrent.current,           \
+                                 impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Iq_fbk.current,          \
+                                 impl->amc_bldc.AMC_BLDC_Y.ControlOutputs_p.Vq);
+
+//        sprintf(msg2, "%d,%d,%d,%.3f,%.3f,%.3f", \
+//                                 Vabc0,  \
+//                                 Vabc1,  \
+//                                 Vabc2,  \
+//                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.Iabc[0],       \
+//                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.Iabc[1],       \
+//                                 impl->amc_bldc.AMC_BLDC_U.SensorsData_p.motorsensors.Iabc[2]);
         embot::core::print(msg2);
         counter = 0;
     }

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.268
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:13:31 2022
+// C/C++ source code generated on : Wed Mar 16 14:14:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.268
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:13:31 2022
+// C/C++ source code generated on : Wed Mar 16 14:14:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.268
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:13:31 2022
+// C/C++ source code generated on : Wed Mar 16 14:14:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.268
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:13:31 2022
+// C/C++ source code generated on : Wed Mar 16 14:14:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.87
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:50 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.87
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:50 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.87
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:50 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.87
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:50 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 2.53
+// Model version                  : 2.55
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Feb 17 15:05:37 2022
+// C/C++ source code generated on : Wed Mar  9 12:12:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -97,9 +97,9 @@ namespace amc_bldc_codegen
     }
 
     // DataTypeConversion: '<S2>/Data Type Conversion1' incorporates:
-    //   Gain: '<S2>/Gain'
+    //   Gain: '<S2>/Gain1'
 
-    tmp_0 = CAN_ANGLE_DEG2ICUB * arg_messages_tx.foc.velocity;
+    tmp_0 = CAN_ANGLE_DEG2ICUB / 1000.0F * arg_messages_tx.foc.velocity;
     if (tmp_0 < 32768.0F) {
       if (tmp_0 >= -32768.0F) {
         rtb_DataTypeConversion1_0 = static_cast<int16_T>(tmp_0);
@@ -111,7 +111,7 @@ namespace amc_bldc_codegen
     }
 
     // DataTypeConversion: '<S2>/Data Type Conversion2' incorporates:
-    //   Gain: '<S2>/Gain1'
+    //   Gain: '<S2>/Gain3'
 
     tmp_0 = CAN_ANGLE_DEG2ICUB * arg_messages_tx.foc.position;
     if (tmp_0 < 2.14748365E+9F) {

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 2.53
+// Model version                  : 2.55
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Feb 17 15:05:37 2022
+// C/C++ source code generated on : Wed Mar  9 12:12:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -34,8 +34,8 @@
 
 extern real32_T CAN_ANGLE_DEG2ICUB;    // Variable: CAN_ANGLE_DEG2ICUB
                                           //  Referenced by:
-                                          //    '<S2>/Gain'
                                           //    '<S2>/Gain1'
+                                          //    '<S2>/Gain3'
                                           //  2^16/360
 
 extern uint8_T CAN_ID_AMC;             // Variable: CAN_ID_AMC

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 2.53
+// Model version                  : 2.55
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Feb 17 15:05:37 2022
+// C/C++ source code generated on : Wed Mar  9 12:12:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 2.53
+// Model version                  : 2.55
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Thu Feb 17 15:05:37 2022
+// C/C++ source code generated on : Wed Mar  9 12:12:40 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.89
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Tue Feb 22 10:22:27 2022
+// C/C++ source code generated on : Wed Mar 16 14:13:50 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.89
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Tue Feb 22 10:22:27 2022
+// C/C++ source code generated on : Wed Mar 16 14:13:50 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.89
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Tue Feb 22 10:22:27 2022
+// C/C++ source code generated on : Wed Mar 16 14:13:50 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.89
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Tue Feb 22 10:22:27 2022
+// C/C++ source code generated on : Wed Mar 16 14:13:50 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.89
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Tue Feb 22 10:22:27 2022
+// C/C++ source code generated on : Wed Mar 16 14:13:50 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 2.89
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Tue Feb 22 10:22:27 2022
+// C/C++ source code generated on : Wed Mar 16 14:13:50 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -35,6 +35,34 @@ typedef enum {
   ControlModes_Torque,
   ControlModes_HwFaultCM
 } ControlModes;
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
+#define DEFINED_TYPEDEF_FOR_MotorCurrent_
+
+struct MotorCurrent
+{
+  // motor current
+  real32_T current;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_ControlOutputs_
+#define DEFINED_TYPEDEF_FOR_ControlOutputs_
+
+struct ControlOutputs
+{
+  // control effort (quadrature)
+  real32_T Vq;
+
+  // control effort (3-phases)
+  real32_T Vabc[3];
+
+  // quadrature current
+  MotorCurrent Iq_fbk;
+};
 
 #endif
 
@@ -243,17 +271,6 @@ struct EstimatedData
 
 #endif
 
-#ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
-#define DEFINED_TYPEDEF_FOR_MotorCurrent_
-
-struct MotorCurrent
-{
-  // motor current
-  real32_T current;
-};
-
-#endif
-
 #ifndef DEFINED_TYPEDEF_FOR_MotorVoltage_
 #define DEFINED_TYPEDEF_FOR_MotorVoltage_
 
@@ -301,23 +318,6 @@ struct FOCSlowInputs
   EstimatedData estimateddata;
   Targets targets;
   ControlOuterOutputs controlouteroutputs;
-};
-
-#endif
-
-#ifndef DEFINED_TYPEDEF_FOR_ControlOutputs_
-#define DEFINED_TYPEDEF_FOR_ControlOutputs_
-
-struct ControlOutputs
-{
-  // control effort (quadrature)
-  real32_T Vq;
-
-  // control effort (3-phases)
-  real32_T Vabc[3];
-
-  // quadrature current
-  MotorCurrent Iq_fbk;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.157
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:12:58 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.157
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:12:58 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.157
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:12:58 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.157
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Fri Feb 25 14:12:58 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:25 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.27
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:42 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.27
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:42 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.27
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:42 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.27
 // Simulink Coder version         : 9.6 (R2021b) 14-May-2021
-// C/C++ source code generated on : Mon Jan 31 18:31:42 2022
+// C/C++ source code generated on : Fri Mar 11 17:07:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M


### PR DESCRIPTION
What's new in this PR:
- Update the prints in `application07/src/embot_app_application_theMBDagent.cpp`.
- Update codegen containing the fix of the encoded velocity in `icubdeg/ms`.
- ⚠️[In Progress]: Update codegen with the strategy to use to optimize the FOC output.

**Note:**
- To use the `Lego-setup` just enable the macro `USE_LEGO_SETUP` (disabled by default)
- This macro will be removed when the `hal` will become configurable (currently WIP).
 
cc @pattacini