### PR TITLE
Fix euler angles representation for strain2

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
@@ -37,8 +37,8 @@ static void *paramEVNT = nullptr;
 
 constexpr embot::os::theTimerManager::Config tmcfg {};
 constexpr embot::os::theCallbackManager::Config cmcfg {};
-    
-    
+
+
 static const embot::app::skeleton::os::basic::sysConfig syscfg { threadINITstacksize, paramINIT, threadIDLEstacksize, paramIDLE, paramERR, tmcfg, cmcfg};
 
 static const embot::app::skeleton::os::evthreadcan::evtConfig evtcfg { threadEVNTstacksize, paramEVNT, threadEVNTtimeout};
@@ -52,9 +52,9 @@ static const embot::app::skeleton::os::evthreadcan::canConfig cancfg { maxINPcan
 class mySYS final : public embot::app::skeleton::os::evthreadcan::SYSTEMevtcan
 {
 public:
-    mySYS(const embot::app::skeleton::os::basic::sysConfig &cfg) 
+    mySYS(const embot::app::skeleton::os::basic::sysConfig &cfg)
         : SYSTEMevtcan(cfg) {}
-        
+
     void userdefOnIdle(embot::os::Thread *t, void* idleparam) const override;
     void userdefonOSerror(void *errparam) const override;
     void userdefInit_Extra(embot::os::EventThread* evtsk, void *initparam) const override;
@@ -64,13 +64,13 @@ public:
 class myEVT final : public embot::app::skeleton::os::evthreadcan::evThreadCAN
 {
 public:
-    myEVT(const embot::app::skeleton::os::evthreadcan::evtConfig& ecfg, const embot::app::skeleton::os::evthreadcan::canConfig& ccfg, const embot::app::theCANboardInfo::applicationInfo& a) 
+    myEVT(const embot::app::skeleton::os::evthreadcan::evtConfig& ecfg, const embot::app::skeleton::os::evthreadcan::canConfig& ccfg, const embot::app::theCANboardInfo::applicationInfo& a)
         : evThreadCAN(ecfg, ccfg, a) {}
-        
+
     void userdefStartup(embot::os::Thread *t, void *param) const override;
     void userdefOnTimeout(embot::os::Thread *t, embot::os::EventMask eventmask, void *param) const override;
     void userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::prot::can::Frame &frame, std::vector<embot::prot::can::Frame> &outframes) const override;
-    void userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const override;                   
+    void userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const override;
 };
 
 
@@ -81,9 +81,9 @@ constexpr embot::app::skeleton::os::evthreadcan::CFG cfg{ &mysys, &myevt };
 // --------------------------------------------------------------------------------------------------------------------
 
 int main(void)
-{ 
+{
     embot::app::skeleton::os::evthreadcan::run(cfg);
-    for(;;);    
+    for(;;);
 }
 
 
@@ -94,13 +94,13 @@ int main(void)
 #include "embot_hw_bno055.h"
 
 namespace embot { namespace hw { namespace bsp { namespace mtb4 {
-        
+
     constexpr embot::hw::SI7051 thermometer = embot::hw::SI7051::one;
     constexpr embot::hw::si7051::Config thermometerconfig = {};
-   
+
     constexpr embot::hw::BNO055 imuBOSCH = embot::hw::BNO055::one;
-    constexpr embot::hw::bno055::Config imuBOSCHconfig = {};   
-             
+    constexpr embot::hw::bno055::Config imuBOSCHconfig = {};
+
 }}}} // namespace embot { namespace hw { namespace bsp { namespace mtb4 {
 
 #include "embot_os_theScheduler.h"
@@ -123,42 +123,42 @@ constexpr embot::os::Event evTHERMOdataready = 0x00000001 << 6;
 void mySYS::userdefOnIdle(embot::os::Thread *t, void* idleparam) const
 {
     static int a = 0;
-    a++;        
+    a++;
 }
 
 void mySYS::userdefonOSerror(void *errparam) const
 {
     static int code = 0;
     embot::os::theScheduler::getInstance().getOSerror(code);
-    for(;;);    
+    for(;;);
 }
 
 
 void mySYS::userdefInit_Extra(embot::os::EventThread* evtsk, void *initparam) const
 {
-    // inside the init thread: put the init of many things ...  
-    
+    // inside the init thread: put the init of many things ...
+
     // led manager
-    static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};  
-    embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();     
-    theleds.init(allleds);    
-    theleds.get(embot::hw::LED::one).pulse(embot::core::time1second); 
+    static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};
+    embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();
+    theleds.init(allleds);
+    theleds.get(embot::hw::LED::one).pulse(embot::core::time1second);
 
     // init of can basic paser
     embot::app::application::theCANparserBasic::getInstance().initialise({});
-        
-    // init agent of skin 
+
+    // init agent of skin
     embot::app::application::theSkin &theskin = embot::app::application::theSkin::getInstance();
     embot::app::application::theSkin::Config configskin;
     configskin.tickevent = evSKINprocess;
     configskin.totask = evtsk;
-    theskin.initialise(configskin);   
-    
+    theskin.initialise(configskin);
+
     // init canparser skin and link it to its agent
     embot::app::application::theCANparserSkin &canparserskin = embot::app::application::theCANparserSkin::getInstance();
     embot::app::application::theCANparserSkin::Config configparserskin { &theskin };
-    canparserskin.initialise(configparserskin);  
-                   
+    canparserskin.initialise(configparserskin);
+
     // init agent of imu
     embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
     embot::app::application::theIMU::Config configimu(embot::hw::bsp::mtb4::imuBOSCH, embot::hw::bsp::mtb4::imuBOSCHconfig, evIMUtick, evIMUdataready, evtsk);
@@ -167,48 +167,48 @@ void mySYS::userdefInit_Extra(embot::os::EventThread* evtsk, void *initparam) co
     // init canparser imu and link it to its agent
     embot::app::application::theCANparserIMU &canparserimu = embot::app::application::theCANparserIMU::getInstance();
     embot::app::application::theCANparserIMU::Config configparserimu { &theimu };
-    canparserimu.initialise(configparserimu);   
-    
+    canparserimu.initialise(configparserimu);
+
     // init agent of thermo
     embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
     embot::app::application::theTHERMO::Config configthermo(embot::hw::bsp::mtb4::thermometer, embot::hw::bsp::mtb4::thermometerconfig, evTHERMOtick, evTHERMOdataready, evtsk);
-    thethermo.initialise(configthermo);  
+    thethermo.initialise(configthermo);
 
     // init canparser thermo and link it to its agent
     embot::app::application::theCANparserTHERMO &canparserthermo = embot::app::application::theCANparserTHERMO::getInstance();
     embot::app::application::theCANparserTHERMO::Config configparserthermo { &thethermo };
-    canparserthermo.initialise(configparserthermo);       
-        
+    canparserthermo.initialise(configparserthermo);
+
 }
 
 void myEVT::userdefStartup(embot::os::Thread *t, void *param) const
 {
-    // inside startup of evnt thread: put the init of many things ...     
+    // inside startup of evnt thread: put the init of many things ...
 }
 
 
 void myEVT::userdefOnTimeout(embot::os::Thread *t, embot::os::EventMask eventmask, void *param) const
 {
     static uint32_t cnt = 0;
-    cnt++;    
+    cnt++;
 }
 
 
 void myEVT::userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::prot::can::Frame &frame, std::vector<embot::prot::can::Frame> &outframes) const
-{        
+{
     // process w/ the basic parser. if not recognised call the parsers specific of the board
     if(true == embot::app::application::theCANparserBasic::getInstance().process(frame, outframes))
-    {                   
+    {
     }
     if(true == embot::app::application::theCANparserSkin::getInstance().process(frame, outframes))
-    {               
+    {
     }
     else if(true == embot::app::application::theCANparserIMU::getInstance().process(frame, outframes))
-    {               
+    {
     }
     else if(true == embot::app::application::theCANparserTHERMO::getInstance().process(frame, outframes))
-    {               
-    }   
+    {
+    }
 }
 
 void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const
@@ -217,40 +217,40 @@ void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask ev
     {
         embot::app::application::theSkin &theskin = embot::app::application::theSkin::getInstance();
         theskin.tick(outframes);
-        
+
         // we operate on the skin triangles by calling a skin.tick(outframes);
         // the evSKINprocess is emitted  by:
         // 1. a periodic timer started at the reception of a specific message.
 
 
-        // the .tick(outframes) will do whatever it needs to do and it may emit some 
+        // the .tick(outframes) will do whatever it needs to do and it may emit some
         // can frames for transmission. the can frames can be up to 16x2 = 32.
         // hence, how many packets? max of replies = 8 + max of broadcast = 32 --> 40.
-        
+
     }
-        
+
     if(true == embot::core::binary::mask::check(eventmask, evIMUtick))
-    {        
+    {
         embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
-        theimu.tick(outframes);        
-    }   
-    
+        theimu.tick(outframes);
+    }
+
     if(true == embot::core::binary::mask::check(eventmask, evIMUdataready))
-    {        
+    {
         embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
-        theimu.processdata(outframes);        
-    }    
+        theimu.processdata(outframes);
+    }
 
     if(true == embot::core::binary::mask::check(eventmask, evTHERMOtick))
-    {        
+    {
         embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
-        thethermo.tick(outframes);        
-    }   
-    
+        thethermo.tick(outframes);
+    }
+
     if(true == embot::core::binary::mask::check(eventmask, evTHERMOdataready))
-    {        
+    {
         embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
-        thethermo.processdata(outframes);        
+        thethermo.processdata(outframes);
     }
 }
 
@@ -260,10 +260,10 @@ void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask ev
 #if defined(CUSTOMIZATION_MTB4_FOR_TLR)
     #warning CUSTOMIZATION_MTB4_FOR_TLR is active: see what changes it takes
     // the TLR customization changes the IDs of the CAN frames emitted periodically to broadcast the 12 values of the skin taxel so that:
-    // - the first frame has unchanged ID formed by the following three nibbles [cls | adr | trg] 
+    // - the first frame has unchanged ID formed by the following three nibbles [cls | adr | trg]
     //   with cls = 4 = embot::protocol::can::Cls::periodicSkin, adr = address of transmitting mtb4 board, trg = number of the triangle.
     // - the second frame has an ID different from standard protocol because the value of cls is now = 6 = embot::protocol::can::Cls::periodicForFutureUse
-    // it also has a embot::prot::can::versionOfCANPROTOCOL {20, 0} 
+    // it also has a embot::prot::can::versionOfCANPROTOCOL {20, 0}
 #endif
 
 

--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
@@ -12,15 +12,15 @@
 // --------------------------------------------------------------------------------------------------------------------
 // config start
 
-constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
+constexpr embot::app::theCANboardInfo::applicationInfo applInfo
 {
-#if defined(CUSTOMIZATION_MTB4_FOR_TLR) 
-    embot::prot::can::versionOfAPPLICATION {20, 4, 5},    
-    embot::prot::can::versionOfCANPROTOCOL {20, 0} 
-#else    
-    embot::prot::can::versionOfAPPLICATION {1, 4, 6},    
-    embot::prot::can::versionOfCANPROTOCOL {2, 0} 
-#endif    
+#if defined(CUSTOMIZATION_MTB4_FOR_TLR)
+    embot::prot::can::versionOfAPPLICATION {20, 4, 5},
+    embot::prot::can::versionOfCANPROTOCOL {20, 0}
+#else
+    embot::prot::can::versionOfAPPLICATION {1, 4, 7},
+    embot::prot::can::versionOfCANPROTOCOL {2, 0}
+#endif
 };
 
 constexpr std::uint16_t threadIDLEstacksize = 512;

--- a/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
@@ -42,8 +42,8 @@ static void *paramEVNT = nullptr;
 
 constexpr embot::os::theTimerManager::Config tmcfg {};
 constexpr embot::os::theCallbackManager::Config cmcfg {};
-    
-    
+
+
 static const embot::app::skeleton::os::basic::sysConfig syscfg { threadINITstacksize, paramINIT, threadIDLEstacksize, paramIDLE, paramERR, tmcfg, cmcfg};
 
 static const embot::app::skeleton::os::evthreadcan::evtConfig evtcfg { threadEVNTstacksize, paramEVNT, threadEVNTtimeout};
@@ -57,9 +57,9 @@ static const embot::app::skeleton::os::evthreadcan::canConfig cancfg { maxINPcan
 class mySYS final : public embot::app::skeleton::os::evthreadcan::SYSTEMevtcan
 {
 public:
-    mySYS(const embot::app::skeleton::os::basic::sysConfig &cfg) 
+    mySYS(const embot::app::skeleton::os::basic::sysConfig &cfg)
         : SYSTEMevtcan(cfg) {}
-        
+
     void userdefOnIdle(embot::os::Thread *t, void* idleparam) const override;
     void userdefonOSerror(void *errparam) const override;
     void userdefInit_Extra(embot::os::EventThread* evtsk, void *initparam) const override;
@@ -69,13 +69,13 @@ public:
 class myEVT final : public embot::app::skeleton::os::evthreadcan::evThreadCAN
 {
 public:
-    myEVT(const embot::app::skeleton::os::evthreadcan::evtConfig& ecfg, const embot::app::skeleton::os::evthreadcan::canConfig& ccfg, const embot::app::theCANboardInfo::applicationInfo& a) 
+    myEVT(const embot::app::skeleton::os::evthreadcan::evtConfig& ecfg, const embot::app::skeleton::os::evthreadcan::canConfig& ccfg, const embot::app::theCANboardInfo::applicationInfo& a)
         : evThreadCAN(ecfg, ccfg, a) {}
-        
+
     void userdefStartup(embot::os::Thread *t, void *param) const override;
     void userdefOnTimeout(embot::os::Thread *t, embot::os::EventMask eventmask, void *param) const override;
     void userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::prot::can::Frame &frame, std::vector<embot::prot::can::Frame> &outframes) const override;
-    void userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const override;                   
+    void userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const override;
 };
 
 
@@ -86,9 +86,9 @@ constexpr embot::app::skeleton::os::evthreadcan::CFG cfg{ &mysys, &myevt };
 // --------------------------------------------------------------------------------------------------------------------
 
 int main(void)
-{ 
+{
     embot::app::skeleton::os::evthreadcan::run(cfg);
-    for(;;);    
+    for(;;);
 }
 
 
@@ -108,11 +108,11 @@ int main(void)
 
 #include "embot_app_application_theCANtracer.h"
 
-namespace embot { namespace hw { namespace bsp { namespace rfe {    
-    const embot::hw::LED ledBLUE = embot::hw::LED::one;    
-    //const embot::hw::i2c::Descriptor descrI2Cone = embot::hw::i2c::Descriptor(embot::hw::I2C::one, 400000);    
+namespace embot { namespace hw { namespace bsp { namespace rfe {
+    const embot::hw::LED ledBLUE = embot::hw::LED::one;
+    //const embot::hw::i2c::Descriptor descrI2Cone = embot::hw::i2c::Descriptor(embot::hw::I2C::one, 400000);
     const embot::hw::BNO055 imuBOSCH = embot::hw::BNO055::one;
-    const embot::hw::bno055::Config imuBOSCHconfig = {};        
+    const embot::hw::bno055::Config imuBOSCHconfig = {};
 }}}} // namespace embot { namespace hw { namespace bsp { namespace rfe {
 
 
@@ -135,7 +135,7 @@ RfeApp::FaceExpressions faceExpressions;
 //    float               avg_f;
 //    embot::core::Time min;
 //    embot::core::Time max;
-//    
+//
 //    Average_t() : sum(0), count(0), avg(0), avg_f(0.0), min(3000000), max(0){;}
 //    void calculate(void){avg=sum/count;avg_f=sum/static_cast<float>(count);}
 //    void set(embot::core::Time val)
@@ -157,31 +157,31 @@ RfeApp::FaceExpressions faceExpressions;
 void mySYS::userdefOnIdle(embot::os::Thread *t, void* idleparam) const
 {
     static int a = 0;
-    a++;   
+    a++;
 }
 
 void mySYS::userdefonOSerror(void *errparam) const
 {
     static int code = 0;
     embot::os::theScheduler::getInstance().getOSerror(code);
-    for(;;);    
+    for(;;);
 }
 
 
 void mySYS::userdefInit_Extra(embot::os::EventThread* evtsk, void *initparam) const
 {
-    // inside the init thread: put the init of many things ...  
-    
+    // inside the init thread: put the init of many things ...
+
     // led manager
-    static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};  
-    embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();     
-    theleds.init(allleds);    
-    theleds.get(embot::hw::LED::one).pulse(embot::core::time1second); 
+    static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};
+    embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();
+    theleds.init(allleds);
+    theleds.get(embot::hw::LED::one).pulse(embot::core::time1second);
 
     // init of can basic paser
     embot::app::application::theCANparserBasic::getInstance().initialise({});
-        
-                   
+
+
     // init agent of imu
     embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
     embot::app::application::theIMU::Config configimu(embot::hw::bsp::rfe::imuBOSCH, embot::hw::bsp::rfe::imuBOSCHconfig, evIMUtick, evIMUdataready, evtsk);
@@ -190,8 +190,8 @@ void mySYS::userdefInit_Extra(embot::os::EventThread* evtsk, void *initparam) co
     // init canparser imu and link it to its agent
     embot::app::application::theCANparserIMU &canparserimu = embot::app::application::theCANparserIMU::getInstance();
     embot::app::application::theCANparserIMU::Config configparserimu { &theimu };
-    canparserimu.initialise(configparserimu);   
-    
+    canparserimu.initialise(configparserimu);
+
 }
 
 static void alerteventbasedthreadusb(void *arg)
@@ -200,20 +200,20 @@ static void alerteventbasedthreadusb(void *arg)
     if(nullptr != evtsk)
     {
         evtsk->setEvent(evRXusbmessage);
-    }       
+    }
 }
 
 
 void myEVT::userdefStartup(embot::os::Thread *t, void *param) const
 {
-    // inside startup of evnt thread: put the init of many things ... 
+    // inside startup of evnt thread: put the init of many things ...
 
     embot::hw::usb::Config config;
     config.rxcapacity = 16;
-    config.onrxmessage = embot::core::Callback(alerteventbasedthreadusb, t); 
+    config.onrxmessage = embot::core::Callback(alerteventbasedthreadusb, t);
     embot::hw::usb::init(embot::hw::usb::Port::one, config);
-    
-    faceExpressions.init(RfeApp::Expression_t::neutral, RfeApp::Color::white, RfeApp::Brightness::medium);    
+
+    faceExpressions.init(RfeApp::Expression_t::neutral, RfeApp::Color::white, RfeApp::Brightness::medium);
 }
 
 
@@ -221,39 +221,39 @@ void myEVT::userdefStartup(embot::os::Thread *t, void *param) const
 void myEVT::userdefOnTimeout(embot::os::Thread *t, embot::os::EventMask eventmask, void *param) const
 {
     static uint32_t cnt = 0;
-    cnt++; 
-    
+    cnt++;
+
 #if defined(DO_TEST)
     test(cnt);
-#endif  
+#endif
 
 }
 
 
 void myEVT::userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::prot::can::Frame &frame, std::vector<embot::prot::can::Frame> &outframes) const
-{        
+{
     // process w/ the basic parser. if not recognised call the parsers specific of the board
     if(true == embot::app::application::theCANparserBasic::getInstance().process(frame, outframes))
-    {                   
+    {
     }
     else if(true == embot::app::application::theCANparserIMU::getInstance().process(frame, outframes))
-    {               
+    {
     }
- 
+
 }
 
 void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const
-{ 
+{
     if(true == embot::core::binary::mask::check(eventmask, evRXusbmessage))
-    {        
+    {
         embot::hw::usb::Message msg;
         std::uint8_t remainingINrx = 0;
         if(embot::hw::resOK == embot::hw::usb::get(embot::hw::usb::Port::one, msg, remainingINrx))
-        {   
+        {
             faceExpressions.processcommands(msg.data, msg.size);
             faceExpressions.displayExpression();
-#undef RFE_SEND_CANPRINT            
-#if defined(RFE_SEND_CANPRINT)                        
+#undef RFE_SEND_CANPRINT
+#if defined(RFE_SEND_CANPRINT)
             RfeApp::Error errorvalue = faceExpressions.getError();
             if(RfeApp::Error::none != errorvalue)
             {
@@ -265,29 +265,29 @@ void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask ev
                 else if(RfeApp::Error::SPIfailure == errorvalue)
                 {
                     tracer.print("RFE spi fail", outframes);
-                }              
+                }
             }
-#endif            
-            
+#endif
+
             if(remainingINrx > 0)
             {
-                t->setEvent(evRXusbmessage);                 
+                t->setEvent(evRXusbmessage);
             }
 
-        }        
+        }
     }
-    
-    
+
+
     if(true == embot::core::binary::mask::check(eventmask, evIMUtick))
-    {        
+    {
         embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
-        theimu.tick(outframes);        
-    }   
-    
+        theimu.tick(outframes);
+    }
+
     if(true == embot::core::binary::mask::check(eventmask, evIMUdataready))
-    {        
+    {
         embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
-        theimu.processdata(outframes);        
+        theimu.processdata(outframes);
     }
 
 }
@@ -296,10 +296,10 @@ void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask ev
 
 #if defined(DO_TEST)
 
-static uint8_t bufferZbe[] =  // i use big endianess for words 
+static uint8_t bufferZbe[] =  // i use big endianess for words
 {
     'Z',
-    // left 
+    // left
     '0', '2', // red
     '0', '4', // high
     '0', '0', '0', '1', '1', '1', '1', '1', // top line 0x00011111
@@ -307,17 +307,17 @@ static uint8_t bufferZbe[] =  // i use big endianess for words
     '0', 'D', // purple
     '0', '4', // high
     '0', '0', '0', '1', '1', '1', '1', '1', // top line (be)
-    // mouth    
+    // mouth
     '0', '1', // white
     '0', '4', // high
     '0', '0', '0', '4', '5', '6', '4', '5' // happy (be)
 };
 
 
-static uint8_t bufferZle[] =  // i use little endianess for words 
+static uint8_t bufferZle[] =  // i use little endianess for words
 {
     'Z',
-    // left 
+    // left
     '0', '2', // red
     '0', '4', // high
     '1', '1', '1', '1', '0', '1', '0', '0', // top line (le)
@@ -325,51 +325,51 @@ static uint8_t bufferZle[] =  // i use little endianess for words
     '0', 'D', // purple
     '0', '4', // high
     '1', '1', '1', '1', '0', '1', '0', '0', // top line (le)
-    // mouth    
+    // mouth
     '0', '1', // white
     '0', '4', // high
     '4', '5', '5', '6', '0', '4', '0', '0' // happy (le)
 };
 
-static uint8_t bufferB[] =  // i use ... 
+static uint8_t bufferB[] =  // i use ...
 {
     'B',
     '0', '1'
 };
 
-static uint8_t bufferE[] =  // all parte have expression 
+static uint8_t bufferE[] =  // all parte have expression
 {
     'E',
     '0', '2' // sad
 };
 
-static uint8_t bufferECBm[] =  // all parte have expression 
+static uint8_t bufferECBm[] =  // all parte have expression
 {
     'E',    // expression for all
     '0', '2', // sad
-    ' ', // separator 
+    ' ', // separator
     'C',    // color for all
     '0', '4', // blue
-    ',', // separator 
+    ',', // separator
     'B',    // brightness for all
     '0', '2', // low
-    ' ', // separator 
-    'm',      // mouth multiple 
+    ' ', // separator
+    'm',      // mouth multiple
     '0', '3', // suprised
     '0', '2', // red
-    '0', '5', // maximum   
-    ' ', // separator 
-    'l',      // left multiple 
+    '0', '5', // maximum
+    ' ', // separator
+    'l',      // left multiple
     '0', '0', // neutral
     '0', '2', // red
-    '0', '5', // maximum      
-    ' ', // separator 
-    'a',      // all multiple 
+    '0', '5', // maximum
+    ' ', // separator
+    'a',      // all multiple
     '0', '0', // neutral
     '0', '1', // white
-    '0', '5', // max 
-    's', 2, 3, 5    
-    
+    '0', '5', // max
+    's', 2, 3, 5
+
 };
 
 static uint8_t *buffer = bufferZbe;
@@ -386,16 +386,16 @@ void test(uint32_t cnt)
     volatile RfeApp::Brightness br = RfeApp::tobrightness(cnt%RfeApp::brightnessMaxNum);
    // RfeApp::PartProps pp { RfeApp::Color::purple, br, picture };
     //faceExpressions.display(RfeApp::FacePart_t::all, pp);
-    
+
     //faceExpressions.display(RfeApp::FacePart_t::all, RfeApp::Expression_t::evil, RfeApp::Color::purple, br);
 //    std::array<RfeApp::Color, 3> cols { RfeApp::Color::purple,  RfeApp::Color::purple,  RfeApp::Color::red };
 //    faceExpressions.display(RfeApp::Expression_t::evil, cols, br);
-    
+
     faceExpressions.processcommands(buffer, sizeofbuffer, false);
     faceExpressions.displayExpression();
 }
 
 #endif // #if defined(DO_TEST)
-   
+
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------
 

--- a/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
+++ b/emBODY/eBcode/arch-arm/board/rfe/application/src/rfe-application-main-template.cpp
@@ -22,10 +22,10 @@ constexpr uint32_t numMilli = 50;
 // --------------------------------------------------------------------------------------------------------------------
 // config start
 
-constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
-{ 
-    embot::prot::can::versionOfAPPLICATION {1, 2, 2},    
-    embot::prot::can::versionOfCANPROTOCOL {2, 0}    
+constexpr embot::app::theCANboardInfo::applicationInfo applInfo
+{
+    embot::prot::can::versionOfAPPLICATION {1, 2, 3},
+    embot::prot::can::versionOfCANPROTOCOL {2, 0}
 };
 
 constexpr std::uint16_t threadIDLEstacksize = 512;

--- a/emBODY/eBcode/arch-arm/board/strain2/application/src/main-strain2-application.cpp
+++ b/emBODY/eBcode/arch-arm/board/strain2/application/src/main-strain2-application.cpp
@@ -11,10 +11,10 @@
 // --------------------------------------------------------------------------------------------------------------------
 // config start
 
-constexpr embot::app::theCANboardInfo::applicationInfo applInfo 
-{ 
-    embot::prot::can::versionOfAPPLICATION {2, 0, 14},
-    embot::prot::can::versionOfCANPROTOCOL {2, 0}    
+constexpr embot::app::theCANboardInfo::applicationInfo applInfo
+{
+    embot::prot::can::versionOfAPPLICATION {2, 0, 15},
+    embot::prot::can::versionOfCANPROTOCOL {2, 0}
 };
 
 constexpr std::uint16_t threadIDLEstacksize = 1*512;

--- a/emBODY/eBcode/arch-arm/board/strain2/application/src/main-strain2-application.cpp
+++ b/emBODY/eBcode/arch-arm/board/strain2/application/src/main-strain2-application.cpp
@@ -31,8 +31,8 @@ static void *paramEVNT = nullptr;
 
 constexpr embot::os::theTimerManager::Config tmcfg {};
 constexpr embot::os::theCallbackManager::Config cmcfg {};
-    
-    
+
+
 static const embot::app::skeleton::os::basic::sysConfig syscfg { threadINITstacksize, paramINIT, threadIDLEstacksize, paramIDLE, paramERR, tmcfg, cmcfg};
 
 static const embot::app::skeleton::os::evthreadcan::evtConfig evtcfg { threadEVNTstacksize, paramEVNT, threadEVNTtimeout};
@@ -46,9 +46,9 @@ static const embot::app::skeleton::os::evthreadcan::canConfig cancfg { maxINPcan
 class mySYS final : public embot::app::skeleton::os::evthreadcan::SYSTEMevtcan
 {
 public:
-    mySYS(const embot::app::skeleton::os::basic::sysConfig &cfg) 
+    mySYS(const embot::app::skeleton::os::basic::sysConfig &cfg)
         : SYSTEMevtcan(cfg) {}
-        
+
     void userdefOnIdle(embot::os::Thread *t, void* idleparam) const override;
     void userdefonOSerror(void *errparam) const override;
     void userdefInit_Extra(embot::os::EventThread* evthr, void *initparam) const override;
@@ -58,13 +58,13 @@ public:
 class myEVT final : public embot::app::skeleton::os::evthreadcan::evThreadCAN
 {
 public:
-    myEVT(const embot::app::skeleton::os::evthreadcan::evtConfig& ecfg, const embot::app::skeleton::os::evthreadcan::canConfig& ccfg, const embot::app::theCANboardInfo::applicationInfo& a) 
+    myEVT(const embot::app::skeleton::os::evthreadcan::evtConfig& ecfg, const embot::app::skeleton::os::evthreadcan::canConfig& ccfg, const embot::app::theCANboardInfo::applicationInfo& a)
         : evThreadCAN(ecfg, ccfg, a) {}
-        
+
     void userdefStartup(embot::os::Thread *t, void *param) const override;
     void userdefOnTimeout(embot::os::Thread *t, embot::os::EventMask eventmask, void *param) const override;
     void userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::prot::can::Frame &frame, std::vector<embot::prot::can::Frame> &outframes) const override;
-    void userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const override;                   
+    void userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const override;
 };
 
 
@@ -75,9 +75,9 @@ constexpr embot::app::skeleton::os::evthreadcan::CFG cfg{ &mysys, &myevt };
 // --------------------------------------------------------------------------------------------------------------------
 
 int main(void)
-{ 
+{
     embot::app::skeleton::os::evthreadcan::run(cfg);
-    for(;;);    
+    for(;;);
 }
 
 
@@ -96,11 +96,11 @@ int main(void)
 #include "embot_hw_pga308.h"
 
 namespace embot { namespace hw { namespace bsp { namespace strain2 {
-    const embot::hw::LED ledBLUE = embot::hw::LED::one;      
+    const embot::hw::LED ledBLUE = embot::hw::LED::one;
     const embot::hw::SI7051 thermometerSGAUGES = embot::hw::SI7051::one;
-    const embot::hw::si7051::Config thermometerSGAUGESconfig {};    
+    const embot::hw::si7051::Config thermometerSGAUGESconfig {};
     const embot::hw::BNO055 imuBOSCH = embot::hw::BNO055::one;
-    const embot::hw::bno055::Config imuBOSCHconfig {};         
+    const embot::hw::bno055::Config imuBOSCHconfig {};
 }}}} // namespace embot { namespace hw { namespace bsp { namespace strain2 {
 
 #include "embot_os_theScheduler.h"
@@ -134,40 +134,40 @@ static void ihavejuststarted_tick(std::vector<embot::prot::can::Frame> &outframe
 void mySYS::userdefOnIdle(embot::os::Thread *t, void* idleparam) const
 {
     static int a = 0;
-    a++;        
+    a++;
 }
 
 void mySYS::userdefonOSerror(void *errparam) const
 {
     static int code = 0;
     embot::os::theScheduler::getInstance().getOSerror(code);
-    for(;;);    
+    for(;;);
 }
 
 
 void mySYS::userdefInit_Extra(embot::os::EventThread* evthr, void *initparam) const
 {
-    // inside the init thread: put the init of many things ...  
-    
+    // inside the init thread: put the init of many things ...
+
     // led manager
-    static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};  
-    embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();     
-    theleds.init(allleds);    
-    theleds.get(embot::hw::LED::one).pulse(embot::core::time1second); 
+    static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};
+    embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();
+    theleds.init(allleds);
+    theleds.get(embot::hw::LED::one).pulse(embot::core::time1second);
 
     // init of can basic paser
     embot::app::application::theCANparserBasic::getInstance().initialise({});
-        
+
     // init agent of strain
     embot::app::application::theSTRAIN &thestrain = embot::app::application::theSTRAIN::getInstance();
     embot::app::application::theSTRAIN::Config configstrain(evSTRAINtick, evSTRAINdataready, evthr);
-    thestrain.initialise(configstrain); 
-    
+    thestrain.initialise(configstrain);
+
     // init canparser strain and link it to its agent
     embot::app::application::theCANparserSTRAIN &canparserstrain = embot::app::application::theCANparserSTRAIN::getInstance();
     embot::app::application::theCANparserSTRAIN::Config configparserstrain { &thestrain };
-    canparserstrain.initialise(configparserstrain);  
-                   
+    canparserstrain.initialise(configparserstrain);
+
     // init agent of imu
     embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
     embot::app::application::theIMU::Config configimu(embot::hw::bsp::strain2::imuBOSCH, embot::hw::bsp::strain2::imuBOSCHconfig, evIMUtick, evIMUdataready, evthr);
@@ -176,106 +176,106 @@ void mySYS::userdefInit_Extra(embot::os::EventThread* evthr, void *initparam) co
     // init canparser imu and link it to its agent
     embot::app::application::theCANparserIMU &canparserimu = embot::app::application::theCANparserIMU::getInstance();
     embot::app::application::theCANparserIMU::Config configparserimu { &theimu };
-    canparserimu.initialise(configparserimu);   
-    
+    canparserimu.initialise(configparserimu);
+
     // init agent of thermo
     embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
     embot::app::application::theTHERMO::Config configthermo(embot::hw::bsp::strain2::thermometerSGAUGES, embot::hw::bsp::strain2::thermometerSGAUGESconfig, evTHERMOtick, evTHERMOdataready, evthr);
-    thethermo.initialise(configthermo);  
+    thethermo.initialise(configthermo);
 
     // init canparser thermo and link it to its agent
     embot::app::application::theCANparserTHERMO &canparserthermo = embot::app::application::theCANparserTHERMO::getInstance();
     embot::app::application::theCANparserTHERMO::Config configparserthermo { &thethermo };
-    canparserthermo.initialise(configparserthermo);       
-        
+    canparserthermo.initialise(configparserthermo);
+
 #if defined(ENABLE_IHAVEJUSTSTARTED)
     // init service IHaveJustStarted
-    ihavejuststarted_init(evthr); 
-#endif       
+    ihavejuststarted_init(evthr);
+#endif
 }
 
 void myEVT::userdefStartup(embot::os::Thread *t, void *param) const
 {
-    // inside startup of evnt thread: put the init of many things ... 
- 
+    // inside startup of evnt thread: put the init of many things ...
+
     // maybe we start the tx of ft data straight away
 #if defined(DEBUG_atstartup_tx_FTdata)
     embot::app::application::theSTRAIN &thestrain = embot::app::application::theSTRAIN::getInstance();
     thestrain.setTXperiod(10*embot::core::time1millisec);
     thestrain.start(embot::prot::can::analog::polling::Message_SET_TXMODE::StrainMode::txUncalibrated);
-#endif      
+#endif
 }
 
 
 void myEVT::userdefOnTimeout(embot::os::Thread *t, embot::os::EventMask eventmask, void *param) const
 {
     static uint32_t cnt = 0;
-    cnt++;    
+    cnt++;
 }
 
 
 void myEVT::userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::prot::can::Frame &frame, std::vector<embot::prot::can::Frame> &outframes) const
-{        
+{
     // process w/ the basic parser. if not recognised call the parsers specific of the board
     if(true == embot::app::application::theCANparserBasic::getInstance().process(frame, outframes))
-    {                   
+    {
     }
     if(true == embot::app::application::theCANparserSTRAIN::getInstance().process(frame, outframes))
-    {               
+    {
     }
     else if(true == embot::app::application::theCANparserIMU::getInstance().process(frame, outframes))
-    {               
+    {
     }
     else if(true == embot::app::application::theCANparserTHERMO::getInstance().process(frame, outframes))
-    {               
-    }   
+    {
+    }
 }
 
 void myEVT::userdefOnEventANYother(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, std::vector<embot::prot::can::Frame> &outframes) const
 {
     if(true == embot::core::binary::mask::check(eventmask, evSTRAINtick))
-    {        
+    {
         embot::app::application::theSTRAIN &thestrain = embot::app::application::theSTRAIN::getInstance();
-        thestrain.tick(outframes);        
+        thestrain.tick(outframes);
     }
-            
-    if(true == embot::core::binary::mask::check(eventmask, evSTRAINdataready))
-    {        
-        embot::app::application::theSTRAIN &thestrain = embot::app::application::theSTRAIN::getInstance();
-        thestrain.processdata(outframes);        
-    }
-    
-    if(true == embot::core::binary::mask::check(eventmask, evIMUtick))
-    {        
-        embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
-        theimu.tick(outframes);        
-    }   
-    
-    if(true == embot::core::binary::mask::check(eventmask, evIMUdataready))
-    {        
-        embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
-        theimu.processdata(outframes);        
-    }
-     
-    if(true == embot::core::binary::mask::check(eventmask, evTHERMOtick))
-    {        
-        embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
-        thethermo.tick(outframes);        
-    }   
-    
-    if(true == embot::core::binary::mask::check(eventmask, evTHERMOdataready))
-    {        
-        embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
-        thethermo.processdata(outframes);        
-    }  
 
-#if defined(ENABLE_IHAVEJUSTSTARTED)    
+    if(true == embot::core::binary::mask::check(eventmask, evSTRAINdataready))
+    {
+        embot::app::application::theSTRAIN &thestrain = embot::app::application::theSTRAIN::getInstance();
+        thestrain.processdata(outframes);
+    }
+
+    if(true == embot::core::binary::mask::check(eventmask, evIMUtick))
+    {
+        embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
+        theimu.tick(outframes);
+    }
+
+    if(true == embot::core::binary::mask::check(eventmask, evIMUdataready))
+    {
+        embot::app::application::theIMU &theimu = embot::app::application::theIMU::getInstance();
+        theimu.processdata(outframes);
+    }
+
+    if(true == embot::core::binary::mask::check(eventmask, evTHERMOtick))
+    {
+        embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
+        thethermo.tick(outframes);
+    }
+
+    if(true == embot::core::binary::mask::check(eventmask, evTHERMOdataready))
+    {
+        embot::app::application::theTHERMO &thethermo = embot::app::application::theTHERMO::getInstance();
+        thethermo.processdata(outframes);
+    }
+
+#if defined(ENABLE_IHAVEJUSTSTARTED)
     if(true == embot::core::binary::mask::check(eventmask, evIHAVEjuststarted))
-    {        
+    {
         ihavejuststarted_tick(outframes);
-    } 
-#endif 
-    
+    }
+#endif
+
 }
 
 
@@ -303,10 +303,10 @@ static void ihavejuststarted_tick(std::vector<embot::prot::can::Frame> &outframe
     uint32_t mm = tt /= 1000;
     uint32_t s = mm/1000;
     uint32_t m = mm - s*1000;
-    
+
     snprintf(ss, sizeof(ss), "i woke up %ds%dm ago", s, m);
     embot::app::theCANtracer &tracer = embot::app::theCANtracer::getInstance();
-    tracer.print(ss, outframes);        
+    tracer.print(ss, outframes);
 }
 
 #endif // #if defined(ENABLE_IHAVEJUSTSTARTED)

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
@@ -431,12 +431,19 @@ bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot:
         {
             // generate a eul message with canrevisitedconfig.counter
             info.sensor = embot::prot::can::analog::imuSensor::eul;
+            // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue:
+            // https://github.com/icub-tech-iit/fix/issues/780 + https://github.com/icub-tech-iit/task-force-miscellanea/issues/126
+        #if defined(STM32HAL_BOARD_STRAIN2)
+            info.value.x = -imuacquisition.data.eul.z;
+            info.value.y = imuacquisition.data.eul.x;
+            info.value.z = -imuacquisition.data.eul.y;
+        #else
             // The Bosch euler representation can be either the windows(default) or android, but in YARP
             // we have a different representation(see https://github.com/robotology/yarp/blob/0481f994c6e03897d038c5f1d1078145646a1772/src/libYARP_dev/src/yarp/dev/MultipleAnalogSensorsInterfaces.h#L302-L348)
             info.value.x = imuacquisition.data.eul.z;
             info.value.y = -imuacquisition.data.eul.y;
             info.value.z = imuacquisition.data.eul.x;
-
+        #endif
             msg.load(info);
             msg.get(frame);
             replies.push_back(frame);               

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
@@ -219,7 +219,7 @@ bool embot::app::application::theIMU::Impl::fill(embot::prot::can::inertial::per
 
     info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
 
-    
+
     info.x = imuacquisition.data.acc.x;
     info.y = imuacquisition.data.acc.y;
     info.z = imuacquisition.data.acc.z;
@@ -528,7 +528,7 @@ bool embot::app::application::theIMU::initialise(Config &config)
     embot::hw::bno055::write(pImpl->config.sensor, embot::hw::bno055::Register::AXIS_MAP_SIGN, 0x07, 5*embot::core::time1millisec);
 #endif
     embot::hw::bno055::set(pImpl->config.sensor, embot::hw::bno055::Mode::NDOF, 5*embot::core::time1millisec);
-    
+
 
 
     return true;

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theIMU.cpp
@@ -57,30 +57,30 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 
-    
+
 struct embot::app::application::theIMU::Impl
-{ 
-    
+{
+
     struct canLegacyConfig
     {
         embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::Info  accgyroinfo;
         bool accelEnabled;
-        bool gyrosEnabled;  
-        canLegacyConfig() { reset(); } 
+        bool gyrosEnabled;
+        canLegacyConfig() { reset(); }
         void reset()
         {
             accgyroinfo.maskoftypes = 0;
             accgyroinfo.txperiod = 50*embot::core::time1millisec;
-            accelEnabled = false;       
+            accelEnabled = false;
             gyrosEnabled = false;
-        }            
+        }
     };
-    
+
     struct canRevisitedConfig
     {
         embot::prot::can::analog::polling::Message_IMU_CONFIG_SET::Info  imuinfo;
         embot::core::relTime txperiod;
-        canRevisitedConfig() { reset(); } 
+        canRevisitedConfig() { reset(); }
         void reset()
         {
             counter = 0;
@@ -89,42 +89,42 @@ struct embot::app::application::theIMU::Impl
         }
         std::uint8_t counter;
     };
-    
-    
+
+
     struct imuAcquisition
     {
         embot::core::relTime duration;
         embot::core::Time timeofstart;
         bool dataisready;
         embot::hw::bno055::Data data;
-        imuAcquisition() { reset(); } 
+        imuAcquisition() { reset(); }
         void reset()
         {
             duration = 0;
             timeofstart = 0;
             dataisready = false;
             data.clear();
-        } 
+        }
         void onstart()
         {
-            timeofstart = embot::core::now(); 
-            duration = 0;            
+            timeofstart = embot::core::now();
+            duration = 0;
             dataisready = false;
             data.clear();
         }
         void onstop()
         {
-            dataisready = true;  
-            duration = embot::core::now() - timeofstart;    
+            dataisready = true;
+            duration = embot::core::now() - timeofstart;
         }
     };
-    
-   
+
+
 
     Config config;
-           
+
     bool ticking;
-        
+
     embot::os::Timer *ticktimer;
     embot::os::Action action;
 
@@ -133,64 +133,64 @@ struct embot::app::application::theIMU::Impl
     bool legacymode;    // if true we work with the old protocol mode.
     canLegacyConfig canlegacyconfig;
     canRevisitedConfig canrevisitedconfig;
-    
-   
-    Impl() 
-    {   
-        ticking = false;  
 
-        ticktimer = new embot::os::Timer;           
+
+    Impl()
+    {
+        ticking = false;
+
+        ticktimer = new embot::os::Timer;
 
         legacymode = true;
         canlegacyconfig.reset();
-        
+
 
         imuacquisition.reset();
     }
-    
-   
+
+
     bool start();
-    bool stop();    
+    bool stop();
     bool tick(std::vector<embot::prot::can::Frame> &replies);
     bool processdata(std::vector<embot::prot::can::Frame> &replies);
-    
-    
+
+
     bool fill(embot::prot::can::inertial::periodic::Message_DIGITAL_ACCELEROMETER::Info &info);
     bool fill(embot::prot::can::inertial::periodic::Message_DIGITAL_GYROSCOPE::Info &info);
-    
+
     bool fill(embot::prot::can::inertial::periodic::Message_IMU_TRIPLE::Info &info);
-    
-    
-    
+
+
+
     // imu support
     bool acquisition_start();
     bool acquisition_retrieve();
     bool acquisition_processing();
-    
-    
+
+
     static void alertdataisready(void *p)
     {
         embot::app::application::theIMU::Impl *mypImpl = reinterpret_cast<embot::app::application::theIMU::Impl*>(p);
-        
+
         if(true == mypImpl->ticking)
         {
             mypImpl->config.totask->setEvent(mypImpl->config.datareadyevent);
         }
-        
-        mypImpl->imuacquisition.onstop();    
+
+        mypImpl->imuacquisition.onstop();
     }
-                      
+
 };
 
 
 
 bool embot::app::application::theIMU::Impl::start()
-{ 
+{
     if(true == legacymode)
     {
         embot::os::Timer::Config cfg(canlegacyconfig.accgyroinfo.txperiod, action, embot::os::Timer::Mode::forever);
         ticktimer->start(cfg);
-        ticking = true;    
+        ticking = true;
         return true;
     }
     else
@@ -198,17 +198,17 @@ bool embot::app::application::theIMU::Impl::start()
         canrevisitedconfig.counter = 0;
         embot::os::Timer::Config cfg(canrevisitedconfig.txperiod, action, embot::os::Timer::Mode::forever);
         ticktimer->start(cfg);
-        ticking = true;    
-        return true;        
+        ticking = true;
+        return true;
     }
-    
+
 }
 
 
 bool embot::app::application::theIMU::Impl::stop()
-{    
+{
     ticktimer->stop();
-    ticking = false;    
+    ticking = false;
     return true;
 }
 
@@ -216,21 +216,21 @@ bool embot::app::application::theIMU::Impl::stop()
 bool embot::app::application::theIMU::Impl::fill(embot::prot::can::inertial::periodic::Message_DIGITAL_ACCELEROMETER::Info &info)
 {
     bool ret = true;
-    
-    info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress(); 
-	
+
+    info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
+
     //this macro defines different behaviour for the IMU placed in the STRAIN2 board, i.e. the accelerometer/gyroscope/magnetometer axes are remapped to match the FT frame
 #if defined(STM32HAL_BOARD_STRAIN2)
     info.x = -imuacquisition.data.acc.y;
     info.y = -imuacquisition.data.acc.x;
-    info.z = -imuacquisition.data.acc.z;         
+    info.z = -imuacquisition.data.acc.z;
 #else
     info.x = imuacquisition.data.acc.x;
     info.y = imuacquisition.data.acc.y;
-    info.z = imuacquisition.data.acc.z;        	
-#endif   
+    info.z = imuacquisition.data.acc.z;
+#endif
 
-    return ret;    
+    return ret;
 }
 
 
@@ -239,19 +239,19 @@ bool embot::app::application::theIMU::Impl::fill(embot::prot::can::inertial::per
     bool ret = true;
 
     info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
-	
+
     //this macro defines different behaviour for the IMU placed in the STRAIN2 board, i.e. the accelerometer/gyroscope/magnetometer axes are remapped to match the FT frame
 #if defined(STM32HAL_BOARD_STRAIN2)
     info.x = -imuacquisition.data.gyr.y;
     info.y = -imuacquisition.data.gyr.x;
-    info.z = -imuacquisition.data.gyr.z;	
+    info.z = -imuacquisition.data.gyr.z;
 #else
     info.x = imuacquisition.data.gyr.x;
     info.y = imuacquisition.data.gyr.y;
-    info.z = imuacquisition.data.gyr.z;    
+    info.z = imuacquisition.data.gyr.z;
 #endif
 
-    return ret;    
+    return ret;
 }
 
 bool embot::app::application::theIMU::Impl::fill(embot::prot::can::inertial::periodic::Message_IMU_TRIPLE::Info &info)
@@ -259,78 +259,78 @@ bool embot::app::application::theIMU::Impl::fill(embot::prot::can::inertial::per
     bool ret = true;
 
     info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
-    
+
     switch(info.sensor)
     {
         case embot::prot::can::analog::imuSensor::acc:
         {
-            info.value = imuacquisition.data.acc;            
+            info.value = imuacquisition.data.acc;
         } break;
-        
+
         case embot::prot::can::analog::imuSensor::gyr:
         {
-            info.value = imuacquisition.data.gyr;            
+            info.value = imuacquisition.data.gyr;
         } break;
-        
+
         default:
         {
-            info.value.clear();            
-        } break;        
-        
+            info.value.clear();
+        } break;
+
     }
-        
-    return ret;    
+
+    return ret;
 }
 
 
 bool embot::app::application::theIMU::Impl::tick(std::vector<embot::prot::can::Frame> &replies)
-{   
+{
     if(false == ticking)
     {
         return false;
     }
-    
+
     if(true == legacymode)
     {
         if(0 == canlegacyconfig.accgyroinfo.maskoftypes)
         {
-            return false;  
+            return false;
         }
     }
     else //  new mode
     {
         if(0 == canrevisitedconfig.imuinfo.sensormask)
         {
-            return false;  
-        }        
+            return false;
+        }
     }
-    
-    
+
+
     // start acquisition
     acquisition_start();
-       
-    return true;    
+
+    return true;
 }
 
 
 bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot::can::Frame> &replies)
-{   
+{
     if(false == ticking)
     {
         return false;
     }
-        
+
     // retrieve acquired imu values
     acquisition_retrieve();
-    
+
     // processing of acquired data
     acquisition_processing();
-    
-    // we are ready to transmit    
-    embot::prot::can::Frame frame;   
-     
-    if(true == legacymode) 
-    {        
+
+    // we are ready to transmit
+    embot::prot::can::Frame frame;
+
+    if(true == legacymode)
+    {
         if(true == canlegacyconfig.accelEnabled)
         {
             embot::prot::can::inertial::periodic::Message_DIGITAL_ACCELEROMETER msg;
@@ -340,9 +340,9 @@ bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot:
                 msg.load(accelinfo);
                 msg.get(frame);
                 replies.push_back(frame);
-            }            
+            }
         }
-        
+
         if(true == canlegacyconfig.gyrosEnabled)
         {
             embot::prot::can::inertial::periodic::Message_DIGITAL_GYROSCOPE msg;
@@ -352,81 +352,81 @@ bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot:
                 msg.load(gyrosinfo);
                 msg.get(frame);
                 replies.push_back(frame);
-            }            
+            }
         }
     }
     else
     {
         canrevisitedconfig.counter++;
-        
-        embot::prot::can::inertial::periodic::Message_IMU_TRIPLE msg;
-        embot::prot::can::inertial::periodic::Message_IMU_TRIPLE::Info info;  
 
-        
-        info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();   
-        info.seqnumber = canrevisitedconfig.counter;        
-        
+        embot::prot::can::inertial::periodic::Message_IMU_TRIPLE msg;
+        embot::prot::can::inertial::periodic::Message_IMU_TRIPLE::Info info;
+
+
+        info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
+        info.seqnumber = canrevisitedconfig.counter;
+
         // evaluate what to tx
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::acc))
         {
             // generate a acc message with canrevisitedconfig.imuinfo.counter
             info.sensor = embot::prot::can::analog::imuSensor::acc;
 
-	    // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue: 
-	    // https://github.com/icub-tech-iit/fix/issues/780   
+	    // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue:
+	    // https://github.com/icub-tech-iit/fix/issues/780
 	#if defined(STM32HAL_BOARD_STRAIN2)
             info.value.x = -imuacquisition.data.acc.y;
             info.value.y = -imuacquisition.data.acc.x;
             info.value.z = -imuacquisition.data.acc.z;
-        #else
+    #else
 	    info.value = imuacquisition.data.acc;
-	#endif					
-            
+	#endif
+
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);                      
+            replies.push_back(frame);
         }
-        
+
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::mag))
         {
             // generate a mag message with canrevisitedconfig.counter
             info.sensor = embot::prot::can::analog::imuSensor::mag;
-	    
-	    // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue: 
-	    // https://github.com/icub-tech-iit/fix/issues/780   
-	#if defined(STM32HAL_BOARD_STRAIN2)
+
+	    // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue:
+	    // https://github.com/icub-tech-iit/fix/issues/780
+	    #if defined(STM32HAL_BOARD_STRAIN2)
             info.value.x = -imuacquisition.data.mag.y;
             info.value.y = -imuacquisition.data.mag.x;
             info.value.z = -imuacquisition.data.mag.z;
         #else
             info.value = imuacquisition.data.mag;
         #endif
-        
+
 	    msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);           
-        }        
+            replies.push_back(frame);
+        }
 
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::gyr))
         {
             // generate a gyr message with canrevisitedconfig.counter
             info.sensor = embot::prot::can::analog::imuSensor::gyr;
 
-	    // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue: 
-	    // https://github.com/icub-tech-iit/fix/issues/780   
-	#if defined(STM32HAL_BOARD_STRAIN2)
+	    // remapping of  the axis to have IMU and FT frames parallel, neglecting non-inertial corrections, see this github issue:
+	    // https://github.com/icub-tech-iit/fix/issues/780
+	    #if defined(STM32HAL_BOARD_STRAIN2)
             info.value.x = -imuacquisition.data.gyr.y;
             info.value.y = -imuacquisition.data.gyr.x;
             info.value.z = -imuacquisition.data.gyr.z;
         #else
 	    info.value = imuacquisition.data.gyr;
-	#endif					
-            
+	    #endif
+
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);               
-        } 
-        
+            replies.push_back(frame);
+        }
+
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::eul))
         {
             // generate a eul message with canrevisitedconfig.counter
@@ -446,18 +446,18 @@ bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot:
         #endif
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);               
+            replies.push_back(frame);
         }
-        
+
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::lia))
         {
             // generate a lia message with canrevisitedconfig.counter
             info.sensor = embot::prot::can::analog::imuSensor::lia;
             info.value = imuacquisition.data.lia;
-            
+
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);               
+            replies.push_back(frame);
         }
 
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::grv))
@@ -465,46 +465,46 @@ bool embot::app::application::theIMU::Impl::processdata(std::vector<embot::prot:
 
             info.sensor = embot::prot::can::analog::imuSensor::grv;
             info.value = imuacquisition.data.grv;
-            
+
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);               
-        }  
+            replies.push_back(frame);
+        }
 
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::qua))
         {
-            
-            embot::prot::can::inertial::periodic::Message_IMU_QUATERNION msg;
-            embot::prot::can::inertial::periodic::Message_IMU_QUATERNION::Info info;  
 
-            info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();    
+            embot::prot::can::inertial::periodic::Message_IMU_QUATERNION msg;
+            embot::prot::can::inertial::periodic::Message_IMU_QUATERNION::Info info;
+
+            info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
             info.value = imuacquisition.data.qua;
-            
+
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);               
-        }          
+            replies.push_back(frame);
+        }
 
         if(true == canrevisitedconfig.imuinfo.enabled(embot::prot::can::analog::imuSensor::status))
         {
-            
-            embot::prot::can::inertial::periodic::Message_IMU_STATUS msg;
-            embot::prot::can::inertial::periodic::Message_IMU_STATUS::Info info;  
 
-            info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();    
+            embot::prot::can::inertial::periodic::Message_IMU_STATUS msg;
+            embot::prot::can::inertial::periodic::Message_IMU_STATUS::Info info;
+
+            info.canaddress = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
             info.seqnumber = canrevisitedconfig.counter;
             info.acquisitiontime = imuacquisition.duration;
             info.acccalib = static_cast<embot::prot::can::inertial::periodic::Message_IMU_STATUS::Calibration>(imuacquisition.data.calibrationOfACC());
             info.magcalib = static_cast<embot::prot::can::inertial::periodic::Message_IMU_STATUS::Calibration>(imuacquisition.data.calibrationOfMAG());
             info.gyrcalib = static_cast<embot::prot::can::inertial::periodic::Message_IMU_STATUS::Calibration>(imuacquisition.data.calibrationOfGYR());
-            
+
             msg.load(info);
             msg.get(frame);
-            replies.push_back(frame);               
-        }      
+            replies.push_back(frame);
+        }
     }
-         
-    return true;           
+
+    return true;
 }
 
 
@@ -512,7 +512,7 @@ bool embot::app::application::theIMU::Impl::acquisition_start()
 {
     imuacquisition.onstart();
     embot::core::Callback cbk(alertdataisready, this);
-    embot::hw::bno055::acquisition(config.sensor, embot::hw::bno055::Set::FULL, imuacquisition.data, cbk); 
+    embot::hw::bno055::acquisition(config.sensor, embot::hw::bno055::Set::FULL, imuacquisition.data, cbk);
     return true;
 }
 
@@ -520,16 +520,16 @@ bool embot::app::application::theIMU::Impl::acquisition_start()
 bool embot::app::application::theIMU::Impl::acquisition_retrieve()
 {
 
-    // 1. in imuacquisition.data we have the values.    
+    // 1. in imuacquisition.data we have the values.
     //std::memmove(runtimedata.data.adcvalue, runtimedata.data.dmabuffer, sizeof(runtimedata.data.adcvalue));
-           
+
     return true;
 }
 
 bool embot::app::application::theIMU::Impl::acquisition_processing()
 {
     // we dont process IMU data
-    return true;    
+    return true;
 }
 
 
@@ -549,28 +549,28 @@ embot::app::application::theIMU::theIMU()
 //    : pImpl(new Impl)
 {
     pImpl = std::make_unique<Impl>();
-}  
+}
 
-    
+
 embot::app::application::theIMU::~theIMU() { }
 
-         
+
 bool embot::app::application::theIMU::initialise(Config &config)
 {
     pImpl->config = config;
-    
+
     pImpl->action.load(embot::os::EventToThread(pImpl->config.tickevent, pImpl->config.totask));
-   
-    embot::hw::bno055::init(pImpl->config.sensor, pImpl->config.sensorconfig); 
+
+    embot::hw::bno055::init(pImpl->config.sensor, pImpl->config.sensorconfig);
     embot::hw::bno055::set(pImpl->config.sensor, embot::hw::bno055::Mode::NDOF, 5*embot::core::time1millisec);
-     
+
     return true;
 }
 
 
 
 bool embot::app::application::theIMU::start()
-{    
+{
     return pImpl->start();
 }
 
@@ -582,34 +582,34 @@ bool embot::app::application::theIMU::set(const embot::prot::can::analog::pollin
     {
         stop();
     }
-    
+
     // we are in legacy mode:
     pImpl->legacymode = true;
-    
+
     // copy new configuration
     pImpl->canlegacyconfig.accgyroinfo = info;
-    
-    // get some settings from it.    
+
+    // get some settings from it.
 //    static const std::uint8_t accelmask =   static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialType::analogaccelerometer) |
 //                                            static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialType::internaldigitalaccelerometer) |
-//                                            static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialType::externaldigitalaccelerometer) ;                                        
-//    static const std::uint8_t gyrosmask =   static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialType::externaldigitalgyroscope);  
-                                                   
-    pImpl->canlegacyconfig.accelEnabled = 
+//                                            static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialType::externaldigitalaccelerometer) ;
+//    static const std::uint8_t gyrosmask =   static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialType::externaldigitalgyroscope);
+
+    pImpl->canlegacyconfig.accelEnabled =
                             embot::core::binary::bit::check(pImpl->canlegacyconfig.accgyroinfo.maskoftypes, static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialTypeBit::analogaccelerometer))             ||
                             embot::core::binary::bit::check(pImpl->canlegacyconfig.accgyroinfo.maskoftypes, static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialTypeBit::internaldigitalaccelerometer))    ||
-                            embot::core::binary::bit::check(pImpl->canlegacyconfig.accgyroinfo.maskoftypes, static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialTypeBit::externaldigitalaccelerometer));                                               
-    pImpl->canlegacyconfig.gyrosEnabled =   
-                            embot::core::binary::bit::check(pImpl->canlegacyconfig.accgyroinfo.maskoftypes, static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialTypeBit::externaldigitalgyroscope));   
-    
+                            embot::core::binary::bit::check(pImpl->canlegacyconfig.accgyroinfo.maskoftypes, static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialTypeBit::externaldigitalaccelerometer));
+    pImpl->canlegacyconfig.gyrosEnabled =
+                            embot::core::binary::bit::check(pImpl->canlegacyconfig.accgyroinfo.maskoftypes, static_cast<std::uint8_t>(embot::prot::can::analog::polling::Message_ACC_GYRO_SETUP::InertialTypeBit::externaldigitalgyroscope));
+
     // if there is something to acquire and the rate is not zero: start acquisition
-            
+
     if((0 != pImpl->canlegacyconfig.accgyroinfo.maskoftypes) && (0 != pImpl->canlegacyconfig.accgyroinfo.txperiod))
     {
         start();
     }
-  
-    return true;    
+
+    return true;
 }
 
 bool embot::app::application::theIMU::set(const embot::prot::can::analog::polling::Message_IMU_CONFIG_SET::Info &info)
@@ -619,14 +619,14 @@ bool embot::app::application::theIMU::set(const embot::prot::can::analog::pollin
     {
         stop();
     }
-    
+
     // we are not in legacy mode:
     pImpl->legacymode = false;
-    
+
     // copy new configuration
     pImpl->canrevisitedconfig.imuinfo = info;
-    
-    return true;    
+
+    return true;
 }
 
 
@@ -638,44 +638,44 @@ bool embot::app::application::theIMU::set(const embot::prot::can::analog::pollin
     }
     else
     {
-        stop();        
+        stop();
     }
-    
-    return true;    
+
+    return true;
 }
 
 
 bool embot::app::application::theIMU::get(const embot::prot::can::analog::polling::Message_IMU_CONFIG_GET::Info &info, embot::prot::can::analog::polling::Message_IMU_CONFIG_GET::ReplyInfo &replyinfo)
-{    
+{
     // copy configuration
     replyinfo.sensormask = pImpl->canrevisitedconfig.imuinfo.sensormask;
     replyinfo.fusion = pImpl->canrevisitedconfig.imuinfo.fusion;
-    replyinfo.ffu_ranges_measureunits = pImpl->canrevisitedconfig.imuinfo.ffu_ranges_measureunits;    
+    replyinfo.ffu_ranges_measureunits = pImpl->canrevisitedconfig.imuinfo.ffu_ranges_measureunits;
 
-    return true;    
+    return true;
 }
 
 bool embot::app::application::theIMU::start(embot::core::relTime period)
-{      
+{
     pImpl->canrevisitedconfig.txperiod = period;
     return pImpl->start();
 }
 
 
 bool embot::app::application::theIMU::stop()
-{    
+{
     return pImpl->stop();
 }
 
 
 bool embot::app::application::theIMU::tick(std::vector<embot::prot::can::Frame> &replies)
-{   
+{
     return pImpl->tick(replies);
 }
 
 
 bool embot::app::application::theIMU::processdata(std::vector<embot::prot::can::Frame> &replies)
-{   
+{
     return pImpl->processdata(replies);
 }
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bno055.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bno055.h
@@ -30,28 +30,28 @@
 
 #include "embot_hw_i2c.h"
 
-    
+
 namespace embot { namespace hw { namespace bno055 {
-                 
+
     struct Config
     {   // the addressing of the sensor is given by the bps
-        uint8_t tbd {0};        
+        uint8_t tbd {0};
         constexpr Config() = default;
     };
-    
-    
-    enum class Mode 
-    { 
-        CONFIG = 0, 
+
+
+    enum class Mode
+    {
+        CONFIG = 0,
         ACCONLY = 1, MAGONLY = 2, GYRONLY = 3, ACCMAG = 4, ACCGYRO = 5, MAGGYRO = 6, AMG = 7,   // non fusion modes
-        IMU = 8, COMPASS = 9, M4G = 10, NDOF_FMC_OFF = 11, NDOF = 12,                           // fusion modes 
-        none = 32, maxnumberof = 13 
+        IMU = 8, COMPASS = 9, M4G = 10, NDOF_FMC_OFF = 11, NDOF = 12,                           // fusion modes
+        none = 32, maxnumberof = 13
     };
-        
-     
-    enum class Register 
-    { 
-        CHIP_ID         = 0x00, // 7 bytes RO with many info. see embot::hw::bno055::Info 
+
+
+    enum class Register
+    {
+        CHIP_ID         = 0x00, // 7 bytes RO with many info. see embot::hw::bno055::Info
         PAGE_ID         = 0x07, // 1 byte RW. it changes page. unfortunately there are no registers defined for page 1
         DATASET_START   = 0x08, // how many as we want: acc + mag + gyr + eul + qua + lia + grv + temp + calibstat + stresult (total = 47 bytes).
         ACC_DATA        = 0x08, // 6 bytes RO
@@ -64,44 +64,44 @@ namespace embot { namespace hw { namespace bno055 {
         TEMP            = 0x34, // 1 byte RO
         CALIB_STAT      = 0x35, // 1 byte RO in bit pairs: sys|gyr|acc|mag (3 is fully calib, 0 is not calib)
         ST_RESULT       = 0x36, // 1 byte RO, but only ls nibble: mcu|gyr|mag|acc (1 is ok, 0 is ko)
-        OPR_MODE        = 0x3D, 
+        OPR_MODE        = 0x3D,
         PWR_MODE        = 0x3E,
         AXIS_MAP_CONFIG = 0x41,
         AXIS_MAP_SIGN   = 0x42
-    };  
+    };
 
     enum class Set
     {
         A               = 6,        // acc: 6 bytes (1 Triple<std::uint16_t>)
-        AMG             = 18,       // acc+mag+gyr: 18 bytes    
-        AMGE            = 24,       // acc+mag+gyr+eul: 24 bytes 
-        AMGEQ           = 32,       // acc+mag+gyr+eul+quat: 32 bytes 
+        AMG             = 18,       // acc+mag+gyr: 18 bytes
+        AMGE            = 24,       // acc+mag+gyr+eul: 24 bytes
+        AMGEQ           = 32,       // acc+mag+gyr+eul+quat: 32 bytes
         AMGEQL          = 38,       // acc+mag+gyr+eul+quat+lia: 38 bytes
-        AMGEQLG         = 44,       // acc+mag+gyr+eul+quat+lia+grv: 44 bytes        
-        FULL            = 47        // acc+mag+gyr+eul+quat+lia+grv+temp+calib+res: 47 bytes     
+        AMGEQLG         = 44,       // acc+mag+gyr+eul+quat+lia+grv: 44 bytes
+        FULL            = 47        // acc+mag+gyr+eul+quat+lia+grv+temp+calib+res: 47 bytes
     };
-    
-          
+
+
     struct Info
     {   // 7 registers from Register::CHIP_ID
         std::uint8_t    chipID;         // RO: 0xA0
         std::uint8_t    accID;          // RO: 0xFB
         std::uint8_t    magID;          // RO: 0x32
         std::uint8_t    gyrID;          // RO: 0x0F
-        std::uint16_t   swREV;          // RO: 
-        std::uint8_t    blVER;          // RO:      
+        std::uint16_t   swREV;          // RO:
+        std::uint8_t    blVER;          // RO:
         Info() { clear(); }
         void clear() { chipID = 0; accID = 0; magID = 0; gyrID = 0; swREV = 0; blVER = 0; }
-        void load(void *mem) 
-        { 
-            std::uint8_t *m = reinterpret_cast<std::uint8_t*>(mem); 
-            chipID = m[0]; accID = m[1]; magID = m[2]; gyrID = m[3]; 
+        void load(void *mem)
+        {
+            std::uint8_t *m = reinterpret_cast<std::uint8_t*>(mem);
+            chipID = m[0]; accID = m[1]; magID = m[2]; gyrID = m[3];
             swREV = m[4] | (static_cast<std::uint16_t>(m[5]) << 8);
             blVER = m[6];
         }
         bool isvalid() { if((0xA0==chipID)&&(0xFB==accID)&&(0x32==magID)&&(0x0F==gyrID)){return true;} return false; }
     };
-         
+
     static const float accRES = 0.01f;              // = 1/100 [m/(s*s)]
     static const float magRES = 0.0625f;            // = 1/16 [microTesla]
     static const float gyrRES = 0.0625f;            // = 1/16 [deg/s]
@@ -110,10 +110,10 @@ namespace embot { namespace hw { namespace bno055 {
     static const float liaRES = 0.01f;              // = 1/100 [m/(s*s)]
     static const float grvRES = 0.01f;              // = 1/100 [m/(s*s)]
     static const float tmpRES = 1.0f;              // = 1 [Celsius Deg]
-    
+
     struct Data
     {   // it holds the Set::FULL lot
-        embot::core::utils::Triple<std::int16_t>     acc;    // acc.z = 9.8 means: horizontally placed 
+        embot::core::utils::Triple<std::int16_t>     acc;    // acc.z = 9.8 means: horizontally placed
         embot::core::utils::Triple<std::int16_t>     mag;
         embot::core::utils::Triple<std::int16_t>     gyr;
         embot::core::utils::Triple<std::int16_t>     eul;    // eul.x = 0 means: directed towards NORTH
@@ -122,9 +122,9 @@ namespace embot { namespace hw { namespace bno055 {
         embot::core::utils::Triple<std::int16_t>     grv;
         std::uint8_t                            temperature;
         std::uint8_t                            calibstatus;
-        std::uint8_t                            systemstatus;  
+        std::uint8_t                            systemstatus;
         Data() { clear(); }
-        void clear() 
+        void clear()
         {
             acc.clear();
             mag.clear();
@@ -137,9 +137,9 @@ namespace embot { namespace hw { namespace bno055 {
             calibstatus = 0;
             systemstatus = 0;
         }
-        void load(void *mem) 
+        void load(void *mem)
         {
-            std::uint8_t *m = reinterpret_cast<std::uint8_t*>(mem); 
+            std::uint8_t *m = reinterpret_cast<std::uint8_t*>(mem);
             acc.load(m); mag.load(&m[6]); gyr.load(&m[12]); eul.load(&m[18]);
             qua.load(&m[24]);
             lia.load(&m[32]); grv.load(&m[38]);
@@ -147,7 +147,7 @@ namespace embot { namespace hw { namespace bno055 {
         }
         void getACC(embot::core::utils::Triple<float> &a) const { a.x = accRES * acc.x; a.y = accRES * acc.y; a.z = accRES * acc.z; }
         void getMAG(embot::core::utils::Triple<float> &a) const { a.x = magRES * mag.x; a.y = magRES * mag.y; a.z = magRES * mag.z; }
-        void getGYR(embot::core::utils::Triple<float> &a) const { a.x = gyrRES * gyr.x; a.y = gyrRES * gyr.y; a.z = gyrRES * gyr.z; }            
+        void getGYR(embot::core::utils::Triple<float> &a) const { a.x = gyrRES * gyr.x; a.y = gyrRES * gyr.y; a.z = gyrRES * gyr.z; }
         void getEUL(embot::core::utils::Triple<float> &a) const { a.x = eulRES * eul.x; a.y = eulRES * eul.y; a.z = eulRES * eul.z; }
         void getQUA(embot::core::utils::Quadruple<float> &a) const { a.w = quaRES * qua.w; a.x = quaRES * qua.x; a.y = quaRES * qua.y; a.z = quaRES * qua.z; }
         void getLIA(embot::core::utils::Triple<float> &a) const { a.x = liaRES * lia.x; a.y = liaRES * lia.y; a.z = liaRES * lia.z; }
@@ -157,64 +157,64 @@ namespace embot { namespace hw { namespace bno055 {
         std::uint8_t calibrationOfGYR() const { return(embot::core::binary::pair::get(calibstatus, 2)); } // 3 is ok, 1 is not calibrated
         std::uint8_t calibrationOfMAG() const { return(embot::core::binary::pair::get(calibstatus, 0)); } // 3 is ok, 1 is not calibrated
         //std::uint8_t calibrationOfSYS() const { return(embot::core::binary::pair::get(calibstatus, 4)); } // 3 is ok, 1 is not calibrated BUT ALWAYS ZERO
-    };        
-    
-    
-    
+    };
+
+
+
     bool supported(BNO055 s);
-    
+
     bool initialised(BNO055 s);
-    
+
     // the init() starts the chip, prepares i2c, pings it. if all ok it returns resOK.
     // the working mode is however Mode::CONFIG
     result_t init(BNO055 s, const Config &config);
-    
+
     // after that init() returns resOK we can check if it is alive. we can specify a timeout
     bool isalive(BNO055 s, embot::core::relTime timeout = 3*embot::core::time1millisec);
-    
+
     // we can get info
     result_t get(BNO055 s, Info &info, embot::core::relTime timeout = 3*embot::core::time1millisec);
-    
+
     // we can now set a working mode. we can specify a timeout
     result_t set(BNO055 s, Mode m, embot::core::relTime timeout = 3*embot::core::time1millisec);
-    
+
     // we must check that nobody is using the sensor, maybe in non-blocking mode some time earlier
     bool isacquiring(BNO055 s);
-    
+
     // we check isacquiring() but also if any other device is using i2c bus
     bool canacquire(BNO055 s);
-    
+
     // we start acquisition of a set.
     // if returns resOK, we know that acquisition is over if it is called oncompletion() or when operationdone() is true;
     result_t acquisition(BNO055 s, Set set, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
-    
+
     result_t acquisition(BNO055 s, Set set, Data &data, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
-    
+
     // it tells if a previous operation (acquisition, read, write) is over
     bool operationdone(BNO055 s);
-    
+
     // ok, now we can read data previously acquired
     result_t read(BNO055 s, Data &data);
-    
+
     // and here is acquisition in blocking mode
     result_t acquisition(BNO055 s, Set set, Data &data, const embot::core::relTime timeout);
-    
-    // here are some write() and read() funtions which operate directly on a single register reg 
-    
-    
+
+    // here are some write() and read() funtions which operate directly on a single register reg
+
+
     // we write a single byte into a register.
-    // blocking or non-blocking mode. we check end of oepration either with operationdone() or with the execution of oncompletion().      
+    // blocking or non-blocking mode. we check end of oepration either with operationdone() or with the execution of oncompletion().
     result_t write(BNO055 s, embot::hw::bno055::Register reg, std::uint8_t value, const embot::core::relTime timeout);
     result_t write(BNO055 s, embot::hw::bno055::Register reg, std::uint8_t value, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
 
     // we read from register reg, for data.size positions and we place results into data.pointer (which MUST point to at least data.size bytes)
-    // blocking or non-blocking mode. we check end of oepration either with operationdone() or with the execution of oncompletion().  
+    // blocking or non-blocking mode. we check end of oepration either with operationdone() or with the execution of oncompletion().
     result_t read(BNO055 s, embot::hw::bno055::Register reg, embot::core::Data &data, const embot::core::relTime timeout);
     result_t read(BNO055 s, embot::hw::bno055::Register reg, embot::core::Data &data, const embot::core::Callback &oncompletion = embot::core::Callback(nullptr, nullptr));
 
- 
+
 }}} // namespace embot { namespace hw { namespace bno055 {
-    
+
 
 
 #endif  // include-guard

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bno055.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bno055.h
@@ -65,7 +65,9 @@ namespace embot { namespace hw { namespace bno055 {
         CALIB_STAT      = 0x35, // 1 byte RO in bit pairs: sys|gyr|acc|mag (3 is fully calib, 0 is not calib)
         ST_RESULT       = 0x36, // 1 byte RO, but only ls nibble: mcu|gyr|mag|acc (1 is ok, 0 is ko)
         OPR_MODE        = 0x3D, 
-        PWR_MODE        = 0x3E
+        PWR_MODE        = 0x3E,
+        AXIS_MAP_CONFIG = 0x41,
+        AXIS_MAP_SIGN   = 0x42
     };  
 
     enum class Set


### PR DESCRIPTION
This PR fixes the Euler angles representation on strain2.

This conversion keep count of this math: 
```
rpy_newSens = rot2rpy(A_R_newSens) = rot2rpy(A_R_oldSens * oldSens_R_newSens) =

= rot2rpy(A_R_oldSens * (newSens_R_oldSens)^T ) =

= rot2rpy(rpy2rot(rpy_oldSens) * (newSens_R_oldSens)^T )
```

```
rpy2rot(rpy_oldSens) = B =  0     0     1
                            0    -1     0
                            1     0     0
                            
(newSens_R_oldSens)^T = A =  0    -1     0
                            -1     0     0
                             0     0    -1

C = B*A = 0     0    -1
          1     0     0
          0    -1     0

rpy_newSens = rotm2eul(C, 'XYZ') =  0 -1.5707963267949 1.5707963267949                
```


That results in this conversion;

```
x = -z
y = x
z = -y
```


To be tested on the hardware