### PR TITLE
Update Kalman Filter configuration params to be initialized from XML files

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          51
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          52
 
 //  </h>version
 
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          39
 //  </h>build date
 // </h>Info 
 
@@ -495,7 +495,7 @@ extern "C" {
 
 //  <o> max size of output datagrams <64-1500>
 //  <i> default: 1024
-#define EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF                  1416
+#define EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF                  1432
 
 //  </h>datagrams in socket
 
@@ -554,7 +554,7 @@ extern "C" {
 
 //  <o> capacity of the ropframe of reply rops    <16-1440:8>
 //  <i> default: 128
-#define EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY  264  
+#define EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY  280
 
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          39
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          40
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,20 +75,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          35
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          36
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          33
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          40
 //  </h>build date
 
 // </h>Info 
@@ -489,7 +489,7 @@ extern "C" {
 
 //  <o> max size of output datagrams <64-1500>
 //  <i> default: 1024
-#define EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF                  1416
+#define EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF                  1432
 
 //  </h>datagrams in socket
 
@@ -548,7 +548,7 @@ extern "C" {
 
 //  <o> capacity of the ropframe of reply rops    <16-1440:8>
 //  <i> default: 128
-#define EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY  264  
+#define EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY  280  
 
 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -82,13 +82,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          40
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          41
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -87,7 +87,7 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          49
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          50
 
 
 //  </h>version
@@ -96,13 +96,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          38
 
 //  </h>build date
 
@@ -504,7 +504,7 @@ extern "C" {
 
 //  <o> max size of output datagrams <64-1500>
 //  <i> default: 1024
-#define EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF                  1416
+#define EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF                  1432
 
 //  </h>datagrams in socket
 
@@ -563,7 +563,7 @@ extern "C" {
 
 //  <o> capacity of the ropframe of reply rops    <16-1440:8>
 //  <i> default: 128
-#define EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY  264
+#define EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY  280
 
 
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -96,13 +96,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          38
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          42
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -123,8 +123,8 @@ void Joint_init(Joint* o)
     
     // initialize Kalman Filter parameters
     o->kalman_filter_enabled = false;
-    memset(o->x0, 0, sizeof(float)*3);
-    memset(o->Q, 0, sizeof(float)*3);
+    memset(o->x0, 0, sizeof(o->x0));
+    memset(o->Q, 0, sizeof(o->Q));
     o->R = 0;
     o->P0 = 0;
     
@@ -191,8 +191,8 @@ void Joint_config(Joint* o, uint8_t ID, eOmc_joint_config_t* config)
     o->kalman_filter_enabled = config->kalman_params.enabled;
     if(o->kalman_filter_enabled)
     {
-            memcpy(o->x0, config->kalman_params.x0, sizeof(float)*3);
-            memcpy(o->Q, config->kalman_params.Q, sizeof(float)*3);
+            memcpy(o->x0, config->kalman_params.x0, sizeof(o->x0));
+            memcpy(o->Q, config->kalman_params.Q, sizeof(o->Q));
             o->R = config->kalman_params.R;
             o->P0 = config->kalman_params.P0;
         

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -121,6 +121,13 @@ void Joint_init(Joint* o)
     
     o->not_reversible = FALSE;
     
+    // initialize Kalman Filter parameters
+    o->kalman_filter_enabled = false;
+    memset(o->x0, 0, sizeof(float)*3);
+    memset(o->Q, 0, sizeof(float)*3);
+    o->R = 0;
+    o->P0 = 0;
+    
 #ifdef FINGER_MK3
     o->ZTau = 560.0f*1.2f; // PWM/mNm * mNm;
     o->Ke = 0.05f;
@@ -179,6 +186,19 @@ void Joint_config(Joint* o, uint8_t ID, eOmc_joint_config_t* config)
     o->Kadmitt = ZERO;
     
     o->dead_zone = config->deadzone;
+    
+    // copy Kalman Filter parameters configuration.
+    o->kalman_filter_enabled = config->kalman_params.enabled;
+    if(o->kalman_filter_enabled)
+    {
+            memcpy(o->x0, config->kalman_params.x0, sizeof(float)*3);
+            memcpy(o->Q, config->kalman_params.Q, sizeof(float)*3);
+            o->R = config->kalman_params.R;
+            o->P0 = config->kalman_params.P0;
+        
+            // Initialize Kalman Filter for the joint
+            o->kalman_filter.initialize();
+    }
     
 //    eOerrmanDescriptor_t errdes = {0};
 //    char message[150];

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
@@ -113,13 +113,6 @@ typedef struct // JointSet
 #endif
 
     TripodCalib tripod_calib;
-
-    // Kalman Filter Parameters
-    BOOL kalman_filter_enabled;
-    float x0[3];
-    float Q[3];
-    float R;
-    float P0;
 } JointSet;
 
 extern JointSet* JointSet_new(uint8_t n); //

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
@@ -18,6 +18,13 @@ struct Joint_hid // Joint
     
     CTRL_UNITS dead_zone;
     
+    // Kalman Filter Parameters
+    BOOL kalman_filter_enabled;
+    float x0[3];
+    float Q[3];
+    float R;
+    float P0;
+    
     CTRL_UNITS pos_min;
     CTRL_UNITS pos_max;
     CTRL_UNITS vel_max;


### PR DESCRIPTION
What's new in this PR:
- This PR involves changes on `ems`, `mc2plus` and `mc4plus`.
- The Kalman Filter configuration params are now initialized when `Joint_config` is called.
- EOMTHEEMSAPPLCFG_SOCKET_OUTDGRAMSIZEOF and EOMTHEEMSAPPLCFG_TRANSCEIVER_ROPFRAMEREPLIESCAPACITY have been increased by 2 Bytes.

**Notes:**
- This PR is a follow up to #263 
- Currently, the FW has been validated and tested successfully on `AEA3-setup`.
- Kalman Filter is disabled by default when no configurations are provided

cc @pattacini 