### PR TITLE
AMCBLDC: Update firmware to latest master codegen

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -186,6 +186,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1194,8 +1195,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -1364,6 +1365,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -2372,8 +2374,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -2542,6 +2544,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
+// C/C++ source code generated on : Thu Aug 11 17:12:32 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -90,10 +90,10 @@ ConfigurationParameters InitConfParams = {
   {
     0.0F,
     0.0F,
+    1.0F,
+    1.0F,
     0.0F,
-    0.0F,
-    0.0F,
-    0.0F,
+    10.0F,
     0.0F,
     0.0F,
     0U
@@ -229,7 +229,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
     AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw];
 
   // ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc(&AMC_BLDC_U.SensorsData_p, &rtb_BusConversion_InsertedFor_F,
@@ -271,7 +271,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   // End of RateTransition generated from: '<Root>/Adapter1'
 
   // RateTransition generated from: '<Root>/Adapter3' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
 
   rtw_mutex_lock();
   wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g + 1);
@@ -599,7 +599,7 @@ void AMC_BLDC_initialize(void)
   filter_current_Init();
 
   // SystemInitialize for ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc_Init();

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 10:13:31 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -229,7 +229,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
     AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw];
 
   // ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element6'
+  //   Inport generated from: '<Root>/In Bus Element5'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc(&AMC_BLDC_U.SensorsData_p, &rtb_BusConversion_InsertedFor_F,
@@ -271,7 +271,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   // End of RateTransition generated from: '<Root>/Adapter1'
 
   // RateTransition generated from: '<Root>/Adapter3' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element6'
+  //   Inport generated from: '<Root>/In Bus Element5'
 
   rtw_mutex_lock();
   wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g + 1);
@@ -599,7 +599,7 @@ void AMC_BLDC_initialize(void)
   filter_current_Init();
 
   // SystemInitialize for ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element6'
+  //   Inport generated from: '<Root>/In Bus Element5'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc_Init();

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 10:13:31 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
+// C/C++ source code generated on : Thu Aug 11 17:12:32 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 10:13:31 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
+// C/C++ source code generated on : Thu Aug 11 17:12:32 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 10:13:31 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.103
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:58 2022
+// C/C++ source code generated on : Thu Aug 11 17:12:32 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.48
+// Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:48 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -337,17 +337,23 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
                      (rtu_pck_input->PAYLOAD.CMD.OPC == static_cast<int32_T>
                       (MCOPC_Set_Velocity_PID))) {
             if (rtu_pck_input->PAYLOAD.LEN == 8) {
+              real32_T c;
               localB->msg_set_pid.motor = rtu_pck_input->PAYLOAD.CMD.M;
-              localB->msg_set_pid.Kp = can_decoder_merge_2bytes_signed(
-                static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[1]),
-                static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[2]));
-              localB->msg_set_pid.Ki = can_decoder_merge_2bytes_signed(
-                static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[3]),
-                static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[4]));
-              localB->msg_set_pid.Kd = can_decoder_merge_2bytes_signed(
-                static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[5]),
-                static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[6]));
               localB->msg_set_pid.Ks = rtu_pck_input->PAYLOAD.ARG[7];
+              c = static_cast<real32_T>(0x01 << (15 - localB->msg_set_pid.Ks)) /
+                32768.0F;
+              localB->msg_set_pid.Kp = c * static_cast<real32_T>
+                (can_decoder_merge_2bytes_signed(static_cast<uint16_T>
+                  (rtu_pck_input->PAYLOAD.ARG[1]), static_cast<uint16_T>
+                  (rtu_pck_input->PAYLOAD.ARG[2])));
+              localB->msg_set_pid.Ki = c * static_cast<real32_T>
+                (can_decoder_merge_2bytes_signed(static_cast<uint16_T>
+                  (rtu_pck_input->PAYLOAD.ARG[3]), static_cast<uint16_T>
+                  (rtu_pck_input->PAYLOAD.ARG[4])));
+              localB->msg_set_pid.Kd = c * static_cast<real32_T>
+                (can_decoder_merge_2bytes_signed(static_cast<uint16_T>
+                  (rtu_pck_input->PAYLOAD.ARG[5]), static_cast<uint16_T>
+                  (rtu_pck_input->PAYLOAD.ARG[6])));
               localDW->cmd_processed = static_cast<uint16_T>
                 (localDW->cmd_processed + 1);
               if (rtu_pck_input->PAYLOAD.CMD.OPC == static_cast<int32_T>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.48
+// Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:48 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.48
+// Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:48 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.48
+// Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:48 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.49
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:14 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:00 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:26 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:00 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:26 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:00 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:26 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:00 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.26
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:24 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:26 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:11 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:35 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:33 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:25 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.31
+// Model version                  : 3.32
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -51,7 +51,7 @@ void control_outer_Init(void)
   // InitializeConditions for DiscreteIntegrator: '<S104>/Integrator'
   control_outer_DW.Integrator_PrevResetState_n = 2;
 
-  // InitializeConditions for DiscreteIntegrator: '<S156>/Integrator'
+  // InitializeConditions for DiscreteIntegrator: '<S154>/Integrator'
   control_outer_DW.Integrator_PrevResetState_c = 2;
 }
 
@@ -81,6 +81,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   real32_T rtb_Abs;
   real32_T rtb_DProdOut;
   real32_T rtb_DProdOut_f;
+  real32_T rtb_DenCoefOut;
   real32_T rtb_FilterDifferentiatorTF;
   real32_T rtb_FilterDifferentiatorTF_n;
   real32_T rtb_Gain1_h;
@@ -88,9 +89,6 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   real32_T rtb_PProdOut_o;
   real32_T rtb_Product;
   real32_T rtb_Switch2_f;
-  real32_T rtb_UnitDelay1;
-  int8_T rtb_Product_0;
-  int8_T rtb_UnitDelay1_0;
   boolean_T rtb_Compare;
   boolean_T rtb_Compare_m;
   boolean_T rtb_FixPtRelationalOperator;
@@ -121,11 +119,11 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
     && (rtu_Flags->control_mode != ControlModes_HwFaultCM));
 
   // Sum: '<S4>/Sum3'
-  rtb_UnitDelay1 = rtu_Targets->jointpositions.position -
+  rtb_DenCoefOut = rtu_Targets->jointpositions.position -
     rtu_Sensors->jointpositions.position;
 
   // Product: '<S59>/PProd Out'
-  rtb_PProdOut = rtb_UnitDelay1 * rtu_ConfigurationParameters->PosLoopPID.P;
+  rtb_PProdOut = rtb_DenCoefOut * rtu_ConfigurationParameters->PosLoopPID.P;
 
   // SampleTimeMath: '<S49>/Tsamp'
   //
@@ -166,7 +164,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
 
   control_outer_PrevZCX.FilterDifferentiatorTF_Reset_ZC =
     rtb_FixPtRelationalOperator;
-  control_outer_DW.FilterDifferentiatorTF_tmp = rtb_UnitDelay1 *
+  control_outer_DW.FilterDifferentiatorTF_tmp = rtb_DenCoefOut *
     rtu_ConfigurationParameters->PosLoopPID.D - (rtb_Product - 1.0F) *
     rtb_Switch2_f * control_outer_DW.FilterDifferentiatorTF_states;
 
@@ -185,7 +183,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   UnitDelay: '<Root>/Unit Delay'
 
   rtb_DProdOut = (control_outer_DW.UnitDelay_DSTATE - ((rtb_PProdOut +
-    control_outer_DW.Integrator_DSTATE) + rtb_Switch2_f)) + rtb_UnitDelay1 *
+    control_outer_DW.Integrator_DSTATE) + rtb_Switch2_f)) + rtb_DenCoefOut *
     rtu_ConfigurationParameters->PosLoopPID.I;
 
   // DiscreteIntegrator: '<S54>/Integrator'
@@ -204,13 +202,13 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_Compare = (rtu_Flags->control_mode == ControlModes_Position);
 
   // Product: '<S109>/PProd Out'
-  rtb_PProdOut_o = rtb_UnitDelay1 * rtu_ConfigurationParameters->DirLoopPID.P;
+  rtb_PProdOut_o = rtb_DenCoefOut * rtu_ConfigurationParameters->DirLoopPID.P;
 
   // Product: '<S101>/IProd Out'
-  rtb_Product = rtb_UnitDelay1 * rtu_ConfigurationParameters->DirLoopPID.I;
+  rtb_Product = rtb_DenCoefOut * rtu_ConfigurationParameters->DirLoopPID.I;
 
   // Product: '<S96>/DProd Out'
-  rtb_DProdOut_f = rtb_UnitDelay1 * rtu_ConfigurationParameters->DirLoopPID.D;
+  rtb_DProdOut_f = rtb_DenCoefOut * rtu_ConfigurationParameters->DirLoopPID.D;
 
   // SampleTimeMath: '<S99>/Tsamp'
   //
@@ -226,7 +224,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //  About '<S97>/Reciprocal':
   //   Operator: reciprocal
 
-  rtb_UnitDelay1 = 1.0F / (rtb_Gain1_h + 1.0F);
+  rtb_DenCoefOut = 1.0F / (rtb_Gain1_h + 1.0F);
 
   // DiscreteTransferFcn: '<S97>/Filter Differentiator TF' incorporates:
   //   Constant: '<S97>/Constant'
@@ -242,15 +240,15 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   control_outer_PrevZCX.FilterDifferentiatorTF_Reset__m =
     rtb_FixPtRelationalOperator;
   control_outer_DW.FilterDifferentiatorTF_tmp_m = rtb_DProdOut_f - (rtb_Gain1_h
-    - 1.0F) * rtb_UnitDelay1 * control_outer_DW.FilterDifferentiatorTF_states_i;
+    - 1.0F) * rtb_DenCoefOut * control_outer_DW.FilterDifferentiatorTF_states_i;
 
   // Product: '<S107>/NProd Out' incorporates:
   //   DiscreteTransferFcn: '<S97>/Filter Differentiator TF'
   //   Product: '<S97>/DenCoefOut'
 
-  rtb_UnitDelay1 = (control_outer_DW.FilterDifferentiatorTF_tmp_m +
+  rtb_DenCoefOut = (control_outer_DW.FilterDifferentiatorTF_tmp_m +
                     -control_outer_DW.FilterDifferentiatorTF_states_i) *
-    rtb_UnitDelay1 * rtu_ConfigurationParameters->DirLoopPID.N;
+    rtb_DenCoefOut * rtu_ConfigurationParameters->DirLoopPID.N;
 
   // Sum: '<S116>/SumI1' incorporates:
   //   Sum: '<S114>/Sum Fdbk'
@@ -258,7 +256,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   UnitDelay: '<Root>/Unit Delay'
 
   rtb_FilterDifferentiatorTF_n = (control_outer_DW.UnitDelay_DSTATE -
-    ((rtb_PProdOut_o + control_outer_DW.Integrator_DSTATE_i) + rtb_UnitDelay1))
+    ((rtb_PProdOut_o + control_outer_DW.Integrator_DSTATE_i) + rtb_DenCoefOut))
     + rtb_Product;
 
   // DiscreteIntegrator: '<S104>/Integrator'
@@ -286,21 +284,21 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
     //   Sum: '<S63>/Sum'
 
     if (rtb_Compare) {
-      rtb_UnitDelay1 = (rtb_PProdOut + rtb_FilterDifferentiatorTF) +
+      rtb_DenCoefOut = (rtb_PProdOut + rtb_FilterDifferentiatorTF) +
         rtb_Switch2_f;
     } else {
-      rtb_UnitDelay1 += rtb_PProdOut_o + rtb_DProdOut_f;
+      rtb_DenCoefOut += rtb_PProdOut_o + rtb_DProdOut_f;
     }
 
     // End of Switch: '<S4>/Switch5'
   } else {
-    rtb_UnitDelay1 = 0.0F;
+    rtb_DenCoefOut = 0.0F;
   }
 
   // End of Switch: '<Root>/Switch3'
 
   // Sum: '<Root>/Sum2'
-  rtb_Switch2_f = rtb_UnitDelay1 + rtu_Targets->jointvelocities.velocity;
+  rtb_Switch2_f = rtb_DenCoefOut + rtu_Targets->jointvelocities.velocity;
 
   // Switch: '<S5>/Switch2' incorporates:
   //   Gain: '<Root>/Gain'
@@ -325,31 +323,36 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_Product = (rtb_Switch2_f - rtu_Estimates->jointvelocities.velocity) *
     rtu_ConfigurationParameters->motorconfig.reduction;
 
-  // Product: '<S161>/PProd Out'
+  // Product: '<S159>/PProd Out'
   rtb_Abs = rtb_Product * rtu_ConfigurationParameters->VelLoopPID.P;
 
-  // SampleTimeMath: '<S151>/Tsamp'
+  // Product: '<S151>/IProd Out'
+  rtb_Gain1_h = rtb_Product * rtu_ConfigurationParameters->VelLoopPID.I;
+
+  // Product: '<S146>/DProd Out'
+  rtb_PProdOut = rtb_Product * rtu_ConfigurationParameters->VelLoopPID.D;
+
+  // SampleTimeMath: '<S149>/Tsamp'
   //
-  //  About '<S151>/Tsamp':
+  //  About '<S149>/Tsamp':
   //   y = u * K where K = ( w * Ts )
 
-  rtb_Gain1_h = rtu_ConfigurationParameters->VelLoopPID.N * 0.0005F;
+  rtb_Product = rtu_ConfigurationParameters->VelLoopPID.N * 0.0005F;
 
-  // Math: '<S149>/Reciprocal' incorporates:
-  //   Constant: '<S149>/Constant'
-  //   Sum: '<S149>/SumDen'
+  // Math: '<S147>/Reciprocal' incorporates:
+  //   Constant: '<S147>/Constant'
+  //   Sum: '<S147>/SumDen'
   //
-  //  About '<S149>/Reciprocal':
+  //  About '<S147>/Reciprocal':
   //   Operator: reciprocal
 
-  rtb_UnitDelay1 = 1.0F / (rtb_Gain1_h + 1.0F);
+  rtb_DenCoefOut = 1.0F / (rtb_Product + 1.0F);
 
-  // DiscreteTransferFcn: '<S149>/Filter Differentiator TF' incorporates:
-  //   Constant: '<S149>/Constant'
+  // DiscreteTransferFcn: '<S147>/Filter Differentiator TF' incorporates:
+  //   Constant: '<S147>/Constant'
   //   DiscreteTransferFcn: '<S47>/Filter Differentiator TF'
-  //   Product: '<S148>/DProd Out'
-  //   Product: '<S149>/Divide'
-  //   Sum: '<S149>/SumNum'
+  //   Product: '<S147>/Divide'
+  //   Sum: '<S147>/SumNum'
 
   if (rtb_FixPtRelationalOperator &&
       (control_outer_PrevZCX.FilterDifferentiatorTF_Reset__e != POS_ZCSIG)) {
@@ -358,116 +361,41 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
 
   control_outer_PrevZCX.FilterDifferentiatorTF_Reset__e =
     rtb_FixPtRelationalOperator;
-  control_outer_DW.FilterDifferentiatorTF_tmp_p = rtb_Product *
-    rtu_ConfigurationParameters->VelLoopPID.D - (rtb_Gain1_h - 1.0F) *
-    rtb_UnitDelay1 * control_outer_DW.FilterDifferentiatorTF_states_c;
+  control_outer_DW.FilterDifferentiatorTF_tmp_p = rtb_PProdOut - (rtb_Product -
+    1.0F) * rtb_DenCoefOut * control_outer_DW.FilterDifferentiatorTF_states_c;
 
-  // Product: '<S159>/NProd Out' incorporates:
-  //   DiscreteTransferFcn: '<S149>/Filter Differentiator TF'
-  //   Product: '<S149>/DenCoefOut'
+  // Product: '<S157>/NProd Out' incorporates:
+  //   DiscreteTransferFcn: '<S147>/Filter Differentiator TF'
+  //   Product: '<S147>/DenCoefOut'
 
-  rtb_PProdOut = (control_outer_DW.FilterDifferentiatorTF_tmp_p +
-                  -control_outer_DW.FilterDifferentiatorTF_states_c) *
-    rtb_UnitDelay1 * rtu_ConfigurationParameters->VelLoopPID.N;
+  rtb_DenCoefOut = (control_outer_DW.FilterDifferentiatorTF_tmp_p +
+                    -control_outer_DW.FilterDifferentiatorTF_states_c) *
+    rtb_DenCoefOut * rtu_ConfigurationParameters->VelLoopPID.N;
 
-  // Sum: '<S166>/Sum Fdbk'
-  rtb_Gain1_h = (rtb_Abs + control_outer_DW.Integrator_DSTATE_b) + rtb_PProdOut;
-
-  // DeadZone: '<S147>/DeadZone' incorporates:
-  //   Saturate: '<S164>/Saturation'
-
-  if (rtb_Gain1_h > 100.0F) {
-    rtb_UnitDelay1 = rtb_Gain1_h - 100.0F;
-    rtb_Gain1_h = 100.0F;
-  } else {
-    if (rtb_Gain1_h >= -100.0F) {
-      rtb_UnitDelay1 = 0.0F;
-    } else {
-      rtb_UnitDelay1 = rtb_Gain1_h - -100.0F;
-    }
-
-    if (rtb_Gain1_h < -100.0F) {
-      rtb_Gain1_h = -100.0F;
-    }
-  }
-
-  // End of DeadZone: '<S147>/DeadZone'
-
-  // Sum: '<S168>/SumI1' incorporates:
-  //   Product: '<S153>/IProd Out'
-  //   Sum: '<S167>/SumI3'
+  // Sum: '<S166>/SumI1' incorporates:
+  //   Sum: '<S164>/Sum Fdbk'
+  //   Sum: '<S165>/SumI3'
   //   UnitDelay: '<Root>/Unit Delay1'
 
-  rtb_Product = rtb_Product * rtu_ConfigurationParameters->VelLoopPID.I +
-    (control_outer_DW.UnitDelay1_DSTATE - rtb_Gain1_h);
+  rtb_PProdOut = (control_outer_DW.UnitDelay1_DSTATE - ((rtb_Abs +
+    control_outer_DW.Integrator_DSTATE_b) + rtb_DenCoefOut)) + rtb_Gain1_h;
 
-  // Switch: '<S145>/Switch1' incorporates:
-  //   Constant: '<S145>/Constant'
-  //   Constant: '<S145>/Constant2'
-  //   Constant: '<S145>/Constant5'
-  //   RelationalOperator: '<S145>/fix for DT propagation issue'
-
-  if (rtb_UnitDelay1 > 0.0F) {
-    rtb_UnitDelay1_0 = 1;
-  } else {
-    rtb_UnitDelay1_0 = -1;
-  }
-
-  // End of Switch: '<S145>/Switch1'
-
-  // Switch: '<S145>/Switch2' incorporates:
-  //   Constant: '<S145>/Constant3'
-  //   Constant: '<S145>/Constant4'
-  //   Constant: '<S145>/Constant5'
-  //   RelationalOperator: '<S145>/fix for DT propagation issue1'
-
-  if (rtb_Product > 0.0F) {
-    rtb_Product_0 = 1;
-  } else {
-    rtb_Product_0 = -1;
-  }
-
-  // End of Switch: '<S145>/Switch2'
-
-  // Switch: '<S145>/Switch' incorporates:
-  //   Constant: '<S145>/Constant1'
-  //   Constant: '<S145>/Constant5'
-  //   Logic: '<S145>/AND3'
-  //   RelationalOperator: '<S145>/Equal1'
-  //   RelationalOperator: '<S145>/Relational Operator'
-
-  if ((rtb_UnitDelay1 != 0.0F) && (rtb_UnitDelay1_0 == rtb_Product_0)) {
-    rtb_PProdOut_o = 0.0F;
-  } else {
-    rtb_PProdOut_o = rtb_Product;
-  }
-
-  // End of Switch: '<S145>/Switch'
-
-  // DiscreteIntegrator: '<S156>/Integrator'
+  // DiscreteIntegrator: '<S154>/Integrator'
   if (rtb_FixPtRelationalOperator &&
       (control_outer_DW.Integrator_PrevResetState_c <= 0)) {
     control_outer_DW.Integrator_DSTATE_b = 0.0F;
   }
 
-  // DiscreteIntegrator: '<S156>/Integrator'
-  rtb_Product = 0.0005F * rtb_PProdOut_o + control_outer_DW.Integrator_DSTATE_b;
+  // DiscreteIntegrator: '<S154>/Integrator'
+  rtb_Product = 0.0005F * rtb_PProdOut + control_outer_DW.Integrator_DSTATE_b;
 
-  // Switch: '<Root>/Switch1'
+  // Switch: '<Root>/Switch1' incorporates:
+  //   Sum: '<S163>/Sum'
+
   if (rtb_Compare_m) {
-    // Sum: '<S165>/Sum'
-    rtb_UnitDelay1 = (rtb_Abs + rtb_Product) + rtb_PProdOut;
-
-    // Saturate: '<S163>/Saturation'
-    if (rtb_UnitDelay1 > 100.0F) {
-      rtb_UnitDelay1 = 100.0F;
-    } else if (rtb_UnitDelay1 < -100.0F) {
-      rtb_UnitDelay1 = -100.0F;
-    }
-
-    // End of Saturate: '<S163>/Saturation'
+    rtb_Abs = (rtb_Abs + rtb_Product) + rtb_DenCoefOut;
   } else {
-    rtb_UnitDelay1 = rtu_Targets->motorcurrent.current;
+    rtb_Abs = rtu_Targets->motorcurrent.current;
   }
 
   // End of Switch: '<Root>/Switch1'
@@ -478,27 +406,26 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   RelationalOperator: '<S6>/UpperRelop'
   //   Switch: '<S6>/Switch'
 
-  if (rtb_UnitDelay1 > rtu_ConfigurationParameters->thresholds.motorPeakCurrents)
-  {
-    rtb_UnitDelay1 = rtu_ConfigurationParameters->thresholds.motorPeakCurrents;
-  } else if (rtb_UnitDelay1 <
+  if (rtb_Abs > rtu_ConfigurationParameters->thresholds.motorPeakCurrents) {
+    rtb_Abs = rtu_ConfigurationParameters->thresholds.motorPeakCurrents;
+  } else if (rtb_Abs <
              -rtu_ConfigurationParameters->thresholds.motorPeakCurrents) {
     // Switch: '<S6>/Switch' incorporates:
     //   Gain: '<Root>/Gain1'
 
-    rtb_UnitDelay1 = -rtu_ConfigurationParameters->thresholds.motorPeakCurrents;
+    rtb_Abs = -rtu_ConfigurationParameters->thresholds.motorPeakCurrents;
   }
 
   // End of Switch: '<S6>/Switch2'
 
   // BusCreator: '<Root>/Bus Creator2'
-  rty_OuterOutputs->motorcurrent.current = rtb_UnitDelay1;
+  rty_OuterOutputs->motorcurrent.current = rtb_Abs;
 
   // Sum: '<S1>/Sum' incorporates:
   //   Abs: '<S1>/Abs1'
 
-  rtb_Abs = rtu_ConfigurationParameters->thresholds.motorPeakCurrents - std::abs
-    (rtu_Estimates->Iq_filtered.current);
+  rtb_DenCoefOut = rtu_ConfigurationParameters->thresholds.motorPeakCurrents -
+    std::abs(rtu_Estimates->Iq_filtered.current);
 
   // CombinatorialLogic: '<S10>/Logic' incorporates:
   //   Constant: '<S8>/Constant'
@@ -508,10 +435,10 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   RelationalOperator: '<S1>/Relational Operator'
   //   RelationalOperator: '<S8>/Compare'
 
-  rowIdx = static_cast<int32_T>(((((rtb_Abs > 0.05F *
+  rowIdx = static_cast<int32_T>(((((rtb_DenCoefOut > 0.05F *
     rtu_ConfigurationParameters->thresholds.motorPeakCurrents) ||
-    rtb_FixPtRelationalOperator) + (static_cast<uint32_T>(rtb_Abs <= 0.0F) << 1))
-    << 1) + control_outer_DW.Memory_PreviousInput);
+    rtb_FixPtRelationalOperator) + (static_cast<uint32_T>(rtb_DenCoefOut <= 0.0F)
+    << 1)) << 1) + control_outer_DW.Memory_PreviousInput);
   rtb_Compare = rtCP_Logic_table[rowIdx + 8U];
 
   // DiscreteIntegrator: '<S1>/Discrete-Time Integrator'
@@ -525,7 +452,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
     control_outer_B.DiscreteTimeIntegrator = 0.0F;
   } else {
     // DiscreteIntegrator: '<S1>/Discrete-Time Integrator'
-    control_outer_B.DiscreteTimeIntegrator = 0.0005F * rtb_Abs +
+    control_outer_B.DiscreteTimeIntegrator = 0.0005F * rtb_DenCoefOut +
       control_outer_DW.DiscreteTimeIntegrator_DSTATE;
   }
 
@@ -591,17 +518,17 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   control_outer_DW.Integrator_PrevResetState_n = static_cast<int8_T>
     (rtb_FixPtRelationalOperator);
 
-  // Update for DiscreteTransferFcn: '<S149>/Filter Differentiator TF'
+  // Update for DiscreteTransferFcn: '<S147>/Filter Differentiator TF'
   control_outer_DW.FilterDifferentiatorTF_states_c =
     control_outer_DW.FilterDifferentiatorTF_tmp_p;
 
   // Update for UnitDelay: '<Root>/Unit Delay1'
-  control_outer_DW.UnitDelay1_DSTATE = rtb_UnitDelay1;
+  control_outer_DW.UnitDelay1_DSTATE = rtb_Abs;
 
-  // Update for DiscreteIntegrator: '<S156>/Integrator' incorporates:
+  // Update for DiscreteIntegrator: '<S154>/Integrator' incorporates:
   //   DiscreteIntegrator: '<S54>/Integrator'
 
-  control_outer_DW.Integrator_DSTATE_b = 0.0005F * rtb_PProdOut_o + rtb_Product;
+  control_outer_DW.Integrator_DSTATE_b = 0.0005F * rtb_PProdOut + rtb_Product;
   control_outer_DW.Integrator_PrevResetState_c = static_cast<int8_T>
     (rtb_FixPtRelationalOperator);
 
@@ -613,7 +540,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
 
   // Update for DiscreteIntegrator: '<S1>/Discrete-Time Integrator'
   control_outer_DW.DiscreteTimeIntegrator_SYSTEM_E = 0U;
-  control_outer_DW.DiscreteTimeIntegrator_DSTATE = 0.0005F * rtb_Abs +
+  control_outer_DW.DiscreteTimeIntegrator_DSTATE = 0.0005F * rtb_DenCoefOut +
     control_outer_B.DiscreteTimeIntegrator;
   control_outer_DW.DiscreteTimeIntegrator_PrevRese = static_cast<int8_T>
     (rtb_Compare);

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:25 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.31
+// Model version                  : 3.32
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -40,17 +40,17 @@ struct DW_control_outer_f_T {
   real32_T Integrator_DSTATE;          // '<S54>/Integrator'
   real32_T FilterDifferentiatorTF_states_i;// '<S97>/Filter Differentiator TF'
   real32_T Integrator_DSTATE_i;        // '<S104>/Integrator'
-  real32_T FilterDifferentiatorTF_states_c;// '<S149>/Filter Differentiator TF'
+  real32_T FilterDifferentiatorTF_states_c;// '<S147>/Filter Differentiator TF'
   real32_T UnitDelay1_DSTATE;          // '<Root>/Unit Delay1'
-  real32_T Integrator_DSTATE_b;        // '<S156>/Integrator'
+  real32_T Integrator_DSTATE_b;        // '<S154>/Integrator'
   real32_T DiscreteTimeIntegrator_DSTATE;// '<S1>/Discrete-Time Integrator'
   ControlModes DelayInput1_DSTATE;     // '<S2>/Delay Input1'
   real32_T FilterDifferentiatorTF_tmp; // '<S47>/Filter Differentiator TF'
   real32_T FilterDifferentiatorTF_tmp_m;// '<S97>/Filter Differentiator TF'
-  real32_T FilterDifferentiatorTF_tmp_p;// '<S149>/Filter Differentiator TF'
+  real32_T FilterDifferentiatorTF_tmp_p;// '<S147>/Filter Differentiator TF'
   int8_T Integrator_PrevResetState;    // '<S54>/Integrator'
   int8_T Integrator_PrevResetState_n;  // '<S104>/Integrator'
-  int8_T Integrator_PrevResetState_c;  // '<S156>/Integrator'
+  int8_T Integrator_PrevResetState_c;  // '<S154>/Integrator'
   int8_T DiscreteTimeIntegrator_PrevRese;// '<S1>/Discrete-Time Integrator'
   uint8_T DiscreteTimeIntegrator_SYSTEM_E;// '<S1>/Discrete-Time Integrator'
   boolean_T Memory_PreviousInput;      // '<S10>/Memory'
@@ -64,7 +64,7 @@ struct DW_control_outer_f_T {
 struct ZCE_control_outer_T {
   ZCSigState FilterDifferentiatorTF_Reset_ZC;// '<S47>/Filter Differentiator TF' 
   ZCSigState FilterDifferentiatorTF_Reset__m;// '<S97>/Filter Differentiator TF' 
-  ZCSigState FilterDifferentiatorTF_Reset__e;// '<S149>/Filter Differentiator TF' 
+  ZCSigState FilterDifferentiatorTF_Reset__e;// '<S147>/Filter Differentiator TF' 
 };
 
 #endif                                 //control_outer_MDLREF_HIDE_CHILD_
@@ -127,8 +127,8 @@ extern ZCE_control_outer_T control_outer_PrevZCX;
 //  Block '<S65>/Kt' : Eliminated nontunable gain of 1
 //  Block '<S97>/Passthrough for tuning' : Eliminate redundant data type conversion
 //  Block '<S115>/Kt' : Eliminated nontunable gain of 1
-//  Block '<S149>/Passthrough for tuning' : Eliminate redundant data type conversion
-//  Block '<S167>/Kt' : Eliminated nontunable gain of 1
+//  Block '<S147>/Passthrough for tuning' : Eliminate redundant data type conversion
+//  Block '<S165>/Kt' : Eliminated nontunable gain of 1
 
 
 //-
@@ -290,34 +290,32 @@ extern ZCE_control_outer_T control_outer_PrevZCX;
 //  '<S142>' : 'control_outer/Velocity PID control/Tsamp - Ngain'
 //  '<S143>' : 'control_outer/Velocity PID control/postSat Signal'
 //  '<S144>' : 'control_outer/Velocity PID control/preSat Signal'
-//  '<S145>' : 'control_outer/Velocity PID control/Anti-windup/Disc. Clamping Parallel'
-//  '<S146>' : 'control_outer/Velocity PID control/Anti-windup/Disc. Clamping Parallel/Dead Zone'
-//  '<S147>' : 'control_outer/Velocity PID control/Anti-windup/Disc. Clamping Parallel/Dead Zone/Enabled'
-//  '<S148>' : 'control_outer/Velocity PID control/D Gain/External Parameters'
-//  '<S149>' : 'control_outer/Velocity PID control/Filter/Disc. Trapezoidal Filter'
-//  '<S150>' : 'control_outer/Velocity PID control/Filter/Disc. Trapezoidal Filter/Tsamp'
-//  '<S151>' : 'control_outer/Velocity PID control/Filter/Disc. Trapezoidal Filter/Tsamp/Internal Ts'
-//  '<S152>' : 'control_outer/Velocity PID control/Filter ICs/Internal IC - Filter'
-//  '<S153>' : 'control_outer/Velocity PID control/I Gain/External Parameters'
-//  '<S154>' : 'control_outer/Velocity PID control/Ideal P Gain/Passthrough'
-//  '<S155>' : 'control_outer/Velocity PID control/Ideal P Gain Fdbk/Passthrough'
-//  '<S156>' : 'control_outer/Velocity PID control/Integrator/Discrete'
-//  '<S157>' : 'control_outer/Velocity PID control/Integrator ICs/Internal IC'
-//  '<S158>' : 'control_outer/Velocity PID control/N Copy/External Parameters'
-//  '<S159>' : 'control_outer/Velocity PID control/N Gain/External Parameters'
-//  '<S160>' : 'control_outer/Velocity PID control/P Copy/Disabled'
-//  '<S161>' : 'control_outer/Velocity PID control/Parallel P Gain/External Parameters'
-//  '<S162>' : 'control_outer/Velocity PID control/Reset Signal/External Reset'
-//  '<S163>' : 'control_outer/Velocity PID control/Saturation/Enabled'
-//  '<S164>' : 'control_outer/Velocity PID control/Saturation Fdbk/Enabled'
-//  '<S165>' : 'control_outer/Velocity PID control/Sum/Sum_PID'
-//  '<S166>' : 'control_outer/Velocity PID control/Sum Fdbk/Enabled'
-//  '<S167>' : 'control_outer/Velocity PID control/Tracking Mode/Enabled'
-//  '<S168>' : 'control_outer/Velocity PID control/Tracking Mode Sum/Tracking Mode'
-//  '<S169>' : 'control_outer/Velocity PID control/Tsamp - Integral/Passthrough'
-//  '<S170>' : 'control_outer/Velocity PID control/Tsamp - Ngain/Passthrough'
-//  '<S171>' : 'control_outer/Velocity PID control/postSat Signal/Feedback_Path'
-//  '<S172>' : 'control_outer/Velocity PID control/preSat Signal/Feedback_Path'
+//  '<S145>' : 'control_outer/Velocity PID control/Anti-windup/Passthrough'
+//  '<S146>' : 'control_outer/Velocity PID control/D Gain/External Parameters'
+//  '<S147>' : 'control_outer/Velocity PID control/Filter/Disc. Trapezoidal Filter'
+//  '<S148>' : 'control_outer/Velocity PID control/Filter/Disc. Trapezoidal Filter/Tsamp'
+//  '<S149>' : 'control_outer/Velocity PID control/Filter/Disc. Trapezoidal Filter/Tsamp/Internal Ts'
+//  '<S150>' : 'control_outer/Velocity PID control/Filter ICs/Internal IC - Filter'
+//  '<S151>' : 'control_outer/Velocity PID control/I Gain/External Parameters'
+//  '<S152>' : 'control_outer/Velocity PID control/Ideal P Gain/Passthrough'
+//  '<S153>' : 'control_outer/Velocity PID control/Ideal P Gain Fdbk/Passthrough'
+//  '<S154>' : 'control_outer/Velocity PID control/Integrator/Discrete'
+//  '<S155>' : 'control_outer/Velocity PID control/Integrator ICs/Internal IC'
+//  '<S156>' : 'control_outer/Velocity PID control/N Copy/External Parameters'
+//  '<S157>' : 'control_outer/Velocity PID control/N Gain/External Parameters'
+//  '<S158>' : 'control_outer/Velocity PID control/P Copy/Disabled'
+//  '<S159>' : 'control_outer/Velocity PID control/Parallel P Gain/External Parameters'
+//  '<S160>' : 'control_outer/Velocity PID control/Reset Signal/External Reset'
+//  '<S161>' : 'control_outer/Velocity PID control/Saturation/Passthrough'
+//  '<S162>' : 'control_outer/Velocity PID control/Saturation Fdbk/Passthrough'
+//  '<S163>' : 'control_outer/Velocity PID control/Sum/Sum_PID'
+//  '<S164>' : 'control_outer/Velocity PID control/Sum Fdbk/Enabled'
+//  '<S165>' : 'control_outer/Velocity PID control/Tracking Mode/Enabled'
+//  '<S166>' : 'control_outer/Velocity PID control/Tracking Mode Sum/Tracking Mode'
+//  '<S167>' : 'control_outer/Velocity PID control/Tsamp - Integral/Passthrough'
+//  '<S168>' : 'control_outer/Velocity PID control/Tsamp - Ngain/Passthrough'
+//  '<S169>' : 'control_outer/Velocity PID control/postSat Signal/Feedback_Path'
+//  '<S170>' : 'control_outer/Velocity PID control/preSat Signal/Feedback_Path'
 
 #endif                                 // RTW_HEADER_control_outer_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:25 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.31
+// Model version                  : 3.32
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:25 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.31
+// Model version                  : 3.32
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:47 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:41 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:43 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:43 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:43 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:43 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:01 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:58 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:58 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:58 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:28:58 2022
+// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:19:10 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
@@ -9,7 +9,7 @@
 //
 //  Model version              : 3.3
 //  Simulink Coder version : 9.7 (R2022a) 13-Nov-2021
-//  C++ source code generated on : Tue Jul 12 09:18:30 2022
+//  C++ source code generated on : Tue Jun  7 15:42:35 2022
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/multiword_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/multiword_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.6
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
 //
 #ifndef MULTIWORD_TYPES_H
 #define MULTIWORD_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:18:30 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:35 2022
 //
 #include "rtwtypes.h"
 #include "rt_hypotf_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:18:30 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:35 2022
 //
 #ifndef RTW_HEADER_rt_hypotf_snf_h_
 #define RTW_HEADER_rt_hypotf_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 extern "C" {
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.58
+// Model version                  : 4.62
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:01 2022
+// C/C++ source code generated on : Thu Jul 28 12:05:37 2022
 //
 #include "rtwtypes.h"
 #include "rt_roundd_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.58
+// Model version                  : 4.62
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:01 2022
+// C/C++ source code generated on : Thu Jul 28 12:05:37 2022
 //
 #ifndef RTW_HEADER_rt_roundd_snf_h_
 #define RTW_HEADER_rt_roundd_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.58
+// Model version                  : 4.6
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:01 2022
+// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.6
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
 //
 #include "uMultiWord2Double.h"
 #include <cmath>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWord2Double.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.6
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
 //
 #ifndef RTW_HEADER_uMultiWord2Double_h_
 #define RTW_HEADER_uMultiWord2Double_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.6
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
 //
 #include "uMultiWordShl.h"
 #include "rtwtypes.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/uMultiWordShl.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.6
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
 //
 #ifndef RTW_HEADER_uMultiWordShl_h_
 #define RTW_HEADER_uMultiWordShl_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
+// Model version                  : 3.8
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jul 12 09:17:54 2022
+// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:00 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:00 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,7 +19,6 @@
 #ifndef RTW_HEADER_SupervisorFSM_RX_private_h_
 #define RTW_HEADER_SupervisorFSM_RX_private_h_
 #include "rtwtypes.h"
-#include "multiword_types.h"
 #include "SupervisorFSM_RX_types.h"
 
 // Macros for accessing real-time model data structure

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:00 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.61
+// Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:19 2022
+// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:17:46 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:00 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.13
+// Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:34 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -120,7 +120,7 @@ void SupervisorFSM_TX(const SensorsData *rtu_SensorsData, const EstimatedData
   // Chart: '<Root>/SupervisorFSM_TX'
   if (SupervisorFSM_TX_DW.is_active_c3_SupervisorFSM_TX == 0U) {
     SupervisorFSM_TX_DW.is_active_c3_SupervisorFSM_TX = 1U;
-  } else {
+  } else if (rtu_Flags->enable_sending_msg_status) {
     rty_MessagesTx->foc.current = rtu_ControlOutputs->Iq_fbk.current;
     rty_MessagesTx->foc.velocity = rtu_EstimatedData->jointvelocities.velocity;
     rty_MessagesTx->foc.position = rtu_SensorsData->jointpositions.position;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.13
+// Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:34 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.13
+// Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:34 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.13
+// Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Wed Jul 13 11:27:34 2022
+// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Aug  9 15:18:03 2022
+// C/C++ source code generated on : Thu Aug 11 17:11:12 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M


### PR DESCRIPTION
This PR updates the Application07 of the AMCBLDC to the latest master of  https://github.com/icub-tech-iit/study-mbd-amc-bldc/commit/a742f74efce5865b159f38623ae6ee85fbd46411

Highlights are:
- [Remove PID conversion in Supervisor_RX](https://github.com/icub-tech-iit/study-mbd-amc-bldc/commit/5730b2a4a802d6dd10fffda624342f0bf9ecc2fa)
- [SupervisorRX: updated condition to exit HwFault control mode](https://github.com/icub-tech-iit/study-mbd-amc-bldc/commit/700abb763ab3f69588c4a2e660402ce693430d21)
- [moved vector functions up one directory and added README](https://github.com/icub-tech-iit/study-mbd-amc-bldc/commit/b27995a3a7b945f3033a364e7d242bd5dc6df88d)

Additionally, the Device Family Pack of the STM32G4 was updated from V1.4.0 to V1.5.0 upon a suggested update from the Keil IDE. 

The generated code was successfully tested on the Wrist Setup.