### PR TITLE
embot::hw::can -> fixed ID filters for the FDCAN case

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.h
@@ -72,8 +72,15 @@ namespace embot { namespace hw { namespace can {
     
     result_t get(embot::hw::CAN p, Frame &frame, std::uint8_t &remaining);
     
-    result_t setfilters(embot::hw::CAN p, std::uint8_t address);
-    
+    // about filters: after init() every CAN ID is enabled for reception
+    // then, setfilters() allows receptions only of the following CAN IDs sent by node @ 0
+    // bootloader class towards address or towards  0xf (broadcast) 
+    // analog sensor polling class towards address or towards 0xf (broadcast)
+    // motion control polling class towards ID = address or towards ID = 0xf (broadcast) 
+    // for motion control boards only, such as pmc and amcbldc ...
+    // motion control streaming class sent by node @ 0 (but not by other boards)
+    result_t setfilters(embot::hw::CAN p, std::uint8_t address);   
+   
     enum class Direction : uint8_t { TX = 0, RX = 1 }; 
     bool lock(embot::hw::CAN p, embot::hw::can::Direction dir);
     void unlock(embot::hw::CAN p, embot::hw::can::Direction dir, bool lockstatus);

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/amcbldc/v120/src/fdcan.c
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/amcbldc/v120/src/fdcan.c
@@ -44,7 +44,7 @@ void MX_FDCAN2_Init_160mhz(void)
   hfdcan2.Init.DataSyncJumpWidth = 4;
   hfdcan2.Init.DataTimeSeg1 = 5;
   hfdcan2.Init.DataTimeSeg2 = 4;
-  hfdcan2.Init.StdFiltersNbr = 1;
+  hfdcan2.Init.StdFiltersNbr = 8;
   hfdcan2.Init.ExtFiltersNbr = 0;
   hfdcan2.Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
   if (HAL_FDCAN_Init(&hfdcan2) != HAL_OK)
@@ -72,7 +72,7 @@ void MX_FDCAN2_Init(void)
   hfdcan2.Init.DataSyncJumpWidth = 10;
   hfdcan2.Init.DataTimeSeg1 = 13;
   hfdcan2.Init.DataTimeSeg2 = 10;
-  hfdcan2.Init.StdFiltersNbr = 1;
+  hfdcan2.Init.StdFiltersNbr = 8;
   hfdcan2.Init.ExtFiltersNbr = 0;
   hfdcan2.Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
   if (HAL_FDCAN_Init(&hfdcan2) != HAL_OK)

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/pmc/v120/src/fdcan.c
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/src/board/pmc/v120/src/fdcan.c
@@ -45,7 +45,7 @@ void MX_FDCAN1_Init(void)
   hfdcan1.Init.DataSyncJumpWidth = 4;
   hfdcan1.Init.DataTimeSeg1 = 5;
   hfdcan1.Init.DataTimeSeg2 = 4;
-  hfdcan1.Init.StdFiltersNbr = 1;
+  hfdcan1.Init.StdFiltersNbr = 8;
   hfdcan1.Init.ExtFiltersNbr = 0;
   hfdcan1.Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
   if (HAL_FDCAN_Init(&hfdcan1) != HAL_OK)


### PR DESCRIPTION
This PR fixes the CAN ID filtering for the case of FDCAN peripherals and affects boards such as `pmc`, `amcbldc` and `amc`.

Before this change, for the above boards the ID filtering was not effective and the boards received every CAN frame, the so called `pass-all` behavior. Now, the HW filters of the FDCAN peripheral select the CAN frames by their IDs. 

The selection allows only messages for: 
- bootloader class sent to the board or in broadcast;
- analog sensor command class sent to the board or in broadcast;
- motion control command class sent to the board or in broadcast;
- motion control streaming class sent by address 0.

In this way the CPU of each board processes only what it needs.

The previous `pass-all` behavior is not wrong per se, but  in some cases of excessive traffic it caused reception problems which prevent the drive to work correctly.

It is the case of the new wrist in iCub, where we have three `amcbldc` boards. In here if we don't use filtering, each board receives almost in at the same time up to 5 CAN frames, when only one is relevant to the board.

Problem is that the RX FIFO0 buffer which is used to accumulate the frames before the IRQ Handler can get them can host only three messages.

In this PR I fixed the above case by:
- activating the global filtering,
- applying the correct filtering for the CAN protocol messages relevant to each board,
- improving the RX callback activate by teh IRQ Handler to consider the cases of FDCAN_IT_RX_FIFO0_MESSAGE_LOST and FDCAN_IT_RX_FIFO0_FULL,
- increasing the number of allowed filters in the FDCAN driver.


The changes were tested on a `pmc` board for what is related to correct ID filtering and on a `strain2` board to verify that there are no side effects on older boards and finally on the `amcbldc` boards of the wrist.

**NOTE**: the `amc` board must be able to receive every frame and this behavior is satisfied. That happens because it calls only `embot::hw::can::init()` which by default enables the `pass-all` mechanism. The filter is activated only by `embot::hw::can::setfilters()` which the `amc` must not call.



