### PR TITLE
amc: added diagnostics to appl-00 + fixed hw::timer

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/cfg/theApplication_config.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/cfg/theApplication_config.cpp
@@ -25,43 +25,43 @@ namespace embot { namespace app { namespace eth {
     }
 
     
-    embot::os::EventThread *thr {nullptr};
-    
-    void startup(embot::os::Thread *t, void *p)
-    {
-        embot::core::print("startup: ....");
-    }
-    
-    void onevent(embot::os::Thread *t, embot::os::EventMask eventmask, void *p)
-    {
-        if(0 == eventmask)
-        {   // timeout ...   
+//    embot::os::EventThread *thr {nullptr};
+//    
+//    void startup(embot::os::Thread *t, void *p)
+//    {
+//        embot::core::print("startup: ....");
+//    }
+//    
+//    void onevent(embot::os::Thread *t, embot::os::EventMask eventmask, void *p)
+//    {
+//        if(0 == eventmask)
+//        {   // timeout ...   
 
-            embot::core::TimeFormatter tf(embot::core::now());        
-            std::string str = "onevent: timeout @ time = " + tf.to_string();               
-            //embot::core::print(str);
-                    
-            embot::app::eth::emit(sevINFO, {"testThread", t}, {}, str);
-            
-            return;
-        }
+//            embot::core::TimeFormatter tf(embot::core::now());        
+//            std::string str = "onevent: timeout @ time = " + tf.to_string();               
+//            //embot::core::print(str);
+//                    
+//            embot::app::eth::emit(sevINFO, {"testThread", t}, {}, str);
+//            
+//            return;
+//        }
 
-        // eval other events
-        
-    }
-    
-    void tTEST(void *p) { reinterpret_cast<embot::os::Thread*>(p)->run(); }
+//        // eval other events
+//        
+//    }
+//    
+//    void tTEST(void *p) { reinterpret_cast<embot::os::Thread*>(p)->run(); }
     
     void emit_over_backdoor(theErrorManager::Severity sev, const theErrorManager::Caller &caller, const theErrorManager::Descriptor &des, const std::string &str);
     
-    void bkdoor_onrx(EOpacket *rxp)
-    {
-        uint8_t *data {nullptr};
-        uint16_t size {0};
-        eo_packet_Payload_Get(rxp, &data, &size);
-        embot::core::print("theBackdoor-> " + std::string(reinterpret_cast<char*>(data)));                       
-    }
-    
+//    void bkdoor_onrx(EOpacket *rxp)
+//    {
+//        uint8_t *data {nullptr};
+//        uint16_t size {0};
+//        eo_packet_Payload_Get(rxp, &data, &size);
+//        embot::core::print("theBackdoor-> " + std::string(reinterpret_cast<char*>(data)));                       
+//    }
+//    
     
     void addservice();
     
@@ -80,39 +80,39 @@ namespace embot { namespace app { namespace eth {
         // - the object theBackdoor
         // - an EventThread periodically activated by its timeout
 
-        // add the backdoor
-        constexpr embot::app::eth::theBackdoor::Config bkdconfig =
-        {
-            { embot::os::Priority::belownorm23, 2*1024 },   // thread
-            { {2, 64, 2, 512}, 6666 },                      // socket.size, socket.localport
-            {embot::app::eth::IPlocalhost, 6666},           // hostaddress 
-            bkdoor_onrx,                                    // onreception does ... nothing so far          
-        };
-        
-        embot::app::eth::theBackdoor::getInstance().initialise(bkdconfig);
+//        // add the backdoor
+//        constexpr embot::app::eth::theBackdoor::Config bkdconfig =
+//        {
+//            { embot::os::Priority::belownorm23, 2*1024 },   // thread
+//            { {2, 64, 2, 512}, 6666 },                      // socket.size, socket.localport
+//            {embot::app::eth::IPlocalhost, 6666},           // hostaddress 
+//            bkdoor_onrx,                                    // onreception does ... nothing so far          
+//        };
+//        
+//        embot::app::eth::theBackdoor::getInstance().initialise(bkdconfig);
 
 
-        constexpr embot::core::relTime timeout {5*1000*embot::core::time1millisec};
+//        constexpr embot::core::relTime timeout {5*1000*embot::core::time1millisec};
 
-        embot::os::EventThread::Config tCfg { 
-            6*1024, 
-            embot::os::Priority::belownorm23, 
-            startup, nullptr,
-            timeout,
-            onevent,
-            "tTEST"
-        };
-           
-            
-        // create the test thread 
-        thr = new embot::os::EventThread;          
-        // and start it
-        thr->start(tCfg, tTEST);
-        
-#if defined(REDIRECT_ERRORMANAGER_OVER_BACKDOOR)        
-        // now link theErrorManager to send onto the theBackdoor
-        embot::app::eth::theErrorManager::getInstance().set(emit_over_backdoor);
-#endif
+//        embot::os::EventThread::Config tCfg { 
+//            6*1024, 
+//            embot::os::Priority::belownorm23, 
+//            startup, nullptr,
+//            timeout,
+//            onevent,
+//            "tTEST"
+//        };
+//           
+//            
+//        // create the test thread 
+//        thr = new embot::os::EventThread;          
+//        // and start it
+//        thr->start(tCfg, tTEST);
+//        
+//#if defined(REDIRECT_ERRORMANAGER_OVER_BACKDOOR)        
+//        // now link theErrorManager to send onto the theBackdoor
+//        embot::app::eth::theErrorManager::getInstance().set(emit_over_backdoor);
+//#endif
         
         embot::app::eth::addservice();
         
@@ -145,36 +145,36 @@ namespace embot { namespace app { namespace eth {
         
     }
     
-    void emit_over_backdoor(theErrorManager::Severity sev, const theErrorManager::Caller &caller, const theErrorManager::Descriptor &des, const std::string &str)
-    {
-        // form a string and then send it to the ...
+//    void emit_over_backdoor(theErrorManager::Severity sev, const theErrorManager::Caller &caller, const theErrorManager::Descriptor &des, const std::string &str)
+//    {
+//        // form a string and then send it to the ...
 
-        std::string timenow = embot::core::TimeFormatter(embot::core::now()).to_string();
-        std::string eobjstr = (true == caller.isvalid()) ? caller.objectname : "OBJ";
-        std::string threadname = (true == caller.isvalid()) ? caller.owner->getName() : "THR";
-        std::string severity = theErrorManager::to_cstring(sev);
-        
-        std::string out = std::string("[") + severity + "] @" + timenow + " (" + eobjstr + ", " + threadname + "): " + str + "\n";
-        
-        static EOpacket *pkt {nullptr};
-        
-        if(nullptr == pkt)
-        {
-            pkt = eo_packet_New(500); // max size
-        }
-        
-        uint8_t *data = reinterpret_cast<uint8_t *>(const_cast<char*>(out.c_str()));
-        eo_packet_Payload_Set(pkt, data, strlen(out.c_str()));
-        eo_packet_Addressing_Set(pkt, EO_COMMON_IPV4ADDR(10, 0, 1, 104), 6666);
-        
-        embot::app::eth::theBackdoor::getInstance().transmit(pkt);
-      
-//        if(theErrorManager::Severity::fatal == sev)
+//        std::string timenow = embot::core::TimeFormatter(embot::core::now()).to_string();
+//        std::string eobjstr = (true == caller.isvalid()) ? caller.objectname : "OBJ";
+//        std::string threadname = (true == caller.isvalid()) ? caller.owner->getName() : "THR";
+//        std::string severity = theErrorManager::to_cstring(sev);
+//        
+//        std::string out = std::string("[") + severity + "] @" + timenow + " (" + eobjstr + ", " + threadname + "): " + str + "\n";
+//        
+//        static EOpacket *pkt {nullptr};
+//        
+//        if(nullptr == pkt)
 //        {
-//            for(;;);
-//        }            
-        
-    }
+//            pkt = eo_packet_New(500); // max size
+//        }
+//        
+//        uint8_t *data = reinterpret_cast<uint8_t *>(const_cast<char*>(out.c_str()));
+//        eo_packet_Payload_Set(pkt, data, strlen(out.c_str()));
+//        eo_packet_Addressing_Set(pkt, EO_COMMON_IPV4ADDR(10, 0, 1, 104), 6666);
+//        
+//        embot::app::eth::theBackdoor::getInstance().transmit(pkt);
+//      
+////        if(theErrorManager::Severity::fatal == sev)
+////        {
+////            for(;;);
+////        }            
+//        
+//    }
     
             
 }}}

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvoptx
@@ -135,7 +135,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z0 -C0 -M1 -T1</Name>
+          <Name>-L196 -Z21 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -158,12 +158,17 @@
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>currduration,0x0A</ItemText>
+          <ItemText>cfg,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>last4durations</ItemText>
+          <ItemText>referencespeed,0x0A</ItemText>
+        </Ww>
+        <Ww>
+          <count>2</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>prop</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -223,6 +228,12 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
         <Enable>1</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
@@ -1441,7 +1452,7 @@
 
   <Group>
     <GroupName>embot::app::eth</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1621,7 +1632,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1661,6 +1672,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>5</GroupNumber>
+      <FileNumber>18</FileNumber>
+      <FileType>4</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</PathWithFileName>
+      <FilenameWithoutPath>osal.cm4.lib</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1671,7 +1694,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>18</FileNumber>
+      <FileNumber>19</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1683,7 +1706,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1703,7 +1726,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1715,7 +1738,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1727,7 +1750,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1747,7 +1770,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1759,7 +1782,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1771,7 +1794,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1783,7 +1806,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1795,7 +1818,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1807,7 +1830,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1819,7 +1842,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1831,7 +1854,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1843,7 +1866,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1855,7 +1878,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1867,7 +1890,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>33</FileNumber>
+      <FileNumber>34</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1879,7 +1902,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>34</FileNumber>
+      <FileNumber>35</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1891,7 +1914,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>35</FileNumber>
+      <FileNumber>36</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1903,7 +1926,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>36</FileNumber>
+      <FileNumber>37</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1915,7 +1938,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>37</FileNumber>
+      <FileNumber>38</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1927,7 +1950,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>38</FileNumber>
+      <FileNumber>39</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1947,7 +1970,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>39</FileNumber>
+      <FileNumber>40</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1959,7 +1982,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>40</FileNumber>
+      <FileNumber>41</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1971,7 +1994,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>41</FileNumber>
+      <FileNumber>42</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1983,7 +2006,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>42</FileNumber>
+      <FileNumber>43</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1995,7 +2018,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>43</FileNumber>
+      <FileNumber>44</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2015,7 +2038,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>44</FileNumber>
+      <FileNumber>45</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2027,7 +2050,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>45</FileNumber>
+      <FileNumber>46</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2039,7 +2062,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>46</FileNumber>
+      <FileNumber>47</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2051,7 +2074,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>47</FileNumber>
+      <FileNumber>48</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2063,7 +2086,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>48</FileNumber>
+      <FileNumber>49</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2075,7 +2098,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>49</FileNumber>
+      <FileNumber>50</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2087,7 +2110,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>50</FileNumber>
+      <FileNumber>51</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2099,7 +2122,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>51</FileNumber>
+      <FileNumber>52</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2119,7 +2142,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>52</FileNumber>
+      <FileNumber>53</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2131,7 +2154,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>53</FileNumber>
+      <FileNumber>54</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2143,7 +2166,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>54</FileNumber>
+      <FileNumber>55</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2163,7 +2186,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>55</FileNumber>
+      <FileNumber>56</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2175,7 +2198,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>56</FileNumber>
+      <FileNumber>57</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2187,7 +2210,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>57</FileNumber>
+      <FileNumber>58</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2199,7 +2222,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>58</FileNumber>
+      <FileNumber>59</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2211,7 +2234,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>59</FileNumber>
+      <FileNumber>60</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2223,7 +2246,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>60</FileNumber>
+      <FileNumber>61</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2235,7 +2258,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>61</FileNumber>
+      <FileNumber>62</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2247,7 +2270,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>62</FileNumber>
+      <FileNumber>63</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2259,7 +2282,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>63</FileNumber>
+      <FileNumber>64</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2271,7 +2294,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>64</FileNumber>
+      <FileNumber>65</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2283,7 +2306,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>65</FileNumber>
+      <FileNumber>66</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2295,7 +2318,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>66</FileNumber>
+      <FileNumber>67</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2307,7 +2330,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>67</FileNumber>
+      <FileNumber>68</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2319,7 +2342,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>68</FileNumber>
+      <FileNumber>69</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2331,7 +2354,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>69</FileNumber>
+      <FileNumber>70</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2343,7 +2366,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>70</FileNumber>
+      <FileNumber>71</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2355,7 +2378,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>71</FileNumber>
+      <FileNumber>72</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2367,7 +2390,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>72</FileNumber>
+      <FileNumber>73</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2379,7 +2402,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>73</FileNumber>
+      <FileNumber>74</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2391,7 +2414,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>74</FileNumber>
+      <FileNumber>75</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2403,7 +2426,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>75</FileNumber>
+      <FileNumber>76</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2415,7 +2438,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>76</FileNumber>
+      <FileNumber>77</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2427,7 +2450,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <FileNumber>78</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2447,7 +2470,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>79</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2459,7 +2482,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2471,7 +2494,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>81</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2483,7 +2506,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2503,7 +2526,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2515,7 +2538,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2527,7 +2550,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2539,7 +2562,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2551,7 +2574,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2563,7 +2586,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2575,7 +2598,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2595,7 +2618,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2615,7 +2638,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2627,7 +2650,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2647,7 +2670,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2659,7 +2682,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2671,7 +2694,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2683,7 +2706,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2695,7 +2718,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2707,7 +2730,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2719,7 +2742,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2731,7 +2754,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>100</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2743,7 +2766,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>101</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2755,7 +2778,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>101</FileNumber>
+      <FileNumber>102</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2767,7 +2790,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>102</FileNumber>
+      <FileNumber>103</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2779,7 +2802,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>103</FileNumber>
+      <FileNumber>104</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2791,7 +2814,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <FileNumber>105</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2803,7 +2826,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <FileNumber>106</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2815,7 +2838,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <FileNumber>107</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2835,7 +2858,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <FileNumber>108</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2847,7 +2870,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>108</FileNumber>
+      <FileNumber>109</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2859,7 +2882,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>109</FileNumber>
+      <FileNumber>110</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2871,7 +2894,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>110</FileNumber>
+      <FileNumber>111</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2883,7 +2906,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>111</FileNumber>
+      <FileNumber>112</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2895,7 +2918,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>112</FileNumber>
+      <FileNumber>113</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2907,7 +2930,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>113</FileNumber>
+      <FileNumber>114</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2919,7 +2942,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>114</FileNumber>
+      <FileNumber>115</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2931,7 +2954,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>115</FileNumber>
+      <FileNumber>116</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2943,7 +2966,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>116</FileNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2963,7 +2986,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <FileNumber>118</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2975,7 +2998,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <FileNumber>119</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2995,7 +3018,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <FileNumber>120</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3015,7 +3038,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <FileNumber>121</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3035,7 +3058,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <FileNumber>122</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3055,7 +3078,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3067,7 +3090,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3079,7 +3102,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <FileNumber>125</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3099,7 +3122,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>126</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3111,7 +3134,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>127</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3123,7 +3146,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3135,7 +3158,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3147,7 +3170,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3159,7 +3182,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3179,7 +3202,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <FileNumber>132</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3191,7 +3214,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <FileNumber>133</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3203,7 +3226,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <FileNumber>134</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3215,7 +3238,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <FileNumber>135</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3235,7 +3258,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>26</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3255,7 +3278,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3267,7 +3290,7 @@
     </File>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3279,7 +3302,7 @@
     </File>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3291,7 +3314,7 @@
     </File>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3311,7 +3334,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>28</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <FileNumber>141</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3323,7 +3346,7 @@
     </File>
     <File>
       <GroupNumber>28</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <FileNumber>142</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3335,7 +3358,7 @@
     </File>
     <File>
       <GroupNumber>28</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <FileNumber>143</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3355,7 +3378,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>29</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <FileNumber>144</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3375,7 +3398,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>30</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <FileNumber>145</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3387,7 +3410,7 @@
     </File>
     <File>
       <GroupNumber>30</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <FileNumber>146</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3401,13 +3424,13 @@
 
   <Group>
     <GroupName>overridden</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <FileNumber>147</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3419,7 +3442,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <FileNumber>148</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3431,7 +3454,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <FileNumber>149</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3443,7 +3466,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <FileNumber>150</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3455,13 +3478,45 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <FileNumber>151</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\cfg\overridden\overridden_sm.cpp</PathWithFileName>
       <FilenameWithoutPath>overridden_sm.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>scope</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>32</GroupNumber>
+      <FileNumber>152</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\embot_app_scope.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_scope.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>32</GroupNumber>
+      <FileNumber>153</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_tools.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvprojx
@@ -340,7 +340,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal -DIPAL_use_cfg2 -DUSE_EMBOT_runner -DUSE_EMBOT_theHandler -DUSE_EMBOT_theServices</MiscControls>
               <Define>USE_EMBOT_HW EMBOBJ_USE_EMBOT USE_STM32HAL STM32HAL_BOARD_AMC STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\libs\highlevel\abslayer\ipal\api;--..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ipnet;..\src\emb-env;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\bsp;..\cfg;..\..\..\bsp\ethdriver;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\app\eth;.;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\cfg\protocol;..\..\..\..\..\embobj\plus\can;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embobj\plus\board</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\libs\highlevel\abslayer\ipal\api;--..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ipnet;..\src\emb-env;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\bsp;..\cfg;..\..\..\bsp\ethdriver;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\app\eth;.;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\cfg\protocol;..\..\..\..\..\embobj\plus\can;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -502,11 +502,35 @@
               <FileName>osal.cm4.dbg.lib</FileName>
               <FileType>4</FileType>
               <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.dbg.lib</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds/>
+              </FileOption>
             </File>
             <File>
               <FileName>eventviewer.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
+            </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
             </File>
           </Files>
         </Group>
@@ -1971,6 +1995,57 @@
               <FileName>hal_embot.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\hal_embot.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
           </Files>
         </Group>
@@ -2322,6 +2397,21 @@
                   </Cads>
                 </FileArmAds>
               </FileOption>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>scope</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -2829,6 +2919,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -4490,6 +4585,21 @@
                   </Cads>
                 </FileArmAds>
               </FileOption>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>scope</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -4997,6 +5107,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -6658,6 +6773,21 @@
                   </Cads>
                 </FileArmAds>
               </FileOption>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>scope</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -7216,6 +7346,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -8112,6 +8247,21 @@
               <FileName>overridden_sm.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\cfg\overridden\overridden_sm.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>scope</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -8670,6 +8820,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -9569,6 +9724,21 @@
             </File>
           </Files>
         </Group>
+        <Group>
+          <GroupName>scope</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
       </Groups>
     </Target>
     <Target>
@@ -10072,6 +10242,11 @@
               <FileName>eventviewer.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
+            </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
             </File>
           </Files>
         </Group>
@@ -11377,6 +11552,21 @@
               <FileName>overridden_sm.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\cfg\overridden\overridden_sm.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>scope</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
@@ -393,7 +393,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z14 -C0 -M1 -T1</Name>
+          <Name>-L199 -Z14 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -415,18 +415,50 @@
         <Bp>
           <Number>0</Number>
           <Type>0</Type>
-          <LineNumber>2912</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>134232262</Address>
+          <LineNumber>580</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134236398</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
           <BreakIfRCount>1</BreakIfRCount>
-          <Filename>C:\dev\icub-firmware\emBODY\eBcode\arch-arm\libs\lowlevel\stm32hal\src\driver\stm32h7-v1A0\src\stm32h7xx_hal_spi.c</Filename>
+          <Filename>..\src\main-embot-os-hw.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\h7disco\../src/main-embot-os-hw.cpp\580</Expression>
+        </Bp>
+        <Bp>
+          <Number>1</Number>
+          <Type>0</Type>
+          <LineNumber>2912</LineNumber>
+          <EnabledFlag>0</EnabledFlag>
+          <Address>134231268</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>C:\ace\#mar\icub-firmware\emBODY\eBcode\arch-arm\libs\lowlevel\stm32hal\src\driver\stm32h7-v1A0\src\stm32h7xx_hal_spi.c</Filename>
           <ExecCommand></ExecCommand>
           <Expression>\\h7disco\../src/driver/stm32h7-v1A0/src/stm32h7xx_hal_spi.c\2912</Expression>
+        </Bp>
+        <Bp>
+          <Number>2</Number>
+          <Type>0</Type>
+          <LineNumber>577</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\main-embot-os-hw.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
         </Bp>
       </Breakpoint>
       <WatchWindow1>
@@ -490,7 +522,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -504,7 +536,7 @@
         <AscS3>0</AscS3>
         <aSer3>0</aSer3>
         <eProf>0</eProf>
-        <aLa>1</aLa>
+        <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
         <aSer4>1</aSer4>
@@ -1452,7 +1484,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1512,7 +1544,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1552,6 +1584,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>4</GroupNumber>
+      <FileNumber>7</FileNumber>
+      <FileType>4</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</PathWithFileName>
+      <FilenameWithoutPath>osal.cm4.lib</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1562,7 +1606,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>5</GroupNumber>
-      <FileNumber>7</FileNumber>
+      <FileNumber>8</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1574,7 +1618,7 @@
     </File>
     <File>
       <GroupNumber>5</GroupNumber>
-      <FileNumber>8</FileNumber>
+      <FileNumber>9</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1586,7 +1630,7 @@
     </File>
     <File>
       <GroupNumber>5</GroupNumber>
-      <FileNumber>9</FileNumber>
+      <FileNumber>10</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1600,13 +1644,13 @@
 
   <Group>
     <GroupName>embot-hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>10</FileNumber>
+      <FileNumber>11</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1618,7 +1662,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>11</FileNumber>
+      <FileNumber>12</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1630,7 +1674,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>12</FileNumber>
+      <FileNumber>13</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1642,7 +1686,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>13</FileNumber>
+      <FileNumber>14</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1654,7 +1698,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>14</FileNumber>
+      <FileNumber>15</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1666,7 +1710,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>15</FileNumber>
+      <FileNumber>16</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1678,7 +1722,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>16</FileNumber>
+      <FileNumber>17</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1690,7 +1734,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>17</FileNumber>
+      <FileNumber>18</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1702,7 +1746,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>18</FileNumber>
+      <FileNumber>19</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1714,7 +1758,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1726,7 +1770,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1738,7 +1782,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1750,7 +1794,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1762,7 +1806,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1782,7 +1826,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1794,7 +1838,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1806,7 +1850,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1818,7 +1862,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1830,7 +1874,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1842,7 +1886,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1854,7 +1898,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1866,7 +1910,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1880,13 +1924,13 @@
 
   <Group>
     <GroupName>embot-app</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1896,17 +1940,41 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>34</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\embot_app_scope.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_scope.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>35</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_tools.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>33</FileNumber>
+      <FileNumber>36</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
@@ -448,6 +448,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -648,6 +653,16 @@
               <FileName>embot_app_theLEDmanager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -997,7 +1012,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMC STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -1099,11 +1114,35 @@
               <FileName>osal.cm4.dbg.lib</FileName>
               <FileType>4</FileType>
               <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.dbg.lib</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds/>
+              </FileOption>
             </File>
             <File>
               <FileName>eventviewer.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
+            </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
             </File>
           </Files>
         </Group>
@@ -1305,6 +1344,16 @@
               <FileName>embot_app_theLEDmanager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -1813,6 +1862,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2013,6 +2067,16 @@
               <FileName>embot_app_theLEDmanager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -2521,6 +2585,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2721,6 +2790,16 @@
               <FileName>embot_app_theLEDmanager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3229,6 +3308,11 @@
                 </FileArmAds>
               </FileOption>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3429,6 +3513,16 @@
               <FileName>embot_app_theLEDmanager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3886,6 +3980,11 @@
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
             </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -4086,6 +4185,16 @@
               <FileName>embot_app_theLEDmanager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner.c
@@ -44,6 +44,7 @@
 
 #if defined(USE_EMBOT_theHandler)
 #include "embot_app_eth_theHandler.h"
+#include "embot_app_scope.h"
 #else
 #include "OPCprotocolManager_Cfg.h"
 #include "EOMtheEMSappl.h"
@@ -121,22 +122,60 @@ const eOemsrunner_cfg_t eom_emsrunner_DefaultCfg =
 
 #if defined(EOM_EMSRUNNER_EVIEW_MEASURES)
 
-void meas_rx_start(void){}
-void meas_rx_stop(void){}
-void meas_do_start(void){}
-void meas_do_stop(void){}    
-void meas_tx_start(void){}
-void meas_tx_stop(void){}
+//    #define EOM_EMSRUNNER_EVIEW_MEASURES_START
+//    #define EOM_EMSRUNNER_EVIEW_MEASURES_STOP
+    #define EOM_EMSRUNNER_EVIEW_MEASURES_TIMERS
+
+
+    #if defined(EOM_EMSRUNNER_EVIEW_MEASURES_START)
+
+    void meas_rx_start(void){}
+    void meas_do_start(void){} 
+    void meas_tx_start(void){}
+      
+    static const evEntityId_t ev_meas_rx_start = ev_ID_first_usrdef+15; 
+    static const evEntityId_t ev_meas_do_start = ev_ID_first_usrdef+17;   
+    static const evEntityId_t ev_meas_tx_start = ev_ID_first_usrdef+19;         
+    static const evEntityId_t ev_meas_start[3] = {ev_meas_rx_start, ev_meas_do_start, ev_meas_tx_start}; 
     
-static const evEntityId_t ev_meas_rx_start = ev_ID_first_usrdef+15; 
-static const evEntityId_t ev_meas_rx_stop = ev_ID_first_usrdef+16;    
-static const evEntityId_t ev_meas_do_start = ev_ID_first_usrdef+17; 
-static const evEntityId_t ev_meas_do_stop = ev_ID_first_usrdef+18;       
-static const evEntityId_t ev_meas_tx_start = ev_ID_first_usrdef+19; 
-static const evEntityId_t ev_meas_tx_stop = ev_ID_first_usrdef+20; 
+    #endif
+
+    #if defined(EOM_EMSRUNNER_EVIEW_MEASURES_STOP)
     
-//static const evEntityId_t ev_meas_start[3] = {ev_meas_rx_start, ev_meas_do_start, ev_meas_tx_start};    
-static const evEntityId_t ev_meas_stop[3] = {ev_meas_rx_stop, ev_meas_do_stop, ev_meas_tx_stop};
+    void meas_rx_stop(void){}
+    void meas_do_stop(void){}    
+    void meas_tx_stop(void){}
+        
+    static const evEntityId_t ev_meas_rx_stop = ev_ID_first_usrdef+16;    
+    static const evEntityId_t ev_meas_do_stop = ev_ID_first_usrdef+18;       
+    static const evEntityId_t ev_meas_tx_stop = ev_ID_first_usrdef+20;   
+    static const evEntityId_t ev_meas_stop[3] = {ev_meas_rx_stop, ev_meas_do_stop, ev_meas_tx_stop};
+    
+    #endif
+    
+    #if defined(EOM_EMSRUNNER_EVIEW_MEASURES_TIMERS)
+
+    void tmr_all_oneshot_start(void){}
+    void tmr_rx_oneshotexp(void){}    
+    void tmr_do_oneshotexp(void){} 
+    void tmr_tx_oneshotexp(void){} 
+        
+    void tmr_rx_exp(void){} 
+    void tmr_do_exp(void){}   
+    void tmr_tx_exp(void){}
+
+    static const evEntityId_t ev_tmr_all_oneshot_start = ev_ID_first_usrdef+21; 
+    static const evEntityId_t ev_tmr_rx_oneshotexp     = ev_ID_first_usrdef+22; 
+    static const evEntityId_t ev_tmr_do_oneshotexp     = ev_ID_first_usrdef+23; 
+    static const evEntityId_t ev_tmr_tx_oneshotexp     = ev_ID_first_usrdef+24; 
+    static const evEntityId_t ev_tmr_rx_exp            = ev_ID_first_usrdef+25; 
+    static const evEntityId_t ev_tmr_do_exp            = ev_ID_first_usrdef+26; 
+    static const evEntityId_t ev_tmr_tx_exp            = ev_ID_first_usrdef+27;   
+
+    static const evEntityId_t ev_tmr_oneshotexp[3] = {ev_tmr_rx_oneshotexp, ev_tmr_do_oneshotexp, ev_tmr_tx_oneshotexp};
+    static const evEntityId_t ev_tmr_exp[3] = {ev_tmr_rx_exp, ev_tmr_do_exp, ev_tmr_tx_exp};
+    
+    #endif
 
 #endif
 
@@ -280,7 +319,7 @@ extern EOMtheEMSrunner * eom_emsrunner_Initialise(const eOemsrunner_cfg_t *cfg)
                                                                   s_eom_emsrunner_taskRX_startup, s_eom_emsrunner_taskRX_run,  
                                                                   (eOevent_t)(eo_emsrunner_evt_enable) | (eOevent_t)(eo_emsrunner_evt_execute), 
                                                                   eok_reltimeINFINITE, NULL, 
-                                                                  tskEMSrunRX, "runRX");
+                                                                  tRX, "runRX");
  
     s_theemsrunner.task[eo_emsrunner_taskid_runDO] = eom_task_New(eom_mtask_OnAllEventsDriven, 
                                                                   cfg->taskpriority[eo_emsrunner_taskid_runDO], 
@@ -288,7 +327,7 @@ extern EOMtheEMSrunner * eom_emsrunner_Initialise(const eOemsrunner_cfg_t *cfg)
                                                                   s_eom_emsrunner_taskDO_startup, s_eom_emsrunner_taskDO_run,  
                                                                   (eOevent_t)(eo_emsrunner_evt_enable) | (eOevent_t)(eo_emsrunner_evt_execute), 
                                                                   eok_reltimeINFINITE, NULL, 
-                                                                  tskEMSrunDO, "runDO"); 
+                                                                  tDO, "runDO"); 
                                                                   
     s_theemsrunner.task[eo_emsrunner_taskid_runTX] = eom_task_New(eom_mtask_OnAllEventsDriven, 
                                                                   cfg->taskpriority[eo_emsrunner_taskid_runTX], 
@@ -296,16 +335,31 @@ extern EOMtheEMSrunner * eom_emsrunner_Initialise(const eOemsrunner_cfg_t *cfg)
                                                                   s_eom_emsrunner_taskTX_startup, s_eom_emsrunner_taskTX_run,  
                                                                   (eOevent_t)(eo_emsrunner_evt_enable) | (eOevent_t)(eo_emsrunner_evt_execute), 
                                                                   eok_reltimeINFINITE, NULL, 
-                                                                  tskEMSrunTX, "runTX");                                                              
+                                                                  tTX, "runTX");                                                              
      
-#if defined(EOM_EMSRUNNER_EVIEW_MEASURES)
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_START)
     eventviewer_load(ev_meas_rx_start, meas_rx_start);
-    eventviewer_load(ev_meas_rx_stop, meas_rx_stop);
-    eventviewer_load(ev_meas_do_start, meas_do_start);
-    eventviewer_load(ev_meas_do_stop, meas_do_stop);    
+    eventviewer_load(ev_meas_do_start, meas_do_start);  
     eventviewer_load(ev_meas_tx_start, meas_tx_start);
+#endif
+
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_STOP)
+    eventviewer_load(ev_meas_rx_stop, meas_rx_stop);
+    eventviewer_load(ev_meas_do_stop, meas_do_stop);      
     eventviewer_load(ev_meas_tx_stop, meas_tx_stop);
 #endif
+
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_TIMERS)
+    eventviewer_load(ev_tmr_all_oneshot_start, tmr_all_oneshot_start);
+    eventviewer_load(ev_tmr_rx_oneshotexp, tmr_rx_oneshotexp);
+    eventviewer_load(ev_tmr_do_oneshotexp, tmr_do_oneshotexp);
+    eventviewer_load(ev_tmr_tx_oneshotexp, tmr_tx_oneshotexp);
+    eventviewer_load(ev_tmr_rx_exp, tmr_rx_exp);
+    eventviewer_load(ev_tmr_do_exp, tmr_do_exp);
+    eventviewer_load(ev_tmr_tx_exp, tmr_tx_exp);
+#endif
+    
+
 
     s_theemsrunner.isrunning = eobool_false;
 
@@ -389,6 +443,45 @@ extern eObool_t eom_emsrunner_CycleHasJustTransmittedRegulars(EOMtheEMSrunner *p
     return(ret);   
 }
 
+#if defined(USE_EMBOT_theHandler)
+
+#include "embot_hw_bsp_amc_config.h"
+#include "theApplication_Config.h"
+
+#if defined(EMBOT_ENABLE_hw_timer_emulated)
+        
+    // 10: period (1ms) -> 10 ms, dostart (0.4ms) -> 4ms, safetx (0.25ms) -> 2.5 ms
+    // 100: period (1ms) -> 100 ms, dostart (0.4ms) -> 40ms, safetx (0.25ms) -> 25 ms
+constexpr uint32_t cs {(embot::app::eth::theApplication_Config.OStick == 500*embot::core::time1microsec) ? 10 : 100};
+
+#else
+    constexpr uint32_t cs {1};
+#endif
+    
+extern eOresult_t eom_emsrunner_SetTiming(EOMtheEMSrunner *p, const eOemsrunner_timing_t *timing)
+{
+    if((NULL == p) || (NULL == timing))
+    {
+        return(eores_NOK_nullpointer);
+    } 
+    
+    if(eobool_true == s_theemsrunner.cycletiming.cycleisrunning)
+    {
+        return(eores_NOK_generic);        
+    }
+    
+    p->cfg.execRXafter = cs*timing->rxstartafter;
+    p->cfg.safeRXexecutiontime = cs*timing->dostartafter - cs*timing->rxstartafter - cs*timing->safetygap;
+    p->cfg.execDOafter = cs*timing->dostartafter;
+    p->cfg.safeDOexecutiontime = cs*timing->txstartafter - cs*timing->dostartafter - cs*timing->safetygap;
+    p->cfg.execTXafter = cs*timing->txstartafter;
+    p->cfg.safeTXexecutiontime = cs*timing->period - cs*timing->txstartafter + cs*timing->rxstartafter - cs*timing->safetygap;
+    p->cfg.period = cs*timing->period;
+    
+    return(eores_OK);
+}
+
+#else
 
 extern eOresult_t eom_emsrunner_SetTiming(EOMtheEMSrunner *p, const eOemsrunner_timing_t *timing)
 {
@@ -413,8 +506,8 @@ extern eOresult_t eom_emsrunner_SetTiming(EOMtheEMSrunner *p, const eOemsrunner_
     return(eores_OK);
 }
 
-
-
+#endif
+ 
 extern uint64_t eom_emsrunner_Get_IterationNumber(EOMtheEMSrunner *p)
 {  
     if(NULL == p)
@@ -568,21 +661,21 @@ extern void eom_emsrunner_OnUDPpacketTransmitted(EOMtheEMSrunner *p)
 // --------------------------------------------------------------------------------------------------------------------
 
 
-extern void tskEMSrunRX(void *p)
+void tRX(void *p)
 {
     // do here whatever you like before startup() is executed and then forever()
     eom_task_Start((EOMtask*)p);
 } 
 
 
-extern void tskEMSrunDO(void *p)
+void tDO(void *p)
 {
     // do here whatever you like before startup() is executed and then forever()
     eom_task_Start((EOMtask*)p);
 } 
 
 
-extern void tskEMSrunTX(void *p)
+void tTX(void *p)
 {
     // do here whatever you like before startup() is executed and then forever()
     eom_task_Start((EOMtask*)p);
@@ -1110,6 +1203,11 @@ static void s_eom_emsrunner_6HALTIMERS_stop(void)
 static void s_eom_emsrunner_6HALTIMERS_execute_task(void *arg)
 {
     eOemsrunner_taskid_t taskID2execute = (eOemsrunner_taskid_t) (int32_t)arg;
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_TIMERS)
+    evEntityId_t prev = eventviewer_switch_to(ev_tmr_exp[taskID2execute]);      
+    eventviewer_switch_to(prev); 
+#endif    
+    
     EOMtask *task2execute = s_theemsrunner.task[taskID2execute];
            
     eOemsrunner_taskid_t taskIDprevious = (eo_emsrunner_taskid_runRX == taskID2execute) ? (eo_emsrunner_taskid_runTX) : ((eOemsrunner_taskid_t)((uint8_t)taskID2execute-1));
@@ -1171,6 +1269,11 @@ static void s_eom_emsrunner_6HALTIMERS_start_periodic_timer_safestop_check(void 
 static void s_eom_emsrunner_6HALTIMERS_start_periodic_timer_execute_task(void *arg)
 {
     eOemsrunner_taskid_t taskid = (eOemsrunner_taskid_t) (int32_t)arg;
+
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_TIMERS)
+    evEntityId_t prev = eventviewer_switch_to(ev_tmr_oneshotexp[taskid]);      
+    eventviewer_switch_to(prev); 
+#endif
     
     hal_timer_cfg_t periodic_cfg  = 
     {
@@ -1193,13 +1296,17 @@ static void s_eom_emsrunner_6HALTIMERS_start_periodic_timer_execute_task(void *a
 
 static void s_eom_emsrunner_tasktiming_on_entry(eOemsrunner_taskid_t taskid)
 {
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_START)
+    evEntityId_t prev = eventviewer_switch_to(ev_meas_start[taskid]);      
+    eventviewer_switch_to(prev); 
+#endif
     s_theemsrunner.cycletiming.tasktiming[taskid].isexecuting = eobool_true;   
 }
 
 
 static void s_eom_emsrunner_tasktiming_on_exit(eOemsrunner_taskid_t taskid)
 {
-#if defined(EOM_EMSRUNNER_EVIEW_MEASURES)
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_STOP)
     evEntityId_t prev = eventviewer_switch_to(ev_meas_stop[taskid]);      
     eventviewer_switch_to(prev); 
 #endif
@@ -1396,6 +1503,11 @@ static void s_eom_emsrunner_6HALTIMERS_start(EOMtheEMSrunner *p)
 
     // finally: we activate the hal timers. it is best to avoid any interruption in here, thus we disable scheduling
     //osal_system_scheduling_suspend();
+
+#if defined(EOM_EMSRUNNER_EVIEW_MEASURES_TIMERS)
+    evEntityId_t prev = eventviewer_switch_to(ev_tmr_all_oneshot_start );      
+    eventviewer_switch_to(prev); 
+#endif
     
     hal_timer_start(p->haltimer_start[eo_emsrunner_taskid_runRX]);
     hal_timer_start(p->haltimer_start[eo_emsrunner_taskid_runDO]);

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner_hid.h
@@ -118,9 +118,9 @@ struct EOMtheEMSrunner_hid
 // - declaration of extern hidden functions ---------------------------------------------------------------------------
 
 // so that we can see it on uvision
-extern void tskEMSrunRX(void *p);
-extern void tskEMSrunDO(void *p);
-extern void tskEMSrunTX(void *p);
+void tRX(void *p);
+void tDO(void *p);
+void tTX(void *p);
 
 
 // default overridable function (weakly defined) for: transceiver error

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theHandler.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theHandler.cpp
@@ -684,17 +684,19 @@ bool embot::app::eth::theHandler::Impl::moveto(State state)
 //    eom_emserror_Initialise(&theHandler_EOMtheEMSerror_Config);
 //}
 
+extern void xxx_OnError(eOerrmanErrorType_t errtype, const char *info, eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *errdes);
+
+#include "embot_os_rtos.h"
+embot::os::rtos::mutex_t* onerrormutex {nullptr};
+embot::os::rtos::semaphore_t* blockingsemaphore {nullptr};
+
 void embot::app::eth::theHandler::Impl::redefine_errorhandler()
 {
-#if 1
-    #warning add for DIAGNOSTIC2_enabled
-    // or not ...
-#else    
-    embot_cif_diagnostic_Init();
-    // this calls the legacy or the new one depending on internal macros 
-    eo_errman_SetOnErrorHandler(eo_errman_GetHandle(), embot_cif_diagnostic_OnError);
-#endif
+    onerrormutex = embot::os::rtos::mutex_new();
+    blockingsemaphore = embot::os::rtos::semaphore_new(2, 0);
     
+    eo_errman_SetOnErrorHandler(eo_errman_GetHandle(), xxx_OnError);
+
 
 //#if !defined(DIAGNOSTIC2_enabled)
 //    s_emsappl_singleton.blockingsemaphore = osal_semaphore_new(2, 0);
@@ -708,6 +710,183 @@ void embot::app::eth::theHandler::Impl::redefine_errorhandler()
 //    // this calls the legacy or the new one depending on internal macros 
 //    eo_errman_SetOnErrorHandler(eo_errman_GetHandle(), embot_cif_diagnostic_OnError);
 //#endif        
+}
+
+#include "EoError.h"
+#include "EOtheInfoDispatcher.h"
+
+static void s_manage_haltrace(const eOerrmanErrorType_t errtype, const char *info, const eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *edes);
+static void s_manage_dispatch(const eOerrmanErrorType_t errtype, const char *info, const eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *des);
+static void s_manage_fatal(const char *info, const eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *des);
+
+
+
+extern void xxx_OnError(eOerrmanErrorType_t errtype, const char *info, eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *errdes)
+{
+    //s_manage_haltrace(errtype, info, caller, errdes);
+    if(eo_errortype_trace == errtype)
+    {   // we dont transmit the trace
+        return;
+    }
+    
+    // ok, now we dispatch all but trace 
+    s_manage_dispatch(errtype, info, caller, errdes);
+        
+    // if fatal we manage it in a particular way
+    if(eo_errortype_fatal == errtype)
+    {
+        s_manage_fatal(info, caller, errdes);
+    }    
+}
+
+
+static void s_manage_haltrace(const eOerrmanErrorType_t errtype, const char *info, const eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *des)
+{
+    char text[256];
+    text[0] = 0; // i put a '0' terminator. just in case 
+    
+    const char empty[] = "EO?";
+    const char *err = eo_errman_ErrorStringGet(eo_errman_GetHandle(), errtype);
+    const char *eobjstr = (NULL == caller) ? (empty) : ((NULL == caller->eobjstr) ? (empty) : (caller->eobjstr));
+    const uint32_t taskid = (NULL == caller) ? (0) : (caller->taskid);
+    
+    embot::core::TimeFormatter tf {embot::core::now()};
+    
+    if(eo_errortype_trace == errtype)
+    {
+        if(nullptr != info)
+        {
+            snprintf(text, sizeof(text), "[TRACE] (%s @%s)-> %s.", eobjstr, tf.to_string().c_str(), info); 
+        }
+        else
+        {
+            snprintf(text, sizeof(text), "[TRACE] (%s @%s)-> ...", eobjstr, tf.to_string().c_str()); 
+        }
+            
+    }
+    else
+    {        
+        if((NULL == des) && (NULL == info))
+        {
+            snprintf(text, sizeof(text), "[%s] (%s tsk%d @%s)-> ...", err, eobjstr, taskid, tf.to_string().c_str());            
+        }
+        else if((NULL != des) && (NULL != info))
+        {
+            snprintf(text, sizeof(text), "[%s] (%s tsk%d @%s)-> {0x%x p16 0x%04x, p64 0x%016llx, dev %d, adr %d}: %s. INFO = %s", err, eobjstr, taskid, tf.to_string().c_str(), des->code, des->par16, des->par64, des->sourcedevice, des->sourceaddress, eoerror_code2string(des->code), info);  
+        }
+        else if((NULL != des) && (NULL == info))
+        {
+            snprintf(text, sizeof(text), "[%s] (%s tsk%d @%s)-> {0x%x, p16 0x%04x, p64 0x%016llx, dev %d, adr %d}: %s.", err, eobjstr, taskid, tf.to_string().c_str(), des->code, des->par16, des->par64, des->sourcedevice, des->sourceaddress, eoerror_code2string(des->code));               
+        }
+        else if((NULL == des) && (NULL != info))
+        {
+            snprintf(text, sizeof(text), "[%s] (%s tsk%d @%s)-> {}: ... INFO = %s", err, eobjstr, taskid, tf.to_string().c_str(), info);  
+        }
+    }   
+
+    embot::core::print(text);     
+}
+
+
+static void s_manage_dispatch(const eOerrmanErrorType_t errtype, const char *info, const eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *des)
+{
+   
+    
+//#if defined(DIAGNOSTIC2_send_to_yarprobotinterface)
+
+    // old c code used so far
+    
+    // from eOerrmanErrorType_t to eOmn_info_type_t ...
+    uint8_t eee = errtype;
+    eee --;
+    eOmn_info_type_t type = (eOmn_info_type_t)eee;
+    
+    eOmn_info_source_t source = (NULL != des) ? ((eOmn_info_source_t)des->sourcedevice) : (eomn_info_source_board);
+    uint8_t  address = (NULL != des) ? (des->sourceaddress) : (0);
+    eOmn_info_extraformat_t extraformat = (NULL == info) ? (eomn_info_extraformat_none) : (eomn_info_extraformat_verbal);
+        
+    eOmn_info_properties_t props = {0};
+    props.code          = (NULL != des) ? (des->code) : (0);
+    props.par16         = (NULL != des) ? (des->par16) : (0);
+    props.par64         = (NULL != des) ? (des->par64) : (0);
+
+    EOMN_INFO_PROPERTIES_FLAGS_set_type(props.flags, type);
+    EOMN_INFO_PROPERTIES_FLAGS_set_source(props.flags, source);
+    EOMN_INFO_PROPERTIES_FLAGS_set_address(props.flags, address);
+    EOMN_INFO_PROPERTIES_FLAGS_set_extraformat(props.flags, extraformat);
+    EOMN_INFO_PROPERTIES_FLAGS_set_futureuse(props.flags, 0);
+    
+    // well, i DONT want these functions to be interrupted
+    embot::os::rtos::mutex_take(onerrormutex, embot::core::reltimeWaitForever);
+    
+    // the call eo_infodispatcher_Put() is only in here, thus we can either protect with a mutex in here or put put a mutex inside. WE USE MUTEX IN HERE
+    eo_infodispatcher_Put(eo_infodispatcher_GetHandle(), &props, info); 
+    eom_emssocket_TransmissionRequest(eom_emssocket_GetHandle());
+    
+    // the call eom_emsappl_SendTXRequest() either does nothing and is reentrant (when in run mode) or sends an event to a task with osal_eventflag_set() which is reentrant.
+    // it is called also by the can protocol parser in case of proxy, which however is used in run mode (thus reentrant).
+    // i protect both functions in here
+//    eom_emsappl_SendTXRequest(eom_emsappl_GetHandle());
+#warning add a eom_emsappl_SendTXRequest()
+    
+    embot::os::rtos::mutex_release(onerrormutex);   
+
+//#endif
+
+}
+
+static void s_manage_fatal(const char *info, const eOerrmanCaller_t *caller, const eOerrmanDescriptor_t *des)
+{
+    // manage fatal error (go in error state, start periodic tx of error status)  
+    //#warning --> marco.accame: in case of fatal error, shall we: (1) go smoothly to error state, (2) force immediate transition to error state?
+    
+    // if in here tehre is a serious error. but we dont care about concurrency
+    //osal_mutex_take(s_emsappl_singleton.onerrormutex, osal_reltimeINFINITE);    
+    
+    // i am going to error state, thus i set the correct state in eOmn_appl_status_t variable, which is used by robotInterface
+    // to understand the status of the ems: cfg, run, err.
+    eOprotID32_t id32 = eoprot_ID_get(eoprot_endpoint_management, eoprot_entity_mn_appl, 0, eoprot_tag_mn_appl_status);
+    eOmn_appl_status_t *status = (eOmn_appl_status_t*)eoprot_variable_ramof_get(eoprot_board_localboard, id32);
+    status->currstate = applstate_error;
+    
+//#if 1        
+    // this call forces immediate transition to error state. then we stop the calling task, so that 
+    // it does not do anything damaging anymore.
+    // it seems a good approach because we should immediately stop upon fatal error. 
+
+    eom_emserror_SetFatalError(eom_emserror_GetHandle(), des);
+    #warning MANAGE eom_emsappl_SM_ProcessEvent
+//    eom_emsappl_SM_ProcessEvent(eom_emsappl_GetHandle(), eo_sm_emsappl_EVgo2err);  
+    eom_task_SetEvent(eom_emserror_GetTask(eom_emserror_GetHandle()), emserror_evt_fatalerror);    
+    
+
+    // if the caller is not the error state, then we block it execution.
+    // however, we cannot block the execution of the error state otherwise ... we lose operativity
+    // of error task and amongst others we lose communication with the remote host.
+    // when we are in error state the remote host must be able to know it.
+    
+    for(;;);
+ 
+//    eOsmStatesEMSappl_t state = eo_sm_emsappl_STcfg;
+    #warning MANAGE eom_emsappl_GetCurrentState
+//    eom_emsappl_GetCurrentState(eom_emsappl_GetHandle(), &state);
+    
+//    if(eo_sm_emsappl_STerr != state)
+//    {
+//        // this call makes the calling task wait in here forever.
+//        osal_semaphore_decrement(blockingsemaphore, OSAL_reltimeINFINITE);
+//        // the forever loop should not be necessary.
+//        for(;;);
+//    }
+    
+//#else
+//    // in this situation, the transition to error state is done by the active task, thus we require that the execution
+//    // continues. the good thing is that we exit in a clean way from the state, but the high risk is to execute dangerous instructions.
+//    // example: some object inside the runner detects that some pointer that is going to be used is NULL. if we keep on running this
+//    // code, then teh NULL pointer is deferenced and teh application crashes....    
+//    eom_emsappl_ProcessGo2stateRequest(eom_emsappl_GetHandle(), eo_sm_emsappl_STerr);
+//    return;
+//#endif    
 }
 
 //void embot::app::eth::theHandler::Impl::theemssocket_defaultopen()

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer.cpp
@@ -583,10 +583,10 @@ namespace embot { namespace hw { namespace timer {
         // ok: the timer starts.
         const embot::hw::timer::PROP * stm32props = embot::hw::timer::getBSP().getPROP(t);
         TIM_HandleTypeDef* phandletimx = reinterpret_cast<TIM_HandleTypeDef*>(stm32props->handle);
+        __HAL_TIM_CLEAR_IT(phandletimx, TIM_IT_UPDATE);
         HAL_TIM_Base_Start_IT(phandletimx);
   
-        return resOK;
-        
+        return resOK;       
     } 
     
 


### PR DESCRIPTION
This PR adds diagnostics towards `yarprobotinterface` in the appl-00. 

It also fixes  the implementation of the `hw::timer` used by the `amc` board to activate the threads of `EOMtheEMSrunner` with a proper timing. The first expiry of the `hw::timer` now happens exactly after the specified timeout so the threads `RX`, `DO` and `TX` are separated by the right amount of time. The object `EOMtheEMSrunner` is also modified to allow a more powerful mode for visualizing the start / stop of its threads and of the triggering timers. This code is however enabled by specific debug macros.
 
In here the periodic scheduling of the three threads.
```
   ------------         -------           -------       ---
  | RX       <-|->     | DO  <-|->       | TX  <-|->   | RX
   ------------         -------           -------       ---  
 -----------------------------------------------------------> [us]
  |                    |               |               |
  0                    400             700             1000
  
  ^                    ^               ^               ^
  |                    |               |               |
 TIMER::one           TIMER::two      TIMER::three    TIMER::one
```
**Figure**. The three threads of `EOMtheEMSrunner` are activated by a dedicated timer each. All timers have a the same fixed period but each one is started with a specific offset. Both period and the offsets are programmable and imposed by  `yarprobotinterface`. In the above picture the period is 1000 us and the offsets are  0 us, 400 us and 700 us respectively. Note that the duration of the threads is allowed to stretch. 