### PR TITLE
amc-bldc: now the motor configuration is done on `motor_config`message reception

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvoptx
@@ -170,6 +170,22 @@
           <ExecCommand></ExecCommand>
           <Expression>\\amcbldc\../src/embot_app_application_theMBDagent.cpp\418</Expression>
         </Bp>
+        <Bp>
+          <Number>1</Number>
+          <Type>0</Type>
+          <LineNumber>413</LineNumber>
+          <EnabledFlag>0</EnabledFlag>
+          <Address>0</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>0</BreakIfRCount>
+          <Filename>..\src\embot_app_application_theMBDagent.cpp</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression></Expression>
+        </Bp>
       </Breakpoint>
       <WatchWindow1>
         <Ww>
@@ -547,7 +563,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1319,7 +1335,7 @@
 
   <Group>
     <GroupName>others::motorhal</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1375,7 +1391,7 @@
 
   <Group>
     <GroupName>mbd</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1535,6 +1551,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>73</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\sharedutils\rtw_motor_config.c</PathWithFileName>
+      <FilenameWithoutPath>rtw_motor_config.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1545,7 +1573,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>73</FileNumber>
+      <FileNumber>74</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1557,7 +1585,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>74</FileNumber>
+      <FileNumber>75</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1569,7 +1597,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>75</FileNumber>
+      <FileNumber>76</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1581,7 +1609,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>76</FileNumber>
+      <FileNumber>77</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1601,7 +1629,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <FileNumber>78</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1613,7 +1641,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>79</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1625,7 +1653,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1637,7 +1665,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>81</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1657,7 +1685,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1669,7 +1697,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1681,7 +1709,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1693,7 +1721,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1713,7 +1741,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1725,7 +1753,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1737,7 +1765,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1749,7 +1777,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1769,7 +1797,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1781,7 +1809,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1793,7 +1821,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1805,7 +1833,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1825,7 +1853,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1837,7 +1865,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1849,7 +1877,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1869,7 +1897,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1881,7 +1909,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1893,7 +1921,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1905,7 +1933,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>100</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1925,7 +1953,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>101</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1937,7 +1965,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>101</FileNumber>
+      <FileNumber>102</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1949,7 +1977,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>102</FileNumber>
+      <FileNumber>103</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1961,7 +1989,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>103</FileNumber>
+      <FileNumber>104</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1975,13 +2003,13 @@
 
   <Group>
     <GroupName>mbd::amc-bldc</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <FileNumber>105</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1993,7 +2021,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <FileNumber>106</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2005,7 +2033,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <FileNumber>107</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2017,7 +2045,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <FileNumber>108</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -186,7 +186,6 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
-            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -889,6 +888,11 @@
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rt_roundd_snf.cpp</FilePath>
             </File>
+            <File>
+              <FileName>rtw_motor_config.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_motor_config.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1195,8 +1199,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -1365,7 +1369,6 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
-            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -2068,6 +2071,11 @@
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rt_roundd_snf.cpp</FilePath>
             </File>
+            <File>
+              <FileName>rtw_motor_config.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_motor_config.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2374,8 +2382,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -2544,7 +2552,6 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
-            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -3246,6 +3253,11 @@
               <FileName>rt_roundd_snf.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\sharedutils\rt_roundd_snf.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>rtw_motor_config.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\sharedutils\rtw_motor_config.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
@@ -398,9 +398,6 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
     
     AMC_BLDC_step_Time();
     
-    
-    
-
     // if there an output is available, send it to the CAN Netowork
     for (uint8_t i = 0; i < maxNumberOfPacketsCAN; i++)
     {
@@ -417,7 +414,7 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
     
     // If motor configuration parameters changed due to a SET_MOTOR_CONFIG message, then update hal as well (Only pole_pairs at the moment)
     // TODO: We should perform the following update inside the architectural model after a SET_MOTOR_CONFIG message has been received
-    MainConf.pwm.poles = AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs;
+    MainConf.pwm.num_polar_couples = AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs;
     
     measureTick->stop();
     

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
@@ -304,12 +304,7 @@ bool embot::app::application::theMBDagent::Impl::initialise()
     embot::hw::motor::setCallbackOnCurrents(embot::hw::MOTOR::one, Impl::onCurrents_FOC_innerloop, this);
     
     CAN_ID_AMC = embot::app::theCANboardInfo::getInstance().cachedCANaddress();
-    
-    // init motor configuration parameters from hal
-    // InitConfParams.motorconfig.pole_pairs = MainConf.pwm.poles;
-    //InitConfParams.motorconfig.has_hall_sens...
-    //auto todo... = MainConf.encoder.nsteps = 16000;  TODO: fix (this values depends on pole_pairs and actually it is missing in mbd)
-    
+        
     initted = true;
     return initted;
 }
@@ -414,7 +409,7 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
     
     // If motor configuration parameters changed due to a SET_MOTOR_CONFIG message, then update hal as well (Only pole_pairs at the moment)
     // TODO: We should perform the following update inside the architectural model after a SET_MOTOR_CONFIG message has been received
-    MainConf.pwm.num_polar_couples = AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs;
+    //MainConf.pwm.num_polar_couples = AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs;
     
     measureTick->stop();
     

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -46,7 +46,7 @@ ConfigurationParameters InitConfParams = {
     false,
     true,
     false,
-    16000,
+    0,
     0,
     0U,
     7U,

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.105
+// Model version                  : 4.107
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:29:08 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -46,7 +46,7 @@ ConfigurationParameters InitConfParams = {
     false,
     true,
     false,
-    0,
+    16000,
     0,
     0U,
     7U,
@@ -232,7 +232,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
     AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw];
 
   // ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element6'
+  //   Inport generated from: '<Root>/In Bus Element5'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc(&AMC_BLDC_U.SensorsData_p, &rtb_BusConversion_InsertedFor_F,
@@ -274,7 +274,7 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   // End of RateTransition generated from: '<Root>/Adapter1'
 
   // RateTransition generated from: '<Root>/Adapter3' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element6'
+  //   Inport generated from: '<Root>/In Bus Element5'
 
   rtw_mutex_lock();
   wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g + 1);
@@ -602,7 +602,7 @@ void AMC_BLDC_initialize(void)
   filter_current_Init();
 
   // SystemInitialize for ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element6'
+  //   Inport generated from: '<Root>/In Bus Element5'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc_Init();

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.105
+// Model version                  : 4.107
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:29:08 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.105
+// Model version                  : 4.107
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:29:08 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.105
+// Model version                  : 4.107
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:29:08 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/ert_main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/ert_main.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.105
+// Model version                  : 4.107
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:29:08 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.52
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:54 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.52
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:54 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.52
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:54 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.52
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:54 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.30
+// Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:01 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.30
+// Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:01 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.30
+// Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:01 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.30
+// Model version                  : 3.31
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:01 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:11 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.33
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:21 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.33
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:21 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.33
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:21 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.33
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:21 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:33 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:33 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:33 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:33 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:42 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:42 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:42 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.7
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:28:42 2022
+// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
@@ -9,7 +9,7 @@
 //
 //  Model version              : 3.3
 //  Simulink Coder version : 9.7 (R2022a) 13-Nov-2021
-//  C++ source code generated on : Tue Jun  7 15:42:35 2022
+//  C++ source code generated on : Tue Sep 13 12:54:58 2022
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:35 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:58 2022
 //
 #include "rtwtypes.h"
 #include "rt_hypotf_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 3.3
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:35 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:58 2022
 //
 #ifndef RTW_HEADER_rt_hypotf_snf_h_
 #define RTW_HEADER_rt_hypotf_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 extern "C" {
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.62
+// Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Jul 28 12:05:37 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:11 2022
 //
 #include "rtwtypes.h"
 #include "rt_roundd_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.62
+// Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Jul 28 12:05:37 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:11 2022
 //
 #ifndef RTW_HEADER_rt_roundd_snf_h_
 #define RTW_HEADER_rt_roundd_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtw_motor_config.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtw_motor_config.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 iCub Tech Facility - Istituto Italiano di Tecnologia
+ * Author:  Valentina Gaggero
+ * email:   valentina.gaggero@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#include "rtw_motor_config.h"
+#ifdef STM32HAL_BOARD_AMCBLDC
+
+#ifndef __cplusplus
+    #error this file must be compiled in C++ mode when deployed on the amcbldc target
+#endif
+// we use embot::hw
+#include "embot_hw_motor.h"
+#endif /* STM32HAL_BOARD_AMCBLDC */
+
+void rtw_configMotor(int16_t rotor_enc_resolution, uint8_t pole_pairs, uint8_t has_hall_sens, uint8_t swapBC, uint16_t hall_sens_offset)
+{
+    #ifdef STM32HAL_BOARD_AMCBLDC
+    embot::hw::motor::config(
+        embot::hw::MOTOR::one,         
+        rotor_enc_resolution, 
+        pole_pairs, 
+        has_hall_sens,
+        1,
+        120*65536/360);
+    #endif /* STM32HAL_BOARD_AMCBLDC */
+}

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtw_motor_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtw_motor_config.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 iCub Tech Facility - Istituto Italiano di Tecnologia
+ * Author:  Valentina Gaggero
+ * email:   valentina.gaggero@iit.it
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * http://www.robotcub.org/icub/license/gpl.txt
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#ifndef RTW_MOTOR_CONFIG_MOTORS
+#define RTW_MOTOR_CONFIG_MOTORS
+
+#ifdef __cplusplus
+    extern "C" {
+#endif /* __cplusplus */
+
+#include "stdint.h"
+
+/*inizialize the motor encoder using the data read in the configuration files (yarprobotinterface) 
+swapBC = 1
+hall_sens_offset = 120 *65536/360 ; icubDeg*/
+void rtw_configMotor(int16_t rotor_enc_resolution, uint8_t pole_pairs, uint8_t has_hall_sens, uint8_t swapBC, uint16_t hall_sens_offset);
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif /* __cplusplus */        
+
+#endif /* RTW_MOTOR_CONFIG_MOTORS */

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.6
+// Model version                  : 4.67
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:41:38 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:11 2022
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.8
+// Model version                  : 3.10
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Jun  7 15:42:14 2022
+// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
+// Model version                  : 4.74
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:31 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -68,6 +68,7 @@ static void SupervisorFSM_RX_Voltage(void);
 // Forward declaration for local functions
 static ControlModes SupervisorFSM_RX_convert(MCControlModes mccontrolmode);
 static void SupervisorFSM_formatMotorConfig(const BUS_MESSAGES_RX *Selector2);
+static void SupervisorF_hardwareConfigMotor(void);
 
 // Forward declaration for local functions
 static boolean_T SupervisorFSM_isBoardConfigured(void);
@@ -1040,6 +1041,14 @@ static void SupervisorFSM_formatMotorConfig(const BUS_MESSAGES_RX *Selector2)
     Selector2->motor_config.enable_verbosity;
 }
 
+// Function for Chart: '<S1>/CAN Event Dispatcher'
+static void SupervisorF_hardwareConfigMotor(void)
+{
+  rtw_configMotor(SupervisorFSM_RX_B.motorConfig.rotor_encoder_resolution,
+                  SupervisorFSM_RX_B.motorConfig.pole_pairs, static_cast<uint8_T>
+                  (SupervisorFSM_RX_B.motorConfig.has_hall_sens), 1U, 1U);
+}
+
 // System initialize for function-call system: '<Root>/CAN Message Handler'
 void Supervis_CANMessageHandler_Init(void)
 {
@@ -1162,6 +1171,7 @@ void SupervisorFSM_CANMessageHandler(void)
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].motor_config) {
         SupervisorFSM_formatMotorConfig(&Selector2);
+        SupervisorF_hardwareConfigMotor();
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].desired_targets) {
         SupervisorFSM_RX_B.newSetpoint =
@@ -1233,6 +1243,7 @@ void SupervisorFSM_CANMessageHandler(void)
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].motor_config) {
         SupervisorFSM_formatMotorConfig(&Selector2);
+        SupervisorF_hardwareConfigMotor();
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].desired_targets) {
         SupervisorFSM_RX_B.newSetpoint =

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
+// Model version                  : 4.74
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:31 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -23,6 +23,7 @@
 
 // user code (top of header file)
 #include "rtw_enable_disable_motors.h"
+#include "rtw_motor_config.h"
 
 // Block signals for model 'SupervisorFSM_RX'
 #ifndef SupervisorFSM_RX_MDLREF_HIDE_CHILD_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
+// Model version                  : 4.74
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:31 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
+// Model version                  : 4.74
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:31 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:44 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:44 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:44 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.12
 // Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep  1 10:27:44 2022
+// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/analog.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/analog.c
@@ -443,6 +443,9 @@ int32_t analogSetOffsetIph3(int32_t offs)
  * @param   
  * @return  
  */
+
+#undef MainConf
+
 HAL_StatusTypeDef analogInit(void)
 {
 	HAL_StatusTypeDef result = HAL_ERROR;
@@ -500,6 +503,18 @@ HAL_StatusTypeDef analogInit(void)
 		}
 	}
 	return result;
+}
+
+HAL_StatusTypeDef analogDeinit(void)
+{
+    /* Stop any ADC operation */
+    HAL_ADC_Stop_DMA(&hadc1);
+    HAL_ADC_Stop_DMA(&hadc2);
+    
+    /* uncalibrate ADCs */
+    MainConf.analog.cinOffs = 0;
+    
+    return HAL_OK;
 }
 
 #if defined(HALCONFIG_DONTUSE_TESTS)

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/analog.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/analog.h
@@ -50,6 +50,7 @@ typedef struct
 
 extern int32_t analogConvertCurrent(int32_t raw);
 extern HAL_StatusTypeDef analogInit(void);
+extern HAL_StatusTypeDef analogDeinit(void);
 extern uint32_t analogVcc(void);
 extern uint32_t analogVph1(void);
 extern uint32_t analogVph2(void);

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/encoder.h
@@ -35,7 +35,8 @@ typedef struct
     uint16_t    mode;
     uint16_t    filter;
     uint16_t    idxpos;
-    uint16_t    nsteps;
+    uint16_t    resolution;
+    uint16_t    has_hall_sens;
 } encoderConfTypeDef;
 
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/encoder.h
@@ -35,7 +35,7 @@ typedef struct
     uint16_t    mode;
     uint16_t    filter;
     uint16_t    idxpos;
-    uint16_t    resolution;
+    int16_t     resolution;
     uint16_t    has_hall_sens;
 } encoderConfTypeDef;
 
@@ -45,6 +45,9 @@ typedef struct
 /* Exported functions prototypes -------------------------------------------------------------------------------------*/
 
 extern HAL_StatusTypeDef encoderInit(void);
+extern HAL_StatusTypeDef encoderDeinit(void);
+extern HAL_StatusTypeDef encoderConfig(int16_t resolution, uint8_t num_polar_couples, uint8_t has_hall_sens);
+
 extern uint32_t encoderGetCounter(void);
 extern void encoderReset();
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.c
@@ -120,20 +120,7 @@ extern void set_ADC_callback(pwm_ADC_callback_t *cbk)
 
 #if defined(USE_STM32HAL) && defined(__cplusplus)
 
-#ifdef USE_KOLLMORGEN_SETUP
-constexpr uint16_t hallAngleTable[] =
-{
-    /* ABC  (°)  */
-    /* LLL ERROR */ 0,
-    /* LLH  300  */ static_cast<uint16_t>(120.0 * 65536.0 / 360.0 + 0.5), /* 54613 */
-    /* LHL  180  */ static_cast<uint16_t>(0.0 * 65536.0 / 360.0 + 0.5), /* 32768 */
-    /* LHH  240  */ static_cast<uint16_t>(60.0 * 65536.0 / 360.0 + 0.5), /* 43690 */
-    /* HLL   60  */ static_cast<uint16_t>(240.0 * 65536.0 / 360.0 + 0.5), /* 10923 */
-    /* HLH    0  */ static_cast<uint16_t>(180.0 * 65536.0 / 360.0 + 0.5), /*     0 */
-    /* HHL  120  */ static_cast<uint16_t>(300.0 * 65536.0 / 360.0 + 0.5), /* 21845 */
-    /* HHH ERROR */ static_cast<uint16_t>(0)
-};
-#else        
+
 constexpr uint16_t hallAngleTable[] =
 {
     /* ABC  (°)  */
@@ -146,33 +133,19 @@ constexpr uint16_t hallAngleTable[] =
     /* HHL   60  */ static_cast<uint16_t>( 60.0 * 65536.0 / 360.0), /* 10922 */
     /* HHH ERROR */ static_cast<uint16_t>(0)
 };
-#endif // USE_KOLLMORGEN_SETUP
 
 //constexpr int16_t hallSectorTable[] =
 //{
 //    /* ABC  (°)  */
-//    /* LLL ERROR */ 0,
-//    /* LLH  270  */ 4, /* 54613 */
-//    /* LHL  150  */ 2, /* 32768 */
-//    /* LHH  210  */ 3, /* 43690 */
-//    /* HLL   30  */ 0, /* 10923 */
-//    /* HLH  -30  */ 5, /*     0 */
-//    /* HHL   90  */ 1, /* 21845 */
-//    /* HHH ERROR */ static_cast<uint16_t>(0)
+//    /* LLL ERROR */ static_cast<int16_t>(0),
+//    /* LLH  240  */ static_cast<int16_t>(4), /* 43690 */
+//    /* LHL  120  */ static_cast<int16_t>(2), /* 21845 */
+//    /* LHH  180  */ static_cast<int16_t>(3), /* 32768 */
+//    /* HLL    0  */ static_cast<int16_t>(0), /*     0 */
+//    /* HLH  300  */ static_cast<int16_t>(5), /* 54613 */
+//    /* HHL   60  */ static_cast<int16_t>(1), /* 10922 */
+//    /* HHH ERROR */ static_cast<int16_t>(0)
 //};
-
-constexpr int16_t hallSectorTable[] =
-{
-    /* ABC  (°)  */
-    /* LLL ERROR */ static_cast<int16_t>(0),
-    /* LLH  240  */ static_cast<int16_t>(4), /* 43690 */
-    /* LHL  120  */ static_cast<int16_t>(2), /* 21845 */
-    /* LHH  180  */ static_cast<int16_t>(3), /* 32768 */
-    /* HLL    0  */ static_cast<int16_t>(0), /*     0 */
-    /* HLH  300  */ static_cast<int16_t>(5), /* 54613 */
-    /* HHL   60  */ static_cast<int16_t>(1), /* 10922 */
-    /* HHH ERROR */ static_cast<int16_t>(0)
-};
 
 #else
 static const uint16_t hallAngleTable[] =
@@ -185,6 +158,19 @@ static const uint16_t hallAngleTable[] =
     /* HLL   60  */  60.0 * 65536.0 / 360.0 + 0.5, /* 10923 */
     /* HLH    0  */   0.0 * 65536.0 / 360.0 + 0.5, /*     0 */
     /* HHL  120  */ 120.0 * 65536.0 / 360.0 + 0.5, /* 21845 */
+    /* HHH ERROR */ 0
+};
+
+static const int16_t hallSectorTable[] =
+{
+    /* ABC  (°)  */
+    /* LLL ERROR */ 0,
+    /* LLH  240  */ 4, /* 43690 */
+    /* LHL  120  */ 2, /* 21845 */
+    /* LHH  180  */ 3, /* 32768 */
+    /* HLL    0  */ 0, /*     0 */
+    /* HLH  300  */ 5, /* 54613 */
+    /* HHL   60  */ 1, /* 10922 */
     /* HHH ERROR */ 0
 };
 #endif
@@ -234,112 +220,84 @@ static uint8_t updateHallStatus(void)
     
     /* Read current value of HALL1, HALL2 and HALL3 signals in bits 2..0 */
     hallStatus = DECODE_HALLSTATUS;
-    
-    int16_t sector = (MainConf.pwm.sector_offset + hallSectorTable[hallStatus]) % 6;
-    static int16_t sector_old = sector;
-    
     uint16_t angle = MainConf.pwm.hall_offset + hallAngleTable[hallStatus];
     
-    hallAngle = angle;
-
-#ifdef USE_KOLLMORGEN_SETUP
-    // To disable the encoder reading, comment the following if then else
-    if (!hallStatus_old)
-    {            
-        hallCounter = 0;
-        
-        encoderReset();
+    //int16_t sector = (MainConf.pwm.sector_offset + hallSectorTable[hallStatus]) % 6;
+    int16_t sector = ((1+(int16_t)(angle)) / 60) % 6;
+    static int16_t sector_old = sector;
     
+    hallAngle = angle;
+    
+    if (MainConf.encoder.resolution == 0) // no encoder
+    {
         encoderForce(angle);
     }
     else
     {
-        bool forward = ((sector-sector_old+6)%6)==1;
-        
-        if (forward) // forward
-        {
-            ++hallCounter;
-            
-            angle -= 5461; // -30 deg
+        if (!hallStatus_old)
+        {            
+            hallCounter = 0;
+            encoderReset();
+            encoderForce(angle);
         }
         else
         {
-            --hallCounter;
-            
-            angle += 5461; // +30 deg
-        }
+            bool forward = ((sector-sector_old+6)%6)==1;
+        
+            if (forward) // forward
+            {
+                ++hallCounter;
+                angle -= 5461; // -30 deg
+            }
+            else
+            {
+                --hallCounter;
+                angle += 5461; // +30 deg
+            }
   
-        if (calibration_step == 0)
-        {
-            encoderForce(angle);
-            
-            //if (hallCounter < -50 || hallCounter > 50) // > npoles*6
-            //{
-                // now the optical encoder is Index calibrated
+            if (calibration_step == 0)
+            {
+                encoderForce(angle);
                 calibration_step = 1;
+            }
+            else if (calibration_step == 1)
+            {
+                encoderForce(angle);
+            
+                uint8_t s = forward ? sector : (sector+1)%6;
+            
+                border[s] = encoderGetUncalibrated();
+            
+                border_flag |= 1<<s;
+            
+                if (border_flag == 63)
+                {
+                    calibration_step = 2;
+                
+                    int32_t offset = int16_t(border[0]);
+                    offset += int16_t(border[1]-10923);
+                    offset += int16_t(border[2]-21845);
+                    offset += int16_t(border[3]-32768);
+                    offset += int16_t(border[4]-43691);
+                    offset += int16_t(border[5]-54613);
+                
+                    offset /= 6;
+                     
+                    embot::core::print("CALIBRATED\n");
+            
+                    encoderCalibrate(-int16_t(offset));
+                }
+            }
+            //else if (calibration_step == 2)
+            //{   
+            //    encoderCalibrate(angle);
             //}
         }
-        else if (calibration_step == 1)
-        {
-            encoderForce(angle);
-            
-            uint8_t s = forward ? sector : (sector+1)%6;
-            
-            border[s] = encoderGetUncalibrated();
-            
-            border_flag |= 1<<s;
-            
-            if (border_flag == 63)
-            {
-                calibration_step = 2;
-                
-                int32_t offset = int16_t(border[0]);
-                offset += int16_t(border[1]-10923);
-                offset += int16_t(border[2]-21845);
-                offset += int16_t(border[3]-32768);
-                offset += int16_t(border[4]-43691);
-                offset += int16_t(border[5]-54613);
-                
-                offset /= 6;
-                     
-                embot::core::print("CALIBRATED\n");
-            
-                encoderCalibrate(-int16_t(offset));
-            }
-        }
-        //else if (calibration_step == 2)
-        //{   
-        //    encoderCalibrate(angle);
-        //}
     }
-#else
-    encoderForce(angle);
-#endif
-
 
     // update the old sector and hall status
     sector_old = sector;
     hallStatus_old = hallStatus;
-    
-//    static uint32_t counter;
-//    static std::array<uint32_t, 128> hall_array;
-//    static std::array<uint32_t, 128> sector_array;
-//    
-//    hall_array[counter] = hallStatus;
-//    sector_array[counter] = sector;
-//    
-//    if (counter == 50) {
-//        static char msg[64] = {};
-
-//        for(int i = 0; i < hall_array.size(); i++){
-//            sprintf(msg, "%d %d", hall_array[i], sector_array[i]);
-//            embot::core::print(msg);
-//        }
-//        counter = 0;
-//    }
-//    counter++;
-    
-
     
     return hallStatus;
 }
@@ -434,6 +392,9 @@ void pwmSetCurrents_cb(int16_t i1, int16_t i2, int16_t i3)
  */
 HAL_StatusTypeDef pwmInit(void)
 {
+    /* todo: no HALL sensor motor index startup calibration */    
+    MainConf.pwm.mode = PWM_CONF_MODE_HALL;
+    
     /* Clear any preceeding fault condition */
     pwmReset(ENABLE);
     pwmSleep(DISABLE);
@@ -441,15 +402,11 @@ HAL_StatusTypeDef pwmInit(void)
     pwmReset(DISABLE);
     HAL_Delay(10);
 
-    if (0 == (MainConf.pwm.mode & PWM_CONF_MODE_MASK))
-    {
-        MainConf.pwm.mode = PWM_CONF_MODE_HALL;
-#ifdef USE_KOLLMORGEN_SETUP
-        MainConf.pwm.num_polar_couples = 4;//7; // // //
-#else
-        MainConf.pwm.num_polar_couples = 7; // // //
-#endif
-    }
+//    if (0 == (MainConf.pwm.mode & PWM_CONF_MODE_MASK))
+//    {
+//        MainConf.pwm.mode = PWM_CONF_MODE_HALL;
+//        MainConf.pwm.num_polar_couples = num_polar_couples;
+//    }
         
     /* Register the required TIM1 callback functions */
     HAL_TIM_RegisterCallback(&htim1, HAL_TIM_BREAK_CB_ID, pwmMotorFault_cb);
@@ -458,7 +415,7 @@ HAL_StatusTypeDef pwmInit(void)
     /* Reset the PWM value */
     pwmSet(0, 0 ,0);
     
-    updateHallStatus();
+    //updateHallStatus();
 
     /* Start TIM1 as 3-phase PWM generator */
     if (HAL_OK != HAL_TIM_PWM_Start(&htim1, TIM_CHANNEL_1) ||
@@ -485,16 +442,6 @@ HAL_StatusTypeDef pwmInit(void)
  */
 HAL_StatusTypeDef hallInit(void)
 {
-    hallOrder[0] = 0;
-    hallOrder[1] = MainConf.pwm.swapBC ? 2 : 1;
-    hallOrder[2] = MainConf.pwm.swapBC ? 1 : 2;
-    
-    /* Read value of HALL1, HALL2 and HALL3 signals in bits 2..0 */
-    hallStatus = DECODE_HALLSTATUS;
-
-    /* Init angle */
-    hallAngle = MainConf.pwm.hall_offset + hallAngleTable[hallStatus];
-    
     /* Start position counter */
     hallCounter = 0;
 
@@ -507,6 +454,27 @@ HAL_StatusTypeDef hallInit(void)
             (HAL_OK == HAL_TIM_Base_Start_IT(&htim3)))? HAL_OK : HAL_ERROR;
 }
 
+HAL_StatusTypeDef hallDeinit(void)
+{
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef hallConfig(uint8_t swapBC, uint16_t pwm_hall_offset)
+{
+    MainConf.pwm.hall_offset = pwm_hall_offset;
+    MainConf.pwm.swapBC = swapBC;
+    
+    hallOrder[0] = 0;
+    hallOrder[1] = MainConf.pwm.swapBC ? 2 : 1;
+    hallOrder[2] = MainConf.pwm.swapBC ? 1 : 2;
+
+    updateHallStatus();
+    
+    /* Start position counter */
+    hallCounter = 0;
+    
+    return HAL_OK;
+}
 
 /*******************************************************************************************************************//**
  * @brief   Read the position counter driven by the Hall sensors

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.c
@@ -434,6 +434,12 @@ HAL_StatusTypeDef pwmInit(void)
     return HAL_OK;
 }
 
+HAL_StatusTypeDef pwmDeinit(void)
+{
+    pwmPhaseDisable(PWM_PHASE_ALL);
+    
+    return HAL_OK;
+}
 
 /*******************************************************************************************************************//**
  * @brief   Complete the CubeMx TIM3 configuration for the PWM subsystem

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.h
@@ -49,7 +49,10 @@
 typedef struct
 {
     uint32_t    mode;
-    uint8_t    poles;
+    uint16_t    hall_offset;
+    uint16_t    sector_offset;
+    uint8_t     num_polar_couples;
+    uint8_t     swapBC;
 } pwmConfTypeDef;
 
 // we keep int32_t even if the adc gets only int16_t values

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.h
@@ -79,6 +79,7 @@ extern uint16_t hallGetAngle(void);
 extern uint16_t hallGetStatus(void);
 
 extern HAL_StatusTypeDef pwmInit(void);
+extern HAL_StatusTypeDef pwmDeinit(void);
 extern void pwmSleep(FunctionalState enable);
 extern void pwmReset(FunctionalState enable);
 extern HAL_StatusTypeDef pwmResetFault(void);

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/motorhal/pwm.h
@@ -50,7 +50,7 @@ typedef struct
 {
     uint32_t    mode;
     uint16_t    hall_offset;
-    uint16_t    sector_offset;
+    //uint16_t    sector_offset;
     uint8_t     num_polar_couples;
     uint8_t     swapBC;
 } pwmConfTypeDef;
@@ -71,6 +71,8 @@ typedef struct
 /* Exported functions prototypes -------------------------------------------------------------------------------------*/
 
 extern HAL_StatusTypeDef hallInit(void);
+HAL_StatusTypeDef hallDeinit(void);
+HAL_StatusTypeDef hallConfig(uint8_t swapBC, uint16_t pwm_hall_offset);
 extern int32_t hallGetCounter(void);
 extern void hallSetCounter(int32_t count);
 extern uint16_t hallGetAngle(void);

--- a/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc.cpp
@@ -730,7 +730,22 @@ namespace embot { namespace hw { namespace motor {
   
     };
     
-    void BSP::init(embot::hw::MOTOR h) const {}
+    void BSP::init(embot::hw::MOTOR h) const {
+    // step 1: what cube mx does
+        MX_ADC1_Init();
+        MX_ADC2_Init();
+        
+        MX_TIM1_Init();
+        MX_TIM3_Init();
+        MX_TIM2_Init();
+        MX_CORDIC_Init();
+        MX_FMAC_Init();
+        MX_CRC_Init();   
+        
+        HAL_GPIO_WritePin(VAUXEN_GPIO_Port, VAUXEN_Pin, GPIO_PIN_SET);
+        HAL_Delay(10); 
+    
+    }
         
     #else
         #error embot::hw::motor::thebsp must be defined    

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -371,8 +371,20 @@ namespace embot { namespace hw { namespace motor {
         MX_FMAC_Init();
         MX_CRC_Init();   
 
-        // step 2: what giorgio zini does
+        // step 2: motor+sensors configuration
         memset(&MainConf, 0, sizeof(MainConf));
+        
+        MainConf.encoder.mode   = TIM_ENCODERMODE_TI12;
+        MainConf.encoder.filter = 4;
+        MainConf.encoder.idxpos = TIM_ENCODERINDEX_POSITION_00;
+        MainConf.encoder.resolution = 0; // Wrist Mk2 does not have quadrature encoder
+        MainConf.encoder.has_hall_sens = 1;
+        
+        MainConf.pwm.mode = PWM_CONF_MODE_HALL;
+        MainConf.pwm.num_polar_couples = 7;
+        MainConf.pwm.hall_offset = (120 * 65536)/360;
+        MainConf.pwm.sector_offset = 4; // TODO verify correctness
+        MainConf.pwm.swapBC = 1;
         
         analogInit();
         pwmInit(); // pwmInit() shall be called before encoderInit() as the latter uses specific PWM quantities

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -389,9 +389,9 @@ namespace embot { namespace hw { namespace motor {
         // motor+sensors configuration
         memset(&MainConf, 0, sizeof(MainConf));
 
-        analogInit();  // done
-        encoderInit(); // done
-        hallInit();    // done
+        analogInit();  
+        encoderInit(); 
+        hallInit();    
         pwmInit();
 
         return resOK; 
@@ -399,6 +399,7 @@ namespace embot { namespace hw { namespace motor {
     
     result_t s_hw_deinit(MOTOR h)
     {
+        pwmDeinit();
         analogDeinit();
         encoderDeinit();
         hallDeinit();
@@ -415,6 +416,10 @@ namespace embot { namespace hw { namespace motor {
         uint16_t pwm_hall_offset)
     {
         result_t res = resOK;
+        
+        s_hw_deinit(h);
+        
+        s_hw_init(h);
         
         if (HAL_OK != encoderConfig(enc_resolution, pwm_num_polar_couples, pwm_has_hall_sens)) res = resNOK;
         if (HAL_OK != hallConfig(pwm_swapBC, pwm_hall_offset)) res = resNOK;

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -138,6 +138,7 @@ namespace embot { namespace hw { namespace motor {
     static PrivateData s_privatedata;
     
     result_t s_hw_init(MOTOR h);
+    result_t s_hw_deinit(MOTOR h);
     result_t s_hw_configure(
         MOTOR h,
         int16_t  enc_resolution, 
@@ -211,7 +212,8 @@ namespace embot { namespace hw { namespace motor {
         
         if(true == initialised(h))
         {
-            return resOK;
+            s_hw_deinit(h);
+            //return resOK;
         }
                 
         std::uint8_t index = embot::core::tointegral(h);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -384,38 +384,14 @@ namespace embot { namespace hw { namespace motor {
     
     result_t s_hw_init(MOTOR h)
     {
-        // step 1: what cube mx does
-        MX_ADC1_Init();
-        MX_ADC2_Init();
-        
-        MX_TIM1_Init();
-        MX_TIM3_Init();
-        MX_TIM2_Init();
-        MX_CORDIC_Init();
-        MX_FMAC_Init();
-        MX_CRC_Init();   
-
-        // step 2: motor+sensors configuration
+        // motor+sensors configuration
         memset(&MainConf, 0, sizeof(MainConf));
-//        
-//        MainConf.pwm.mode = PWM_CONF_MODE_HALL;
-//        MainConf.pwm.num_polar_couples = 7;
-//        MainConf.pwm.hall_offset = (120 * 65536)/360;
-//        MainConf.pwm.sector_offset = 4; // TODO verify correctness
-//        MainConf.pwm.swapBC = 1;
-        
+
         analogInit();  // done
         encoderInit(); // done
         hallInit();    // done
         pwmInit();
 
-        HAL_GPIO_WritePin(VAUXEN_GPIO_Port, VAUXEN_Pin, GPIO_PIN_SET);
-        HAL_Delay(10); 
-
-
-        // ok, we are now ready to use the driver
-        // or not. we should test it
-        
         return resOK; 
     }
     

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
@@ -53,6 +53,12 @@ namespace embot { namespace hw { namespace motor {
     
     result_t fault(MOTOR h, bool on);
     result_t init(embot::hw::MOTOR h, const Config &config);   
+    result_t config(MOTOR h, 
+        int16_t  enc_resolution, 
+        uint8_t  pwm_num_polar_couples, 
+        uint8_t  pwm_has_hall_sens,
+        uint8_t  pwm_swapBC,
+        uint16_t pwm_hall_offset);
     // enable(h, true) is effective only if(false == faulted(h))    
     result_t enable(MOTOR h, bool on);
     


### PR DESCRIPTION
@ale-git and I updated the amc-bldc fw in order to configure the motor device (composed by analog, rotor encoder and PWM) in run time on `motor_config`message reception.

We tested the fw on wrist setup and it works fine.

cc @mfussi66 