### PR TITLE
Fix typo when calling eom_task_New in EOMtheEMSdiscoverylistener.cpp

### DIFF
--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiscoverylistener.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSdiscoverylistener.c
@@ -172,7 +172,7 @@ extern EOMtheEMSdiscoverylistener * eom_emsdiscoverylistener_Initialise(const eO
     s_emsdiscoverylistener_singleton.task = eom_task_New(eom_mtask_EventDriven, cfg->taskpriority, cfg->taskstacksize, 
                                                     s_eom_emsdiscoverylistener_task_startup, s_eom_emsdiscoverylistener_task_run,  
                                                     (eOevent_t)0, eok_reltimeINFINITE, NULL, 
-                                                    tskEMScfg, "listener");
+                                                    tskEMSlis, "listener");
  
                                                    
     


### PR DESCRIPTION
**Note:**
- This PR fixes a typo in `EOMtheEMSdiscoverylistener.cpp` that prevents `ems` and `mc4plus` projects from compiling without error.