### PR TITLE
Fixed bootstrap in the amc board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/environment/eloader/src/eloader-embot.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eloader/src/eloader-embot.cpp
@@ -15,7 +15,7 @@
 // in here we run the baremetal embot::hw application.
 // for the required get1microtime() we can either use a very naked approach or even the systick
 
-#undef USE_SYSTICK_AS_TIME_BASE
+#define USE_SYSTICK_AS_TIME_BASE
 
 #if defined(USE_SYSTICK_AS_TIME_BASE)
 
@@ -124,14 +124,14 @@ constexpr eEmoduleExtendedInfo_t s_loader_info_extended __attribute__((section(E
                 .version    = 
                 { 
                     .major = 3, 
-                    .minor = 1
+                    .minor = 2
                 },  
                 .builddate  = 
                 {
                     .year  = 2022,
-                    .month = 4,
-                    .day   = 11,
-                    .hour  = 12,
+                    .month = 9,
+                    .day   = 16,
+                    .hour  = 9,
                     .min   = 15
                 }
             },


### PR DESCRIPTION
This PR fixes a problem in the bootstrap of the `amc`.

It happened that at power up, the board did not launch the application. 

The cause was that the `eLoader` program did not execute correctly because the low level initialization of the STM32 HAL failed for timeout due to a grossly simplified implementation of the `HAL_Delay(uint32_t ms)` which did not wait as it must.

Now the `eLoader` has a proper `HAL_Delay()` which uses SysTick to count in ms. That correctly initialize HW peripherals, so the board bootstraps finely.

