### PR TITLE
Enhancement of the `embot::hw::timer` driver

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc.cpp
@@ -1322,5 +1322,62 @@ extern "C"
 // - support map: end of embot::hw::spi
 
 
+
+// - support map: begin of embot::hw::timer
+
+#include "embot_hw_timer_bsp.h"
+
+#if   !defined(HAL_TIM_MODULE_ENABLED) || !defined(EMBOT_ENABLE_hw_timer)
+
+namespace embot { namespace hw { namespace timer {
+    
+    constexpr BSP thebsp { };
+    void BSP::init(embot::hw::TIMER h) const {}    
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }
+    
+}}}
+
+#elif defined(EMBOT_ENABLE_hw_timer_emulated)
+
+namespace embot { namespace hw { namespace timer {
+    
+    #if defined(STM32HAL_BOARD_AMC)    
+    
+    constexpr PROP tim01p = { };
+    constexpr PROP tim02p = { };
+    constexpr PROP tim03p = { };
+    constexpr PROP tim04p = { };  
+    constexpr PROP tim05p = { };
+    constexpr PROP tim06p = { };  
+    
+    constexpr BSP thebsp {        
+        // maskofsupported
+        mask::pos2mask<uint32_t>(TIMER::one) | mask::pos2mask<uint32_t>(TIMER::two) | 
+        mask::pos2mask<uint32_t>(TIMER::three) | mask::pos2mask<uint32_t>(TIMER::four) |
+        mask::pos2mask<uint32_t>(TIMER::four) | mask::pos2mask<uint32_t>(TIMER::five),        
+        // properties
+        {{
+            &tim01p, &tim02p, &tim03p, &tim04p, &tim05p, &tim06p, nullptr, nullptr,     // from 1 to 8
+            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr      // from 9 to 16             
+        }}        
+    };
+    
+    void BSP::init(embot::hw::TIMER h) const {}
+    
+    #else
+        #error embot::hw::timer::thebsp must be defined    
+    #endif
+        
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }    
+}}}
+
+#endif // timer
+
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------
 

--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc_config.h
@@ -35,6 +35,8 @@
 //    #define EMBOT_ENABLE_hw_eth
 
     #define EMBOT_ENABLE_hw_eth
+    #define EMBOT_ENABLE_hw_timer
+    #define EMBOT_ENABLE_hw_timer_emulated
         
 #else
     #error this is the bsp config of STM32HAL_BOARD_AMC ...

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer.h
@@ -29,21 +29,26 @@
 namespace embot { namespace hw { namespace timer {
  
 
-    enum class Mode { oneshot = 0, periodic = 1};    
+    enum class Mode : uint8_t { oneshot = 0, periodic = 1};   
+
+    enum class Status : uint8_t { none = 0, idle = 1, running = 2, expired = 3 };  
     
     struct Config
     {
-        embot::core::relTime      time;               
-        Mode                        mode;             
-        embot::core::Callback     onexpiry;
-        Config() : time(embot::core::time1millisec), mode(Mode::periodic), onexpiry(nullptr, 0) {}         
+        embot::core::relTime time {embot::core::time1millisec};               
+        Mode mode {Mode::periodic};             
+        embot::core::Callback onexpiry {};
+        constexpr Config() = default;
+        constexpr Config(embot::core::relTime t, Mode m, const embot::core::Callback &e ) : time(t), mode(m), onexpiry(e) {}         
     };
     
     
     bool supported(embot::hw::TIMER t);    
     bool initialised(embot::hw::TIMER t);    
     result_t init(embot::hw::TIMER t, const Config &config);
+    result_t deinit(embot::hw::TIMER t);
     
+    // configure() allows to change the configuration after the init()
     result_t configure(embot::hw::TIMER t, const Config &config);
     
     bool isrunning(embot::hw::TIMER t);
@@ -52,7 +57,9 @@ namespace embot { namespace hw { namespace timer {
     
     result_t stop(embot::hw::TIMER t);
     
-    // for use of the IRQhandler only 
+    Status status(embot::hw::TIMER t);
+    
+    // execute() must be placed inside the IRQHandler of the timer
     void execute(embot::hw::TIMER t);
  
 }}} // namespace embot { namespace hw { namespace timer { 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer_bsp.h
@@ -31,8 +31,8 @@ namespace embot { namespace hw { namespace timer {
         TIM_t* TIMx {nullptr};
         TIM_Handle* handle {nullptr};  
         embot::hw::CLOCK clock {embot::hw::CLOCK::none}; // the clock used by the timer      
-        bool isonepulse {false}; // others
-        bool mastermode {false}; // others        
+        bool isonepulse {false};
+        bool mastermode {false};      
     };
  
     


### PR DESCRIPTION
This PR enhances the `embot::hw::timer` driver in two ways:
- it adds some extra functions required for the porting of the objects `EOMtheRunner` to the `amc` application,
- it adds the support of emulated HW timers.

The emulation is implemented w/ the `embot::os::Timer` objects and is enabled w/ macros `EMBOT_ENABLE_hw_timer` and `EMBOT_ENABLE_hw_timer_emulated`.

This feature is useful because I can begin testing the control loop inside the `EOMtheRunner` using some sort of timers which can still do the job, even if not surely at 1KHz.

In the meantime the development of the `embot::hw::timer` using the HW of the new H7 CPU can proceed, hopefully in parallel.

This change does not affect other boards which use the same `embot::hw::timer` driver because I have added functions, and not changed or removed existing ones.

So, this PR can be safely merged.  