### PR TITLE
Application 07: Set FOC and STATUS messages as response to DESIRED_CURRENT message

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.56
+// Model version                  : 4.58
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:34 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:18 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -210,7 +210,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
     AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw];
 
   // ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc(&AMC_BLDC_U.SensorsData_p, &rtb_BusConversion_InsertedFor_F,
@@ -252,7 +252,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   // End of RateTransition generated from: '<Root>/Adapter1'
 
   // RateTransition generated from: '<Root>/Adapter3' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
 
   rtw_mutex_lock();
   wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g + 1);
@@ -577,7 +577,7 @@ void AMC_BLDC_initialize(void)
   filter_current_Init();
 
   // SystemInitialize for ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc_Init();

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.56
+// Model version                  : 4.58
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:34 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:18 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.56
+// Model version                  : 4.58
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:34 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:18 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.56
+// Model version                  : 4.58
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:34 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:18 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:51 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:16 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:51 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:16 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:51 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:16 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:51 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:16 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.4
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:55 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.4
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:55 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.4
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:55 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.4
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:55 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:00 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.28
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:06 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.28
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:06 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.28
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:06 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.28
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:06 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:13 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:55 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:13 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:55 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:13 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:55 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:13 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:55 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:19 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:19 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:19 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:03:19 2022
+// C/C++ source code generated on : Wed Jun 15 10:22:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
@@ -9,7 +9,7 @@
 //
 //  Model version              : 3.3
 //  Simulink Coder version : 9.7 (R2022a) 13-Nov-2021
-//  C++ source code generated on : Tue Jun  7 15:42:35 2022
+//  C++ source code generated on : Wed Jun  8 16:23:05 2022
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/multiword_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/multiword_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:07 2022
 //
 #ifndef MULTIWORD_TYPES_H
 #define MULTIWORD_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:35 2022
+// C/C++ source code generated on : Wed Jun  8 16:23:05 2022
 //
 #include "rtwtypes.h"
 #include "rt_hypotf_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:35 2022
+// C/C++ source code generated on : Wed Jun  8 16:23:05 2022
 //
 #ifndef RTW_HEADER_rt_hypotf_snf_h_
 #define RTW_HEADER_rt_hypotf_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 extern "C" {
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:07 2022
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:07 2022
 //
 #include "uMultiWord2Double.h"
 #include <cmath>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:07 2022
 //
 #ifndef RTW_HEADER_uMultiWord2Double_h_
 #define RTW_HEADER_uMultiWord2Double_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:07 2022
 //
 #include "uMultiWordShl.h"
 #include "rtwtypes.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:07 2022
 //
 #ifndef RTW_HEADER_uMultiWordShl_h_
 #define RTW_HEADER_uMultiWordShl_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Wed Jun  8 16:22:46 2022
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:39 2022
+// C/C++ source code generated on : Wed Jun 15 10:20:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -1069,70 +1069,75 @@ void SupervisorFSM_CANMessageHandler(void)
         SupervisorFSM_RX_B.hasMotorConfigChanged = true;
       }
     }
-  } else if (!SupervisorFSM_RX_rtu_ErrorsRx->
-             errors[SupervisorFSM_RX_B.messageIndex - 1].event) {
-    if (SupervisorFSM_RX_rtu_StatusRx->status[SupervisorFSM_RX_B.messageIndex -
-        1].desired_current) {
-      SupervisorFSM_RX_B.newSetpoint.type = ControlModes_Current;
-      SupervisorFSM_RX_B.newSetpoint.value =
-        SupervisorFSM_RX_rtu_MessagesRx->
-        messages[SupervisorFSM_RX_B.messageIndex - 1].desired_current.current;
-      SupervisorFSM_RX_B.enableSendingMsgStatus = true;
-      SupervisorFSM_RX_B.receivedNewSetpoint = true;
+  } else {
+    SupervisorFSM_RX_B.enableSendingMsgStatus =
+      ((SupervisorFSM_RX_B.messageIndex != 1) &&
+       SupervisorFSM_RX_B.enableSendingMsgStatus);
+    if (!SupervisorFSM_RX_rtu_ErrorsRx->errors[SupervisorFSM_RX_B.messageIndex -
+        1].event) {
+      if (SupervisorFSM_RX_rtu_StatusRx->status[SupervisorFSM_RX_B.messageIndex
+          - 1].desired_current) {
+        SupervisorFSM_RX_B.newSetpoint.type = ControlModes_Current;
+        SupervisorFSM_RX_B.newSetpoint.value =
+          SupervisorFSM_RX_rtu_MessagesRx->
+          messages[SupervisorFSM_RX_B.messageIndex - 1].desired_current.current;
+        SupervisorFSM_RX_B.enableSendingMsgStatus = true;
+        SupervisorFSM_RX_B.receivedNewSetpoint = true;
 
-      // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-      SupervisorFSM_R_SetpointHandler();
+        // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
+        SupervisorFSM_R_SetpointHandler();
 
-      // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-    } else if (SupervisorFSM_RX_rtu_StatusRx->
-               status[SupervisorFSM_RX_B.messageIndex - 1].control_mode) {
-      SupervisorFSM_RX_B.requiredControlMode = SupervisorFSM_RX_convert
-        (SupervisorFSM_RX_rtu_MessagesRx->
-         messages[SupervisorFSM_RX_B.messageIndex - 1].control_mode.mode);
-      SupervisorFSM_RX_B.receivedNewSetpoint = false;
+        // End of Outputs for SubSystem: '<Root>/SetpointHandler'
+      } else if (SupervisorFSM_RX_rtu_StatusRx->
+                 status[SupervisorFSM_RX_B.messageIndex - 1].control_mode) {
+        SupervisorFSM_RX_B.requiredControlMode = SupervisorFSM_RX_convert
+          (SupervisorFSM_RX_rtu_MessagesRx->
+           messages[SupervisorFSM_RX_B.messageIndex - 1].control_mode.mode);
+        SupervisorFSM_RX_B.receivedNewSetpoint = false;
 
-      // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-      Superv_ControlModeHandlerMotor0();
+        // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
+        Superv_ControlModeHandlerMotor0();
 
-      // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0'
-    } else if (SupervisorFSM_RX_rtu_StatusRx->
-               status[SupervisorFSM_RX_B.messageIndex - 1].current_limit) {
-      SupervisorFSM_RX_B.newLimit.type = ControlModes_Current;
-      SupervisorFSM_RX_B.newLimit.peak =
-        SupervisorFSM_RX_rtu_MessagesRx->
-        messages[SupervisorFSM_RX_B.messageIndex - 1].current_limit.peak;
-      SupervisorFSM_RX_B.newLimit.nominal =
-        SupervisorFSM_RX_rtu_MessagesRx->
-        messages[SupervisorFSM_RX_B.messageIndex - 1].current_limit.nominal;
-      SupervisorFSM_RX_B.newLimit.overload =
-        SupervisorFSM_RX_rtu_MessagesRx->
-        messages[SupervisorFSM_RX_B.messageIndex - 1].current_limit.overload;
+        // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0'
+      } else if (SupervisorFSM_RX_rtu_StatusRx->
+                 status[SupervisorFSM_RX_B.messageIndex - 1].current_limit) {
+        SupervisorFSM_RX_B.newLimit.type = ControlModes_Current;
+        SupervisorFSM_RX_B.newLimit.peak =
+          SupervisorFSM_RX_rtu_MessagesRx->
+          messages[SupervisorFSM_RX_B.messageIndex - 1].current_limit.peak;
+        SupervisorFSM_RX_B.newLimit.nominal =
+          SupervisorFSM_RX_rtu_MessagesRx->
+          messages[SupervisorFSM_RX_B.messageIndex - 1].current_limit.nominal;
+        SupervisorFSM_RX_B.newLimit.overload =
+          SupervisorFSM_RX_rtu_MessagesRx->
+          messages[SupervisorFSM_RX_B.messageIndex - 1].current_limit.overload;
 
-      // Outputs for Function Call SubSystem: '<Root>/Limits Handler'
-      SupervisorFSM_RX_LimitsHandler();
+        // Outputs for Function Call SubSystem: '<Root>/Limits Handler'
+        SupervisorFSM_RX_LimitsHandler();
 
-      // End of Outputs for SubSystem: '<Root>/Limits Handler'
-    } else if (SupervisorFSM_RX_rtu_StatusRx->
-               status[SupervisorFSM_RX_B.messageIndex - 1].current_pid) {
-      uint8_T Motorconfig_tmp;
+        // End of Outputs for SubSystem: '<Root>/Limits Handler'
+      } else if (SupervisorFSM_RX_rtu_StatusRx->
+                 status[SupervisorFSM_RX_B.messageIndex - 1].current_pid) {
+        uint8_T Motorconfig_tmp;
 
-      // Selector: '<S1>/Selector2'
-      Motorconfig_tmp = SupervisorFSM_RX_rtu_MessagesRx->
-        messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Ks;
-      SupervisorFSM_RX_B.Motorconfig.Kp = SupervisorFSM_RX_ConvertPid
-        (SupervisorFSM_RX_rtu_MessagesRx->
-         messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Kp,
-         Motorconfig_tmp);
-      SupervisorFSM_RX_B.Motorconfig.Ki = SupervisorFSM_RX_ConvertPid
-        (SupervisorFSM_RX_rtu_MessagesRx->
-         messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Ki,
-         Motorconfig_tmp);
-      SupervisorFSM_RX_B.Motorconfig.Kd = SupervisorFSM_RX_ConvertPid
-        (SupervisorFSM_RX_rtu_MessagesRx->
-         messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Kd,
-         Motorconfig_tmp);
-      SupervisorFSM_RX_B.Motorconfig.Ks = Motorconfig_tmp;
-      SupervisorFSM_RX_B.hasMotorConfigChanged = true;
+        // Selector: '<S1>/Selector2'
+        Motorconfig_tmp = SupervisorFSM_RX_rtu_MessagesRx->
+          messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Ks;
+        SupervisorFSM_RX_B.Motorconfig.Kp = SupervisorFSM_RX_ConvertPid
+          (SupervisorFSM_RX_rtu_MessagesRx->
+           messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Kp,
+           Motorconfig_tmp);
+        SupervisorFSM_RX_B.Motorconfig.Ki = SupervisorFSM_RX_ConvertPid
+          (SupervisorFSM_RX_rtu_MessagesRx->
+           messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Ki,
+           Motorconfig_tmp);
+        SupervisorFSM_RX_B.Motorconfig.Kd = SupervisorFSM_RX_ConvertPid
+          (SupervisorFSM_RX_rtu_MessagesRx->
+           messages[SupervisorFSM_RX_B.messageIndex - 1].current_pid.Kd,
+           Motorconfig_tmp);
+        SupervisorFSM_RX_B.Motorconfig.Ks = Motorconfig_tmp;
+        SupervisorFSM_RX_B.hasMotorConfigChanged = true;
+      }
     }
   }
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:39 2022
+// C/C++ source code generated on : Wed Jun 15 10:20:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:39 2022
+// C/C++ source code generated on : Wed Jun 15 10:20:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:39 2022
+// C/C++ source code generated on : Wed Jun 15 10:20:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.9
+// Model version                  : 4.11
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:45 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:08 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -120,22 +120,16 @@ void SupervisorFSM_TX(const SensorsData *rtu_SensorsData, const EstimatedData
   // Chart: '<Root>/SupervisorFSM_TX'
   if (SupervisorFSM_TX_DW.is_active_c3_SupervisorFSM_TX == 0U) {
     SupervisorFSM_TX_DW.is_active_c3_SupervisorFSM_TX = 1U;
-  } else {
-    if (rtu_Flags->control_mode != ControlModes_Idle) {
-      rty_MessagesTx->foc.current = rtu_ControlOutputs->Iq_fbk.current;
-      rty_MessagesTx->foc.velocity = rtu_EstimatedData->jointvelocities.velocity;
-      rty_MessagesTx->foc.position = rtu_SensorsData->jointpositions.position;
-      SupervisorFSM_TX_DW.ev_focEventCounter++;
-    }
-
-    if (rtu_Flags->enable_sending_msg_status) {
-      rty_MessagesTx->status.control_mode = SupervisorFSM_TX_convert
-        (rtu_Flags->control_mode);
-      rty_MessagesTx->status.pwm_fbk = rtu_ControlOutputs->Vq;
-      rty_MessagesTx->status.flags.ExternalFaultAsserted =
-        rtu_Flags->fault_button;
-      SupervisorFSM_TX_DW.ev_statusEventCounter++;
-    }
+  } else if (rtu_Flags->enable_sending_msg_status) {
+    rty_MessagesTx->foc.current = rtu_ControlOutputs->Iq_fbk.current;
+    rty_MessagesTx->foc.velocity = rtu_EstimatedData->jointvelocities.velocity;
+    rty_MessagesTx->foc.position = rtu_SensorsData->jointpositions.position;
+    SupervisorFSM_TX_DW.ev_focEventCounter++;
+    rty_MessagesTx->status.control_mode = SupervisorFSM_TX_convert
+      (rtu_Flags->control_mode);
+    rty_MessagesTx->status.pwm_fbk = rtu_ControlOutputs->Vq;
+    rty_MessagesTx->status.flags.ExternalFaultAsserted = rtu_Flags->fault_button;
+    SupervisorFSM_TX_DW.ev_statusEventCounter++;
   }
 
   if (SupervisorFSM_TX_DW.ev_focEventCounter > 0U) {

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.9
+// Model version                  : 4.11
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:45 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:08 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.9
+// Model version                  : 4.11
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:45 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:08 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.9
+// Model version                  : 4.11
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 16:02:45 2022
+// C/C++ source code generated on : Wed Jun 15 10:21:08 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M


### PR DESCRIPTION
This PR updates Application 07 to the latest version of the AMC-BLDC model. Currently, that is [this](https://github.com/icub-tech-iit/study-mbd-amc-bldc/commit/305b7ac313fd6443271adcffc3632089a4475dd8) commit.

This includes the change in [this](https://github.com/icub-tech-iit/study-mbd-amc-bldc/pull/220) PR, which makes the board send the `FOC` and `STATUS` messages only as a response to a `SET_DESIRED_CURRENT` message. Before, the messages would be sent continuously without ever stopping after the first desired current request.