### PR TITLE
AMCBLDC – Update codegen

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvoptx
@@ -120,7 +120,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP1445368 -O206 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC168000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
+          <Name>-UP0948193 -O206 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC168000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -153,40 +153,7 @@
           <Name>UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512 -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM))</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>418</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>134405684</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\embot_app_application_theMBDagent.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcbldc\../src/embot_app_application_theMBDagent.cpp\418</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>413</LineNumber>
-          <EnabledFlag>0</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\embot_app_application_theMBDagent.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/proj/amcbldc-application07.uvprojx
@@ -10,7 +10,7 @@
       <TargetName>amcbldc-app07-osal-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6160000::V6.16::ARMCLANG</pCCUsed>
+      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -186,6 +186,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1369,6 +1370,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -2552,6 +2554,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/embot_app_application_theMBDagent.cpp
@@ -224,8 +224,6 @@ struct embot::app::application::theMBDagent::Impl
     volatile embot::core::Time EXTFAULTpressedtime {0};
     volatile embot::core::Time EXTFAULTreleasedtime {0};
     
-    static constexpr uint8_t maxNumberOfPacketsCAN {4};  //define the max number of CAN pkt managed
-
     #ifdef PRINT_HISTO_DEBUG 
     void printHistogram_rxPkt(size_t cur_size); //cur_size is the currente queue size
     static constexpr uint8_t numOfBins {11}; //size of queue of the CAN drive plus 1 (in case any packet is received)
@@ -359,7 +357,7 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
     }
         
     // 1. reset all info 
-    for (uint8_t i = 0; i < maxNumberOfPacketsCAN; i++) {
+    for (uint8_t i = 0; i < CAN_MAX_NUM_PACKETS; i++) {
         AMC_BLDC_U.PacketsRx.packets[i].available = false;
     }
     
@@ -368,8 +366,8 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
     size_t ninputframes = cur_size;
     
     // 3. limit the number of can pkts per cycle to maxNumberOfPacketsCAN 
-    if(ninputframes>maxNumberOfPacketsCAN)
-        ninputframes = maxNumberOfPacketsCAN;
+    if(ninputframes>CAN_MAX_NUM_PACKETS)
+        ninputframes = CAN_MAX_NUM_PACKETS;
     
     // 4. take ninputframes frames and inset them in the supervisor input queue.
     for (uint8_t i = 0; i < ninputframes; i++) {
@@ -394,7 +392,7 @@ bool embot::app::application::theMBDagent::Impl::tick(std::vector<embot::prot::c
     AMC_BLDC_step_Time();
     
     // if there an output is available, send it to the CAN Netowork
-    for (uint8_t i = 0; i < maxNumberOfPacketsCAN; i++)
+    for (uint8_t i = 0; i < CAN_MAX_NUM_PACKETS; i++)
     {
         //if (amc_bldc.AMC_BLDC_Y.PacketsTx.packets[i].available)
         if (AMC_BLDC_Y.PacketsTx.packets[i].available)

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.107
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
+// Model version                  : 5.1
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:31 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.107
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
+// Model version                  : 5.1
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:31 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -127,7 +127,8 @@ struct tag_RTM_AMC_BLDC_T {
 // Block signals (default storage)
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -136,6 +137,7 @@ extern "C" {
 #ifdef __cplusplus
 
 }
+
 #endif
 
 // Block states (default storage)
@@ -143,7 +145,8 @@ extern struct DW_AMC_BLDC_T AMC_BLDC_DW;
 
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -156,6 +159,7 @@ extern "C" {
 #ifdef __cplusplus
 
 }
+
 #endif
 
 //
@@ -186,7 +190,8 @@ extern uint8_T CAN_ID_AMC;             // Variable: CAN_ID_AMC
 
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -200,12 +205,14 @@ extern "C" {
 #ifdef __cplusplus
 
 }
+
 #endif
 
 // Real-time Model object
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -214,6 +221,7 @@ extern "C" {
 #ifdef __cplusplus
 
 }
+
 #endif
 
 //-

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.107
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
+// Model version                  : 5.1
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:31 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,7 @@
 #define RTW_HEADER_AMC_BLDC_private_h_
 #include "rtwtypes.h"
 #include "zero_crossing_types.h"
+#include "AMC_BLDC_types.h"
 #endif                                 // RTW_HEADER_AMC_BLDC_private_h_
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.107
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
+// Model version                  : 5.1
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:31 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,7 +20,20 @@
 #define RTW_HEADER_AMC_BLDC_types_h_
 #include "rtwtypes.h"
 
-// Model Code Variants
+// Includes for objects with custom storage classes
+#include "rtw_defines.h"
+
+//
+//  Registered constraints for dimension variants
+
+#if CAN_MAX_NUM_PACKETS <= 0
+# error "The preprocessor definition 'CAN_MAX_NUM_PACKETS' must be greater than '0'"
+#endif
+
+#if CAN_MAX_NUM_PACKETS >= 16
+# error "The preprocessor definition 'CAN_MAX_NUM_PACKETS' must be less than '16'"
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_JointPositions_
 #define DEFINED_TYPEDEF_FOR_JointPositions_
 
@@ -478,7 +491,7 @@ struct BUS_MESSAGES_RX
 
 struct BUS_MESSAGES_RX_MULTIPLE
 {
-  BUS_MESSAGES_RX messages[4];
+  BUS_MESSAGES_RX messages[CAN_MAX_NUM_PACKETS];
 };
 
 #endif
@@ -504,7 +517,7 @@ struct BUS_STATUS_RX
 
 struct BUS_STATUS_RX_MULTIPLE
 {
-  BUS_STATUS_RX status[4];
+  BUS_STATUS_RX status[CAN_MAX_NUM_PACKETS];
 };
 
 #endif
@@ -541,7 +554,7 @@ struct BUS_CAN_RX_ERRORS
 
 struct BUS_CAN_RX_ERRORS_MULTIPLE
 {
-  BUS_CAN_RX_ERRORS errors[4];
+  BUS_CAN_RX_ERRORS errors[CAN_MAX_NUM_PACKETS];
 };
 
 #endif
@@ -678,7 +691,7 @@ struct BUS_CAN
 
 struct BUS_CAN_MULTIPLE
 {
-  BUS_CAN packets[4];
+  BUS_CAN packets[CAN_MAX_NUM_PACKETS];
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/ert_main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/amc-bldc/ert_main.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 4.107
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:39 2022
+// Model version                  : 5.1
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:31 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.52
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <stddef.h>
 #include "can_decoder_private.h"
+#include "rtw_defines.h"
 
 // Named constants for Chart: '<S2>/Decoding Logic'
 const int32_T ca_event_ev_error_pck_malformed = 1;
@@ -29,7 +30,7 @@ const int32_T can_d_event_ev_error_pck_not4us = 2;
 const int32_T can_decoder_CALL_EVENT = -1;
 const uint8_T can_decoder_IN_Event_Error = 1U;
 const uint8_T can_decoder_IN_Home = 1U;
-const uint8_T can_decoder_IN_Home_b = 2U;
+const uint8_T can_decoder_IN_Home_d = 2U;
 const int32_T event_ev_error_mode_unrecognize = 0;
 MdlrefDW_can_decoder_T can_decoder_MdlrefDW;
 
@@ -72,11 +73,11 @@ static void can_decoder_ERROR_HANDLING(boolean_T rtu_pck_available,
   guard1 = false;
   switch (localDW->is_ERROR_HANDLING) {
    case can_decoder_IN_Event_Error:
-    localDW->is_ERROR_HANDLING = can_decoder_IN_Home_b;
+    localDW->is_ERROR_HANDLING = can_decoder_IN_Home_d;
     localDW->cmd_processed = 0U;
     break;
 
-   case can_decoder_IN_Home_b:
+   case can_decoder_IN_Home_d:
     if (localDW->sfEvent == can_d_event_ev_error_pck_not4us) {
       localB->error_type = CANErrorTypes_Packet_Not4Us;
       localDW->ev_errorEventCounter++;
@@ -103,7 +104,7 @@ static void can_decoder_ERROR_HANDLING(boolean_T rtu_pck_available,
       }
 
       localDW->ev_async = false;
-      localDW->is_ERROR_HANDLING = can_decoder_IN_Home_b;
+      localDW->is_ERROR_HANDLING = can_decoder_IN_Home_d;
       localDW->cmd_processed = 0U;
     }
     break;
@@ -121,7 +122,7 @@ static int16_T can_decoder_merge_2bytes_signed(uint16_T bl, uint16_T bh)
   int16_T sw;
   uint16_T x;
   x = static_cast<uint16_T>(static_cast<uint16_T>(bh << 8) | bl);
-  std::memcpy((void *)&sw, (void *)&x, (uint32_T)((size_t)1 * sizeof(int16_T)));
+  std::memcpy((void *)&sw, (void *)&x, (size_t)1 * sizeof(int16_T));
   return sw;
 }
 
@@ -209,7 +210,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
     localDW->is_SET_MOTOR_CONFIG = can_decoder_IN_Home;
     localDW->is_active_ERROR_HANDLING = 1U;
     localDW->ev_async = false;
-    localDW->is_ERROR_HANDLING = can_decoder_IN_Home_b;
+    localDW->is_ERROR_HANDLING = can_decoder_IN_Home_d;
     localDW->cmd_processed = 0U;
   } else {
     if ((localDW->is_active_SET_CONTROL_MODE != 0U) &&
@@ -543,57 +544,22 @@ void can_decoder_Init(void)
   };
 
   // SystemInitialize for Iterator SubSystem: '<Root>/Cycling Decoder'
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-  // SystemInitialize for MATLAB Function: '<S3>/RAW2STRUCT Decoding Logic'
-  can_decoder_B.CoreSubsys[0].pck_rx_struct = tmp;
+  for (int32_T ForEach_itr = 0; ForEach_itr < CAN_MAX_NUM_PACKETS; ForEach_itr++)
+  {
+    // SystemInitialize for Atomic SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
+    // SystemInitialize for MATLAB Function: '<S3>/RAW2STRUCT Decoding Logic'
+    can_decoder_B.CoreSubsys[ForEach_itr].pck_rx_struct = tmp;
 
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
+    // End of SystemInitialize for SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
 
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_Decoder'
-  // SystemInitialize for Chart: '<S2>/Decoding Logic'
-  can_decoder_DecodingLogic_Init(&can_decoder_B.CoreSubsys[0].sf_DecodingLogic,
-    &can_decoder_DW.CoreSubsys[0].sf_DecodingLogic);
+    // SystemInitialize for Atomic SubSystem: '<S1>/CAN_Decoder'
+    // SystemInitialize for Chart: '<S2>/Decoding Logic'
+    can_decoder_DecodingLogic_Init(&can_decoder_B.CoreSubsys[ForEach_itr].
+      sf_DecodingLogic, &can_decoder_DW.CoreSubsys[ForEach_itr].sf_DecodingLogic);
 
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_Decoder'
+    // End of SystemInitialize for SubSystem: '<S1>/CAN_Decoder'
+  }
 
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-  // SystemInitialize for MATLAB Function: '<S3>/RAW2STRUCT Decoding Logic'
-  can_decoder_B.CoreSubsys[1].pck_rx_struct = tmp;
-
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_Decoder'
-  // SystemInitialize for Chart: '<S2>/Decoding Logic'
-  can_decoder_DecodingLogic_Init(&can_decoder_B.CoreSubsys[1].sf_DecodingLogic,
-    &can_decoder_DW.CoreSubsys[1].sf_DecodingLogic);
-
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_Decoder'
-
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-  // SystemInitialize for MATLAB Function: '<S3>/RAW2STRUCT Decoding Logic'
-  can_decoder_B.CoreSubsys[2].pck_rx_struct = tmp;
-
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_Decoder'
-  // SystemInitialize for Chart: '<S2>/Decoding Logic'
-  can_decoder_DecodingLogic_Init(&can_decoder_B.CoreSubsys[2].sf_DecodingLogic,
-    &can_decoder_DW.CoreSubsys[2].sf_DecodingLogic);
-
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_Decoder'
-
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-  // SystemInitialize for MATLAB Function: '<S3>/RAW2STRUCT Decoding Logic'
-  can_decoder_B.CoreSubsys[3].pck_rx_struct = tmp;
-
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_RX_RAW2STRUCT'
-
-  // SystemInitialize for Atomic SubSystem: '<S1>/CAN_Decoder'
-  // SystemInitialize for Chart: '<S2>/Decoding Logic'
-  can_decoder_DecodingLogic_Init(&can_decoder_B.CoreSubsys[3].sf_DecodingLogic,
-    &can_decoder_DW.CoreSubsys[3].sf_DecodingLogic);
-
-  // End of SystemInitialize for SubSystem: '<S1>/CAN_Decoder'
   // End of SystemInitialize for SubSystem: '<Root>/Cycling Decoder'
 }
 
@@ -607,7 +573,8 @@ void can_decoder(const BUS_CAN_MULTIPLE *rtu_pck_rx_raw, const
   // Outputs for Iterator SubSystem: '<Root>/Cycling Decoder' incorporates:
   //   ForEach: '<S1>/For Each'
 
-  for (int32_T ForEach_itr = 0; ForEach_itr < 4; ForEach_itr++) {
+  for (int32_T ForEach_itr = 0; ForEach_itr < CAN_MAX_NUM_PACKETS; ForEach_itr++)
+  {
     uint8_T minval;
     uint8_T x_idx_1;
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.52
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,7 @@
 #define RTW_HEADER_can_decoder_h_
 #include "rtwtypes.h"
 #include "can_decoder_types.h"
+#include "rtw_defines.h"
 
 // Block signals for system '<S2>/Decoding Logic'
 #ifndef can_decoder_MDLREF_HIDE_CHILD_
@@ -55,16 +56,16 @@ struct DW_DecodingLogic_can_decoder_T {
   uint32_T ev_set_velocity_pidEventCounter;// '<S2>/Decoding Logic'
   uint32_T ev_set_motor_configEventCounter;// '<S2>/Decoding Logic'
   uint16_T cmd_processed;              // '<S2>/Decoding Logic'
-  uint8_T is_active_c3_can_decoder;    // '<S2>/Decoding Logic'
   uint8_T is_SET_CONTROL_MODE;         // '<S2>/Decoding Logic'
-  uint8_T is_active_SET_CONTROL_MODE;  // '<S2>/Decoding Logic'
   uint8_T is_DESIRED_TARGETS;          // '<S2>/Decoding Logic'
-  uint8_T is_active_DESIRED_TARGETS;   // '<S2>/Decoding Logic'
   uint8_T is_SET_OPTIONS;              // '<S2>/Decoding Logic'
-  uint8_T is_active_SET_OPTIONS;       // '<S2>/Decoding Logic'
   uint8_T is_SET_MOTOR_CONFIG;         // '<S2>/Decoding Logic'
-  uint8_T is_active_SET_MOTOR_CONFIG;  // '<S2>/Decoding Logic'
   uint8_T is_ERROR_HANDLING;           // '<S2>/Decoding Logic'
+  uint8_T is_active_c3_can_decoder;    // '<S2>/Decoding Logic'
+  uint8_T is_active_SET_CONTROL_MODE;  // '<S2>/Decoding Logic'
+  uint8_T is_active_DESIRED_TARGETS;   // '<S2>/Decoding Logic'
+  uint8_T is_active_SET_OPTIONS;       // '<S2>/Decoding Logic'
+  uint8_T is_active_SET_MOTOR_CONFIG;  // '<S2>/Decoding Logic'
   uint8_T is_active_ERROR_HANDLING;    // '<S2>/Decoding Logic'
   boolean_T ev_async;                  // '<S2>/Decoding Logic'
 };
@@ -101,7 +102,7 @@ struct DW_CoreSubsys_can_decoder_T {
 #ifndef can_decoder_MDLREF_HIDE_CHILD_
 
 struct B_can_decoder_c_T {
-  B_CoreSubsys_can_decoder_T CoreSubsys[4];// '<Root>/Cycling Decoder'
+  B_CoreSubsys_can_decoder_T CoreSubsys[CAN_MAX_NUM_PACKETS];// '<Root>/Cycling Decoder' 
 };
 
 #endif                                 //can_decoder_MDLREF_HIDE_CHILD_
@@ -110,7 +111,7 @@ struct B_can_decoder_c_T {
 #ifndef can_decoder_MDLREF_HIDE_CHILD_
 
 struct DW_can_decoder_f_T {
-  DW_CoreSubsys_can_decoder_T CoreSubsys[4];// '<Root>/Cycling Decoder'
+  DW_CoreSubsys_can_decoder_T CoreSubsys[CAN_MAX_NUM_PACKETS];// '<Root>/Cycling Decoder' 
 };
 
 #endif                                 //can_decoder_MDLREF_HIDE_CHILD_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.52
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,6 +19,7 @@
 #ifndef RTW_HEADER_can_decoder_private_h_
 #define RTW_HEADER_can_decoder_private_h_
 #include "rtwtypes.h"
+#include "can_decoder_types.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-decoder/can_decoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 3.52
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:52 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:35 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,29 @@
 #ifndef RTW_HEADER_can_decoder_types_h_
 #define RTW_HEADER_can_decoder_types_h_
 #include "rtwtypes.h"
+#include "can_decoder_types.h"
 
-// Model Code Variants
+// Includes for objects with custom storage classes
+#include "rtw_defines.h"
+
+//
+//  Constraints for division operations in dimension variants
+
+#if (1 == 0) || ((CAN_MAX_NUM_PACKETS % 1) != 0)
+# error "The preprocessor definition '1' must not be equal to zero and     the division of 'CAN_MAX_NUM_PACKETS' by '1' must not have a remainder."
+#endif
+
+//
+//  Registered constraints for dimension variants
+
+#if CAN_MAX_NUM_PACKETS <= 0
+# error "The preprocessor definition 'CAN_MAX_NUM_PACKETS' must be greater than '0'"
+#endif
+
+#if CAN_MAX_NUM_PACKETS >= 16
+# error "The preprocessor definition 'CAN_MAX_NUM_PACKETS' must be less than '16'"
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_BUS_CAN_PACKET_
 #define DEFINED_TYPEDEF_FOR_BUS_CAN_PACKET_
 
@@ -54,7 +75,7 @@ struct BUS_CAN
 
 struct BUS_CAN_MULTIPLE
 {
-  BUS_CAN packets[4];
+  BUS_CAN packets[CAN_MAX_NUM_PACKETS];
 };
 
 #endif
@@ -332,7 +353,7 @@ struct BUS_MESSAGES_RX
 
 struct BUS_MESSAGES_RX_MULTIPLE
 {
-  BUS_MESSAGES_RX messages[4];
+  BUS_MESSAGES_RX messages[CAN_MAX_NUM_PACKETS];
 };
 
 #endif
@@ -358,7 +379,7 @@ struct BUS_STATUS_RX
 
 struct BUS_STATUS_RX_MULTIPLE
 {
-  BUS_STATUS_RX status[4];
+  BUS_STATUS_RX status[CAN_MAX_NUM_PACKETS];
 };
 
 #endif
@@ -395,7 +416,7 @@ struct BUS_CAN_RX_ERRORS
 
 struct BUS_CAN_RX_ERRORS_MULTIPLE
 {
-  BUS_CAN_RX_ERRORS errors[4];
+  BUS_CAN_RX_ERRORS errors[CAN_MAX_NUM_PACKETS];
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.31
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <stddef.h>
 #include "can_encoder_private.h"
+#include "rtw_defines.h"
 
 MdlrefDW_can_encoder_T can_encoder_MdlrefDW;
 
@@ -43,25 +44,25 @@ void can_encoder(const BUS_MESSAGES_TX *rtu_messages_tx, const BUS_STATUS_TX
                  *rtu_status_tx, const ConfigurationParameters
                  *rtu_ConfigurationParameters, BUS_CAN_MULTIPLE *rty_pck_tx)
 {
-  BUS_CAN rtb_BusCreator_d;
-  BUS_CAN rtb_BusCreator_j;
+  BUS_CAN rtb_BusCreator_n_0[4];
+  BUS_CAN rtb_BusCreator_hs;
+  BUS_CAN rtb_BusCreator_m;
+  BUS_CAN rtb_BusCreator_n;
   int32_T i;
   real32_T tmp;
   uint32_T qY;
   int16_T rtb_DataTypeConversion1_0;
   int16_T rtb_DataTypeConversion_k;
-  uint16_T rtb_pkt_id;
   uint8_T b_tmp[4];
   uint8_T tmp2[2];
 
   // Outputs for Atomic SubSystem: '<Root>/CAN_Encoder'
   // MATLAB Function: '<S4>/format_status_pck' incorporates:
   //   BusCreator: '<S4>/Bus Creator'
-  //   Concatenate: '<S1>/Vector Concatenate'
 
-  rty_pck_tx->packets[0].packet.PAYLOAD[0] = static_cast<uint8_T>
+  rtb_BusCreator_m.packet.PAYLOAD[0] = static_cast<uint8_T>
     (rtu_messages_tx->status.control_mode);
-  rty_pck_tx->packets[0].packet.PAYLOAD[1] = 0U;
+  rtb_BusCreator_m.packet.PAYLOAD[1] = 0U;
   qY = 5U - rtu_ConfigurationParameters->CurLoopPID.shift_factor;
   if (5U - rtu_ConfigurationParameters->CurLoopPID.shift_factor > 5U) {
     qY = 0U;
@@ -82,23 +83,21 @@ void can_encoder(const BUS_MESSAGES_TX *rtu_messages_tx, const BUS_STATUS_TX
     rtb_DataTypeConversion_k = MAX_int16_T;
   }
 
-  // End of DataTypeConversion: '<S4>/Data Type Conversion'
-
   // MATLAB Function: '<S4>/format_status_pck' incorporates:
   //   BusCreator: '<S4>/Bus Creator'
-  //   Concatenate: '<S1>/Vector Concatenate'
+  //   DataTypeConversion: '<S4>/Data Type Conversion'
 
   rtb_DataTypeConversion_k = static_cast<int16_T>(rtb_DataTypeConversion_k <<
     static_cast<uint8_T>(qY));
-  std::memcpy((void *)&tmp2[0], (void *)&rtb_DataTypeConversion_k, (uint32_T)
-              ((size_t)2 * sizeof(uint8_T)));
-  rty_pck_tx->packets[0].packet.PAYLOAD[2] = tmp2[0];
-  rty_pck_tx->packets[0].packet.PAYLOAD[3] = tmp2[1];
-  rty_pck_tx->packets[0].packet.PAYLOAD[4] =
+  std::memcpy((void *)&tmp2[0], (void *)&rtb_DataTypeConversion_k, (size_t)2 *
+              sizeof(uint8_T));
+  rtb_BusCreator_m.packet.PAYLOAD[2] = tmp2[0];
+  rtb_BusCreator_m.packet.PAYLOAD[3] = tmp2[1];
+  rtb_BusCreator_m.packet.PAYLOAD[4] =
     rtu_messages_tx->status.flags.ExternalFaultAsserted;
-  rty_pck_tx->packets[0].packet.PAYLOAD[5] = 0U;
-  rty_pck_tx->packets[0].packet.PAYLOAD[6] = 0U;
-  rty_pck_tx->packets[0].packet.PAYLOAD[7] = 0U;
+  rtb_BusCreator_m.packet.PAYLOAD[5] = 0U;
+  rtb_BusCreator_m.packet.PAYLOAD[6] = 0U;
+  rtb_BusCreator_m.packet.PAYLOAD[7] = 0U;
 
   // DataTypeConversion: '<S2>/Data Type Conversion' incorporates:
   //   Gain: '<S2>/Gain2'
@@ -148,51 +147,41 @@ void can_encoder(const BUS_MESSAGES_TX *rtu_messages_tx, const BUS_STATUS_TX
   //   DataTypeConversion: '<S2>/Data Type Conversion1'
   //   DataTypeConversion: '<S2>/Data Type Conversion2'
 
-  std::memcpy((void *)&tmp2[0], (void *)&rtb_DataTypeConversion_k, (uint32_T)
-              ((size_t)2 * sizeof(uint8_T)));
-  rtb_BusCreator_d.packet.PAYLOAD[0] = tmp2[0];
-  rtb_BusCreator_d.packet.PAYLOAD[1] = tmp2[1];
-  std::memcpy((void *)&tmp2[0], (void *)&rtb_DataTypeConversion1_0, (uint32_T)
-              ((size_t)2 * sizeof(uint8_T)));
-  rtb_BusCreator_d.packet.PAYLOAD[2] = tmp2[0];
-  rtb_BusCreator_d.packet.PAYLOAD[3] = tmp2[1];
-  std::memcpy((void *)&b_tmp[0], (void *)&i, (uint32_T)((size_t)4 * sizeof
-    (uint8_T)));
-  rtb_BusCreator_d.packet.PAYLOAD[4] = b_tmp[0];
-  rtb_BusCreator_d.packet.PAYLOAD[5] = b_tmp[1];
-  rtb_BusCreator_d.packet.PAYLOAD[6] = b_tmp[2];
-  rtb_BusCreator_d.packet.PAYLOAD[7] = b_tmp[3];
+  std::memcpy((void *)&tmp2[0], (void *)&rtb_DataTypeConversion_k, (size_t)2 *
+              sizeof(uint8_T));
+  rtb_BusCreator_n.packet.PAYLOAD[0] = tmp2[0];
+  rtb_BusCreator_n.packet.PAYLOAD[1] = tmp2[1];
+  std::memcpy((void *)&tmp2[0], (void *)&rtb_DataTypeConversion1_0, (size_t)2 *
+              sizeof(uint8_T));
+  rtb_BusCreator_n.packet.PAYLOAD[2] = tmp2[0];
+  rtb_BusCreator_n.packet.PAYLOAD[3] = tmp2[1];
+  std::memcpy((void *)&b_tmp[0], (void *)&i, (size_t)4 * sizeof(uint8_T));
+  rtb_BusCreator_n.packet.PAYLOAD[4] = b_tmp[0];
+  rtb_BusCreator_n.packet.PAYLOAD[5] = b_tmp[1];
+  rtb_BusCreator_n.packet.PAYLOAD[6] = b_tmp[2];
+  rtb_BusCreator_n.packet.PAYLOAD[7] = b_tmp[3];
 
-  // MATLAB Function: '<S8>/format_can_id' incorporates:
+  // BusCreator: '<S4>/Bus Creator' incorporates:
   //   Constant: '<S4>/Constant'
   //   Constant: '<S4>/Motor Control Streaming'
   //   Constant: '<S4>/TYPESTATUS'
-
-  can_encoder_format_can_id(1, CAN_ID_AMC, 3, &rtb_pkt_id);
-
-  // BusCreator: '<S4>/Bus Creator' incorporates:
-  //   BusCreator: '<S4>/Bus Creator1'
-  //   Concatenate: '<S1>/Vector Concatenate'
   //   Constant: '<S4>/length'
+  //   MATLAB Function: '<S8>/format_can_id'
 
-  rty_pck_tx->packets[0].available = rtu_status_tx->status;
-  rty_pck_tx->packets[0].length = 8U;
-  rty_pck_tx->packets[0].packet.ID = rtb_pkt_id;
+  can_encoder_format_can_id(1, CAN_ID_AMC, 3, &rtb_BusCreator_m.packet.ID);
+  rtb_BusCreator_m.available = rtu_status_tx->status;
+  rtb_BusCreator_m.length = 8U;
 
-  // MATLAB Function: '<S5>/format_can_id' incorporates:
+  // BusCreator: '<S2>/Bus Creator' incorporates:
   //   Constant: '<S2>/Constant'
   //   Constant: '<S2>/Motor Control Streaming'
   //   Constant: '<S2>/TYPE2FOC'
-
-  can_encoder_format_can_id(1, CAN_ID_AMC, 0, &rtb_pkt_id);
-
-  // BusCreator: '<S2>/Bus Creator' incorporates:
-  //   BusCreator: '<S2>/Bus Creator1'
   //   Constant: '<S2>/length'
+  //   MATLAB Function: '<S5>/format_can_id'
 
-  rtb_BusCreator_d.available = rtu_status_tx->foc;
-  rtb_BusCreator_d.length = 8U;
-  rtb_BusCreator_d.packet.ID = rtb_pkt_id;
+  can_encoder_format_can_id(1, CAN_ID_AMC, 0, &rtb_BusCreator_n.packet.ID);
+  rtb_BusCreator_n.available = rtu_status_tx->foc;
+  rtb_BusCreator_n.length = 8U;
 
   // BusCreator: '<S3>/Bus Creator' incorporates:
   //   BusCreator: '<S3>/Bus Creator6'
@@ -200,20 +189,25 @@ void can_encoder(const BUS_MESSAGES_TX *rtu_messages_tx, const BUS_STATUS_TX
   //   Constant: '<S3>/available'
   //   Constant: '<S3>/length'
 
-  rtb_BusCreator_j.available = false;
-  rtb_BusCreator_j.length = 0U;
-  rtb_BusCreator_j.packet.ID = 0U;
+  rtb_BusCreator_hs.available = false;
+  rtb_BusCreator_hs.length = 0U;
+  rtb_BusCreator_hs.packet.ID = 0U;
   for (i = 0; i < 8; i++) {
-    rtb_BusCreator_j.packet.PAYLOAD[i] = 0U;
+    rtb_BusCreator_hs.packet.PAYLOAD[i] = 0U;
   }
 
   // End of BusCreator: '<S3>/Bus Creator'
 
   // Concatenate: '<S1>/Vector Concatenate'
-  rty_pck_tx->packets[1] = rtb_BusCreator_d;
-  rty_pck_tx->packets[2] = rtb_BusCreator_j;
-  rty_pck_tx->packets[3] = rtb_BusCreator_j;
+  rtb_BusCreator_n_0[0] = rtb_BusCreator_m;
+  rtb_BusCreator_n_0[1] = rtb_BusCreator_n;
+  rtb_BusCreator_n_0[2] = rtb_BusCreator_hs;
+  rtb_BusCreator_n_0[3] = rtb_BusCreator_hs;
+  for (i = 0; i < CAN_MAX_NUM_PACKETS; i++) {
+    rty_pck_tx->packets[i] = rtb_BusCreator_n_0[i];
+  }
 
+  // End of Concatenate: '<S1>/Vector Concatenate'
   // End of Outputs for SubSystem: '<Root>/CAN_Encoder'
 }
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.31
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.31
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,6 +19,7 @@
 #ifndef RTW_HEADER_can_encoder_private_h_
 #define RTW_HEADER_can_encoder_private_h_
 #include "rtwtypes.h"
+#include "can_encoder_types.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/can-encoder/can_encoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 3.31
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:58 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:43 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,21 @@
 #ifndef RTW_HEADER_can_encoder_types_h_
 #define RTW_HEADER_can_encoder_types_h_
 #include "rtwtypes.h"
+#include "can_encoder_types.h"
 
-// Model Code Variants
+// Includes for objects with custom storage classes
+#include "rtw_defines.h"
+
+//
+//  Registered constraints for dimension variants
+
+// Constraint 'CAN_MAX_NUM_PACKETS == 4' registered by:
+//  '<S1>/Vector Concatenate'
+
+#if CAN_MAX_NUM_PACKETS != 4
+# error "The preprocessor definition 'CAN_MAX_NUM_PACKETS' must be equal to '4'"
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_BUS_MSG_FOC_
 #define DEFINED_TYPEDEF_FOR_BUS_MSG_FOC_
 
@@ -301,7 +314,7 @@ struct BUS_CAN
 
 struct BUS_CAN_MULTIPLE
 {
-  BUS_CAN packets[4];
+  BUS_CAN packets[CAN_MAX_NUM_PACKETS];
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,11 +20,13 @@
 #include "FOCInnerLoop.h"
 #include "control_foc.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 #include "arm_math.h"
 #include <cmath>
 #include "control_foc_private.h"
@@ -69,8 +71,8 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
   real32_T rtb_algDD_o1_p;
   real32_T rtb_algDD_o2_n;
   real32_T rtb_sum_beta;
-  int8_T rtb_Unary_Minus_0;
-  int8_T rtb_sum_alpha_0;
+  int8_T tmp;
+  int8_T tmp_0;
   boolean_T rtb_FixPtRelationalOperator;
 
   // Sum: '<S1>/Add' incorporates:
@@ -86,17 +88,16 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
   if ((rtu_ConfigurationParameters->motorconfig.Vcc <=
        rtu_ConfigurationParameters->motorconfig.Vmax) || rtIsNaNF
       (rtu_ConfigurationParameters->motorconfig.Vmax)) {
-    rtb_Product = rtu_ConfigurationParameters->motorconfig.Vcc;
+    rtb_Unary_Minus = rtu_ConfigurationParameters->motorconfig.Vcc;
   } else {
-    rtb_Product = rtu_ConfigurationParameters->motorconfig.Vmax;
+    rtb_Unary_Minus = rtu_ConfigurationParameters->motorconfig.Vmax;
   }
-
-  // End of MinMax: '<S1>/Min'
 
   // Product: '<S1>/Product' incorporates:
   //   Gain: '<S1>/Gain4'
+  //   MinMax: '<S1>/Min'
 
-  rtb_Product = 0.5F * rtb_Product * control_foc_ConstB.Sum5;
+  rtb_Product = 0.5F * rtb_Unary_Minus * control_foc_ConstB.Sum5;
 
   // Gain: '<S1>/Ia+Ib+Ic=0'
   for (int32_T i = 0; i < 2; i++) {
@@ -162,7 +163,7 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
     1.82857148E-5F;
 
   // Math: '<S91>/Reciprocal' incorporates:
-  //   Constant: '<S91>/Constant'
+  //   Constant: '<S91>/Filter Den Constant'
   //   Math: '<S39>/Reciprocal'
   //   SampleTimeMath: '<S93>/Tsamp'
   //   Sum: '<S91>/SumDen'
@@ -189,7 +190,7 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
     control_foc_DW.DelayInput1_DSTATE);
 
   // DiscreteTransferFcn: '<S91>/Filter Differentiator TF' incorporates:
-  //   Constant: '<S91>/Constant'
+  //   Constant: '<S91>/Filter Den Constant'
   //   Math: '<S91>/Reciprocal'
   //   Product: '<S90>/DProd Out'
   //   Product: '<S91>/Divide'
@@ -221,9 +222,9 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
   //  About '<S91>/Reciprocal':
   //   Operator: reciprocal
 
-  rtb_algDD_o2_n = (control_foc_DW.FilterDifferentiatorTF_tmp +
-                    -control_foc_DW.FilterDifferentiatorTF_states) *
-    rtb_sum_beta * rtu_ConfigurationParameters->CurLoopPID.N;
+  rtb_algDD_o2_n = (control_foc_DW.FilterDifferentiatorTF_tmp -
+                    control_foc_DW.FilterDifferentiatorTF_states) * rtb_sum_beta
+    * rtu_ConfigurationParameters->CurLoopPID.N;
 
   // Sum: '<S110>/SumI1' incorporates:
   //   Product: '<S95>/IProd Out'
@@ -297,7 +298,7 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
 
   // DiscreteTransferFcn: '<S39>/Filter Differentiator TF' incorporates:
   //   AlgorithmDescriptorDelegate generated from: '<S8>/a16'
-  //   Constant: '<S39>/Constant'
+  //   Constant: '<S39>/Filter Den Constant'
   //   Gain: '<S1>/Gain'
   //   Product: '<S38>/DProd Out'
   //   Product: '<S39>/Divide'
@@ -322,9 +323,9 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
   //   DiscreteTransferFcn: '<S39>/Filter Differentiator TF'
   //   Product: '<S39>/DenCoefOut'
 
-  rtb_sum_beta = (control_foc_DW.FilterDifferentiatorTF_tmp_c +
-                  -control_foc_DW.FilterDifferentiatorTF_states_k) *
-    rtb_sum_beta * rtu_ConfigurationParameters->CurLoopPID.N;
+  rtb_sum_beta = (control_foc_DW.FilterDifferentiatorTF_tmp_c -
+                  control_foc_DW.FilterDifferentiatorTF_states_k) * rtb_sum_beta
+    * rtu_ConfigurationParameters->CurLoopPID.N;
 
   // Sum: '<S57>/Sum Fdbk'
   rtb_FilterDifferentiatorTF_f = (rtb_PProdOut_k +
@@ -345,9 +346,9 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
     rtb_Unary_Minus = -rtb_Product;
   }
 
-  // End of Switch: '<S37>/Switch'
+  // Sum: '<S37>/Diff' incorporates:
+  //   Switch: '<S37>/Switch'
 
-  // Sum: '<S37>/Diff'
   rtb_FilterDifferentiatorTF_f -= rtb_Unary_Minus;
 
   // Outputs for Atomic SubSystem: '<S1>/Park Transform'
@@ -360,42 +361,39 @@ void FOCInnerLoop(const Flags *rtu_Flags, const ConfigurationParameters
   // End of Outputs for SubSystem: '<S1>/Park Transform'
 
   // Switch: '<S34>/Switch1' incorporates:
+  //   Constant: '<S34>/Clamping_zero'
   //   Constant: '<S34>/Constant'
   //   Constant: '<S34>/Constant2'
-  //   Constant: '<S34>/Constant5'
   //   RelationalOperator: '<S34>/fix for DT propagation issue'
 
   if (rtb_FilterDifferentiatorTF_f > 0.0F) {
-    rtb_sum_alpha_0 = 1;
+    tmp = 1;
   } else {
-    rtb_sum_alpha_0 = -1;
+    tmp = -1;
   }
 
-  // End of Switch: '<S34>/Switch1'
-
   // Switch: '<S34>/Switch2' incorporates:
+  //   Constant: '<S34>/Clamping_zero'
   //   Constant: '<S34>/Constant3'
   //   Constant: '<S34>/Constant4'
-  //   Constant: '<S34>/Constant5'
   //   RelationalOperator: '<S34>/fix for DT propagation issue1'
 
   if (rtb_Unary_Minus > 0.0F) {
-    rtb_Unary_Minus_0 = 1;
+    tmp_0 = 1;
   } else {
-    rtb_Unary_Minus_0 = -1;
+    tmp_0 = -1;
   }
 
-  // End of Switch: '<S34>/Switch2'
-
   // Switch: '<S34>/Switch' incorporates:
+  //   Constant: '<S34>/Clamping_zero'
   //   Constant: '<S34>/Constant1'
-  //   Constant: '<S34>/Constant5'
   //   Logic: '<S34>/AND3'
   //   RelationalOperator: '<S34>/Equal1'
   //   RelationalOperator: '<S34>/Relational Operator'
+  //   Switch: '<S34>/Switch1'
+  //   Switch: '<S34>/Switch2'
 
-  if ((rtb_FilterDifferentiatorTF_f != 0.0F) && (rtb_sum_alpha_0 ==
-       rtb_Unary_Minus_0)) {
+  if ((rtb_FilterDifferentiatorTF_f != 0.0F) && (tmp == tmp_0)) {
     rtb_FilterDifferentiatorTF_f = 0.0F;
   } else {
     rtb_FilterDifferentiatorTF_f = rtb_Unary_Minus;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -21,12 +21,14 @@
 #include "FOCInnerLoop.h"
 #include "control_foc_private.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
-  MdlrefDW_control_foc_T control_foc_MdlrefDW;
+
+MdlrefDW_control_foc_T control_foc_MdlrefDW;
 
 // Block states (default storage)
 DW_control_foc_f_T control_foc_DW;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,13 +20,21 @@
 #define RTW_HEADER_control_foc_h_
 #include "rtwtypes.h"
 #include "control_foc_types.h"
+
+extern "C"
+{
+
 #include "rtGetInf.h"
 
-extern "C" {
+}
+
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 #include "zero_crossing_types.h"
 
 // Block states (default storage) for model 'control_foc'
@@ -43,6 +51,16 @@ struct DW_control_foc_f_T {
   real32_T FilterDifferentiatorTF_tmp_c;// '<S39>/Filter Differentiator TF'
   int8_T Integrator_PrevResetState;    // '<S98>/Integrator'
   int8_T Integrator_PrevResetState_k;  // '<S46>/Integrator'
+};
+
+#endif                                 //control_foc_MDLREF_HIDE_CHILD_
+
+// Zero-crossing (trigger) state for model 'control_foc'
+#ifndef control_foc_MDLREF_HIDE_CHILD_
+
+struct ZCV_control_foc_g_T {
+  real_T FilterDifferentiatorTF_Reset_ZC;// '<S91>/Filter Differentiator TF'
+  real_T FilterDifferentiatorTF_Reset__c;// '<S39>/Filter Differentiator TF'
 };
 
 #endif                                 //control_foc_MDLREF_HIDE_CHILD_
@@ -116,7 +134,9 @@ extern ZCE_control_foc_T control_foc_PrevZCX;
 //  Block '<S54>/Data Type Propagation' : Unused code path elimination
 //  Block '<S5>/Data Type Duplicate' : Unused code path elimination
 //  Block '<S6>/Data Type Duplicate' : Unused code path elimination
+//  Block '<S6>/Data Type Duplicate1' : Unused code path elimination
 //  Block '<S8>/Data Type Duplicate' : Unused code path elimination
+//  Block '<S8>/Data Type Duplicate1' : Unused code path elimination
 //  Block '<S9>/Data Type Duplicate' : Unused code path elimination
 //  Block '<S9>/Data Type Propagation' : Unused code path elimination
 //  Block '<S39>/Passthrough for tuning' : Eliminate redundant data type conversion

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_data.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-foc/control_foc_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:04 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,6 @@
 #ifndef RTW_HEADER_control_foc_types_h_
 #define RTW_HEADER_control_foc_types_h_
 #include "rtwtypes.h"
-
-// Model Code Variants
 #ifndef DEFINED_TYPEDEF_FOR_ControlModes_
 #define DEFINED_TYPEDEF_FOR_ControlModes_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.33
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -77,7 +77,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
                    *rtu_Estimates, ControlOuterOutputs *rty_OuterOutputs)
 {
   int32_T rowIdx;
-  int32_T rtu_Estimates_0;
+  int32_T tmp;
   real32_T rtb_Abs;
   real32_T rtb_DProdOut;
   real32_T rtb_DProdOut_f;
@@ -133,7 +133,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_Product = rtu_ConfigurationParameters->PosLoopPID.N * 0.0005F;
 
   // Math: '<S47>/Reciprocal' incorporates:
-  //   Constant: '<S47>/Constant'
+  //   Constant: '<S47>/Filter Den Constant'
   //   Sum: '<S47>/SumDen'
   //
   //  About '<S47>/Reciprocal':
@@ -152,7 +152,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
     control_outer_DW.DelayInput1_DSTATE);
 
   // DiscreteTransferFcn: '<S47>/Filter Differentiator TF' incorporates:
-  //   Constant: '<S47>/Constant'
+  //   Constant: '<S47>/Filter Den Constant'
   //   Product: '<S46>/DProd Out'
   //   Product: '<S47>/Divide'
   //   Sum: '<S47>/SumNum'
@@ -172,8 +172,8 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   DiscreteTransferFcn: '<S47>/Filter Differentiator TF'
   //   Product: '<S47>/DenCoefOut'
 
-  rtb_Switch2_f = (control_outer_DW.FilterDifferentiatorTF_tmp +
-                   -control_outer_DW.FilterDifferentiatorTF_states) *
+  rtb_Switch2_f = (control_outer_DW.FilterDifferentiatorTF_tmp -
+                   control_outer_DW.FilterDifferentiatorTF_states) *
     rtb_Switch2_f * rtu_ConfigurationParameters->PosLoopPID.N;
 
   // Sum: '<S66>/SumI1' incorporates:
@@ -218,7 +218,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_Gain1_h = rtu_ConfigurationParameters->DirLoopPID.N * 0.0005F;
 
   // Math: '<S97>/Reciprocal' incorporates:
-  //   Constant: '<S97>/Constant'
+  //   Constant: '<S97>/Filter Den Constant'
   //   Sum: '<S97>/SumDen'
   //
   //  About '<S97>/Reciprocal':
@@ -227,7 +227,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_DenCoefOut = 1.0F / (rtb_Gain1_h + 1.0F);
 
   // DiscreteTransferFcn: '<S97>/Filter Differentiator TF' incorporates:
-  //   Constant: '<S97>/Constant'
+  //   Constant: '<S97>/Filter Den Constant'
   //   DiscreteTransferFcn: '<S47>/Filter Differentiator TF'
   //   Product: '<S97>/Divide'
   //   Sum: '<S97>/SumNum'
@@ -246,8 +246,8 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   DiscreteTransferFcn: '<S97>/Filter Differentiator TF'
   //   Product: '<S97>/DenCoefOut'
 
-  rtb_DenCoefOut = (control_outer_DW.FilterDifferentiatorTF_tmp_m +
-                    -control_outer_DW.FilterDifferentiatorTF_states_i) *
+  rtb_DenCoefOut = (control_outer_DW.FilterDifferentiatorTF_tmp_m -
+                    control_outer_DW.FilterDifferentiatorTF_states_i) *
     rtb_DenCoefOut * rtu_ConfigurationParameters->DirLoopPID.N;
 
   // Sum: '<S116>/SumI1' incorporates:
@@ -295,9 +295,9 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
     rtb_DenCoefOut = 0.0F;
   }
 
-  // End of Switch: '<Root>/Switch3'
+  // Sum: '<Root>/Sum2' incorporates:
+  //   Switch: '<Root>/Switch3'
 
-  // Sum: '<Root>/Sum2'
   rtb_Switch2_f = rtb_DenCoefOut + rtu_Targets->jointvelocities.velocity;
 
   // Switch: '<S5>/Switch2' incorporates:
@@ -337,7 +337,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_Product = rtu_ConfigurationParameters->VelLoopPID.N * 0.0005F;
 
   // Math: '<S147>/Reciprocal' incorporates:
-  //   Constant: '<S147>/Constant'
+  //   Constant: '<S147>/Filter Den Constant'
   //   Sum: '<S147>/SumDen'
   //
   //  About '<S147>/Reciprocal':
@@ -346,7 +346,7 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   rtb_DenCoefOut = 1.0F / (rtb_Product + 1.0F);
 
   // DiscreteTransferFcn: '<S147>/Filter Differentiator TF' incorporates:
-  //   Constant: '<S147>/Constant'
+  //   Constant: '<S147>/Filter Den Constant'
   //   DiscreteTransferFcn: '<S47>/Filter Differentiator TF'
   //   Product: '<S147>/Divide'
   //   Sum: '<S147>/SumNum'
@@ -365,8 +365,8 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   DiscreteTransferFcn: '<S147>/Filter Differentiator TF'
   //   Product: '<S147>/DenCoefOut'
 
-  rtb_DenCoefOut = (control_outer_DW.FilterDifferentiatorTF_tmp_p +
-                    -control_outer_DW.FilterDifferentiatorTF_states_c) *
+  rtb_DenCoefOut = (control_outer_DW.FilterDifferentiatorTF_tmp_p -
+                    control_outer_DW.FilterDifferentiatorTF_states_c) *
     rtb_DenCoefOut * rtu_ConfigurationParameters->VelLoopPID.N;
 
   // Sum: '<S166>/SumI1' incorporates:
@@ -432,11 +432,11 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   RelationalOperator: '<S1>/Relational Operator'
   //   RelationalOperator: '<S8>/Compare'
 
-  rowIdx = static_cast<int32_T>(((((rtb_DenCoefOut > 0.05F *
+  rowIdx = static_cast<int32_T>(((((rtb_DenCoefOut > 0.1F *
     rtu_ConfigurationParameters->thresholds.motorPeakCurrents) ||
     rtb_FixPtRelationalOperator) + (static_cast<uint32_T>(rtb_DenCoefOut <= 0.0F)
     << 1)) << 1) + control_outer_DW.Memory_PreviousInput);
-  rtb_Compare = rtCP_Logic_table[rowIdx + 8U];
+  rtb_Compare = rtCP_Logic_table[static_cast<uint32_T>(rowIdx) + 8U];
 
   // DiscreteIntegrator: '<S1>/Discrete-Time Integrator'
   if (control_outer_DW.DiscreteTimeIntegrator_SYSTEM_E != 0) {
@@ -465,17 +465,16 @@ void control_outer(const Flags *rtu_Flags, const ConfigurationParameters
   //   RelationalOperator: '<S9>/Compare'
 
   if (rtu_Estimates->Iq_filtered.current < 0.0F) {
-    rtu_Estimates_0 = -1;
+    tmp = -1;
   } else {
-    rtu_Estimates_0 = 1;
+    tmp = 1;
   }
-
-  // End of Switch: '<S1>/Switch1'
 
   // BusCreator: '<Root>/Bus Creator1' incorporates:
   //   Product: '<S1>/Product'
+  //   Switch: '<S1>/Switch1'
 
-  rty_OuterOutputs->current_limiter = static_cast<real32_T>(rtu_Estimates_0) *
+  rty_OuterOutputs->current_limiter = static_cast<real32_T>(tmp) *
     control_outer_B.DiscreteTimeIntegrator *
     rtu_ConfigurationParameters->CurLoopPID.I;
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.33
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -54,6 +54,17 @@ struct DW_control_outer_f_T {
   int8_T DiscreteTimeIntegrator_PrevRese;// '<S1>/Discrete-Time Integrator'
   uint8_T DiscreteTimeIntegrator_SYSTEM_E;// '<S1>/Discrete-Time Integrator'
   boolean_T Memory_PreviousInput;      // '<S10>/Memory'
+};
+
+#endif                                 //control_outer_MDLREF_HIDE_CHILD_
+
+// Zero-crossing (trigger) state for model 'control_outer'
+#ifndef control_outer_MDLREF_HIDE_CHILD_
+
+struct ZCV_control_outer_g_T {
+  real_T FilterDifferentiatorTF_Reset_ZC;// '<S47>/Filter Differentiator TF'
+  real_T FilterDifferentiatorTF_Reset__f;// '<S97>/Filter Differentiator TF'
+  real_T FilterDifferentiatorTF_Reset__m;// '<S147>/Filter Differentiator TF'
 };
 
 #endif                                 //control_outer_MDLREF_HIDE_CHILD_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.33
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/control-outer/control_outer_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 3.33
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:11 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:01 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,6 @@
 #ifndef RTW_HEADER_control_outer_types_h_
 #define RTW_HEADER_control_outer_types_h_
 #include "rtwtypes.h"
-
-// Model Code Variants
 #ifndef DEFINED_TYPEDEF_FOR_ControlModes_
 #define DEFINED_TYPEDEF_FOR_ControlModes_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 3.3
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -25,12 +25,14 @@
 #include "rt_hypotf_snf.h"
 #include "estimation_velocity_private.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
-  MdlrefDW_estimation_velocity_T estimation_velocity_MdlrefDW;
+
+MdlrefDW_estimation_velocity_T estimation_velocity_MdlrefDW;
 
 // Block states (default storage)
 DW_estimation_velocity_f_T estimation_velocity_DW;
@@ -182,8 +184,8 @@ static void estimation_velocity_xgeqp3(const real32_T A[32], real32_T b_A[32],
           b_atmp *= 1.01412048E+31F;
         } while ((std::abs(scale) < 9.86076132E-32F) && (knt + 1 < 20));
 
-        scale = estimation_velocity_xnrm2(15 - b_k, b_A, kend + 2);
-        scale = rt_hypotf_snf(b_atmp, scale);
+        scale = rt_hypotf_snf(b_atmp, estimation_velocity_xnrm2(15 - b_k, b_A,
+          kend + 2));
         if (b_atmp >= 0.0F) {
           scale = -scale;
         }
@@ -259,7 +261,8 @@ static void estimation_velocity_xgeqp3(const real32_T A[32], real32_T b_A[32],
         int32_T d;
         if (knt + 1 != 0) {
           if (knt >= 0) {
-            std::memset(&work[0], 0, (knt + 1) * sizeof(real32_T));
+            std::memset(&work[0], 0, static_cast<uint32_T>(knt + 1) * sizeof
+                        (real32_T));
           }
 
           nmip1 = (knt << 4) + kend;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 3.3
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -22,11 +22,13 @@
 #include "estimation_velocity_types.h"
 #include "rtGetInf.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 // Block states (default storage) for model 'estimation_velocity'
 #ifndef estimation_velocity_MDLREF_HIDE_CHILD_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 3.3
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,6 +19,7 @@
 #ifndef RTW_HEADER_estimation_velocity_private_h_
 #define RTW_HEADER_estimation_velocity_private_h_
 #include "rtwtypes.h"
+#include "estimation_velocity_types.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/estimator/estimation_velocity_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 3.3
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:20 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:11 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,6 @@
 #ifndef RTW_HEADER_estimation_velocity_types_h_
 #define RTW_HEADER_estimation_velocity_types_h_
 #include "rtwtypes.h"
-
-// Model Code Variants
 #ifndef DEFINED_TYPEDEF_FOR_JointPositions_
 #define DEFINED_TYPEDEF_FOR_JointPositions_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 3.7
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -25,7 +25,7 @@
 #ifndef filter_current_MDLREF_HIDE_CHILD_
 
 struct DW_filter_current_f_T {
-  dsp_MedianFilter_filter_curre_T obj; // '<Root>/Median Filter'
+  dsp_simulink_MedianFilter_fil_T obj; // '<Root>/Median Filter'
   boolean_T objisempty;                // '<Root>/Median Filter'
 };
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 3.7
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,6 +19,7 @@
 #ifndef RTW_HEADER_filter_current_private_h_
 #define RTW_HEADER_filter_current_private_h_
 #include "rtwtypes.h"
+#include "filter_current_types.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/filter-current/filter_current_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 3.7
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:04:27 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:19 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,6 @@
 #ifndef RTW_HEADER_filter_current_types_h_
 #define RTW_HEADER_filter_current_types_h_
 #include "rtwtypes.h"
-
-// Model Code Variants
 #ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
 #define DEFINED_TYPEDEF_FOR_MotorCurrent_
 
@@ -57,11 +55,11 @@ struct c_dsp_internal_MedianFilterCG_T
   int32_T isInitialized;
   boolean_T isSetupComplete;
   real32_T pWinLen;
-  real32_T pBuf[10];
-  real32_T pHeap[10];
+  real32_T pBuf[32];
+  real32_T pHeap[32];
   real32_T pMidHeap;
   real32_T pIdx;
-  real32_T pPos[10];
+  real32_T pPos[32];
   real32_T pMinHeapLength;
   real32_T pMaxHeapLength;
 };
@@ -78,10 +76,10 @@ struct cell_wrap_filter_current_T
 
 #endif                                 // struct_cell_wrap_filter_current_T
 
-#ifndef struct_dsp_MedianFilter_filter_curre_T
-#define struct_dsp_MedianFilter_filter_curre_T
+#ifndef struct_dsp_simulink_MedianFilter_fil_T
+#define struct_dsp_simulink_MedianFilter_fil_T
 
-struct dsp_MedianFilter_filter_curre_T
+struct dsp_simulink_MedianFilter_fil_T
 {
   boolean_T matlabCodegenIsDeleted;
   int32_T isInitialized;
@@ -91,7 +89,7 @@ struct dsp_MedianFilter_filter_curre_T
   c_dsp_internal_MedianFilterCG_T pMID;
 };
 
-#endif                                // struct_dsp_MedianFilter_filter_curre_T
+#endif                                // struct_dsp_simulink_MedianFilter_fil_T
 
 // Forward declaration for rtModel
 typedef struct tag_RTM_filter_current_T RT_MODEL_filter_current_T;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/const_params.cpp
@@ -7,9 +7,9 @@
 //
 //  Code generation for model "estimation_velocity".
 //
-//  Model version              : 3.3
-//  Simulink Coder version : 9.7 (R2022a) 13-Nov-2021
-//  C++ source code generated on : Tue Sep 13 12:54:58 2022
+//  Model version              : 4.0
+//  Simulink Coder version : 9.8 (R2022b) 13-May-2022
+//  C++ source code generated on : Mon Sep 26 16:38:11 2022
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -7,27 +7,32 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 #include "rtwtypes.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rtGetInf.h"
 
 }
+
 #include <stddef.h>
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 #define NumBitsPerChar                 8U
 
-extern "C" {
+extern "C"
+{
   //
   // Initialize rtInf needed by the generated code.
   // Inf is initialized as non-signaling. Assumes IEEE.
@@ -98,6 +103,7 @@ extern "C" {
     return minfF.wordL.wordLreal;
   }
 }
+
 //
 // File trailer for generated code.
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetInf.h
@@ -7,16 +7,17 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_
 #include "rtwtypes.h"
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -28,6 +29,7 @@ extern "C" {
 #ifdef __cplusplus
 
 }                                      // extern "C"
+
 #endif
 #endif                                 // RTW_HEADER_rtGetInf_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -7,27 +7,32 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 #include "rtwtypes.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rtGetNaN.h"
 
 }
+
 #include <stddef.h>
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 #define NumBitsPerChar                 8U
 
-extern "C" {
+extern "C"
+{
   //
   // Initialize rtNaN needed by the generated code.
   // NaN is initialized as non-signaling. Assumes IEEE.
@@ -64,6 +69,7 @@ extern "C" {
     return nanF.wordL.wordLreal;
   }
 }
+
 //
 // File trailer for generated code.
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtGetNaN.h
@@ -7,16 +7,17 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_
 #include "rtwtypes.h"
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -26,6 +27,7 @@ extern "C" {
 #ifdef __cplusplus
 
 }                                      // extern "C"
+
 #endif
 #endif                                 // RTW_HEADER_rtGetNaN_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
@@ -7,37 +7,43 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 3.3
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:58 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:11 2022
 //
 #include "rtwtypes.h"
 #include "rt_hypotf_snf.h"
 #include <cmath>
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 #include "mw_cmsis.h"
+#include "rtGetNaN.h"
 
 real32_T rt_hypotf_snf(real32_T u0, real32_T u1)
 {
   real32_T a;
+  real32_T b;
   real32_T tmp;
   real32_T y;
   a = std::abs(u0);
-  y = std::abs(u1);
-  if (a < y) {
-    a /= y;
+  b = std::abs(u1);
+  if (a < b) {
+    a /= b;
     mw_arm_sqrt_f32(a * a + 1.0F, &tmp);
-    y *= tmp;
-  } else if (a > y) {
-    y /= a;
-    mw_arm_sqrt_f32(y * y + 1.0F, &tmp);
+    y = tmp * b;
+  } else if (a > b) {
+    b /= a;
+    mw_arm_sqrt_f32(b * b + 1.0F, &tmp);
     y = tmp * a;
-  } else if (!rtIsNaNF(y)) {
+  } else if (rtIsNaNF(b)) {
+    y = (rtNaNF);
+  } else {
     y = a * 1.41421354F;
   }
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_hypotf_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 3.3
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:58 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:38:11 2022
 //
 #ifndef RTW_HEADER_rt_hypotf_snf_h_
 #define RTW_HEADER_rt_hypotf_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -7,16 +7,18 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
-extern "C" {
+extern "C"
+{
 
 #include "rtGetNaN.h"
 
 }
-  extern "C"
+
+extern "C"
 {
 
 #include "rtGetInf.h"
@@ -26,14 +28,17 @@ extern "C" {
 #include <stddef.h>
 #include "rtwtypes.h"
 
-extern "C" {
+extern "C"
+{
 
 #include "rt_nonfinite.h"
 
 }
+
 #define NumBitsPerChar                 8U
 
-extern "C" {
+extern "C"
+{
   real_T rtInf;
   real_T rtMinusInf;
   real_T rtNaN;
@@ -41,7 +46,8 @@ extern "C" {
   real32_T rtMinusInfF;
   real32_T rtNaNF;
 }
-  extern "C"
+
+extern "C"
 {
   //
   // Initialize the rtInf, rtMinusInf, and rtNaN needed by the

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -7,17 +7,19 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_
 #include <stddef.h>
 #include "rtwtypes.h"
+#define NOT_USING_NONFINITE_LITERALS   1
 #ifdef __cplusplus
 
-extern "C" {
+extern "C"
+{
 
 #endif
 
@@ -56,6 +58,7 @@ extern "C" {
 #ifdef __cplusplus
 
 }                                      // extern "C"
+
 #endif
 #endif                                 // RTW_HEADER_rt_nonfinite_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:11 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 #include "rtwtypes.h"
 #include "rt_roundd_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rt_roundd_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:11 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 #ifndef RTW_HEADER_rt_roundd_snf_h_
 #define RTW_HEADER_rt_roundd_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtw_defines.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtw_defines.h
@@ -1,0 +1,28 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: rtw_defines.h
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
+//
+
+#ifndef RTW_HEADER_rtw_defines_h_
+#define RTW_HEADER_rtw_defines_h_
+#include "rtwtypes.h"
+
+// Exported data define
+// Definition for custom storage class: Define
+#define CAN_MAX_NUM_PACKETS            4                         // Maximum number of TX/RX packets handled per time instance.
+#endif                                 // RTW_HEADER_rtw_defines_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.67
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:11 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 3.10
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Tue Sep 13 12:54:44 2022
+// Model version                  : 4.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:51 2022
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.74
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -21,6 +21,7 @@
 #include "SupervisorFSM_RX_types.h"
 #include <cmath>
 #include "rt_roundd_snf.h"
+#include "rtw_defines.h"
 #include "SupervisorFSM_RX_private.h"
 
 // Named constants for Chart: '<S2>/ControlMode_SM_motor0'
@@ -39,7 +40,7 @@ const uint8_T SupervisorFSM_RX_IN_Fault = 2U;
 const uint8_T SupervisorFSM_RX_IN_NoFault = 2U;
 const uint8_T SupervisorFSM_RX_IN_state1 = 1U;
 const uint8_T SupervisorFSM__IN_ButtonPressed = 1U;
-const uint8_T SupervisorFS_IN_NotConfigured_m = 3U;
+const uint8_T SupervisorFS_IN_NotConfigured_d = 3U;
 const uint8_T SupervisorF_IN_OverCurrentFault = 3U;
 MdlrefDW_SupervisorFSM_RX_T SupervisorFSM_RX_MdlrefDW;
 
@@ -132,7 +133,7 @@ void SupervisorFSM_R_SetpointHandler(void)
         newSetpoint = 0.0F;
       }
     } else {
-      newSetpoint = SupervisorFSM_RX_B.newSetpoint_i;
+      newSetpoint = SupervisorFSM_RX_B.newSetpoint_m;
     }
 
     SupervisorFSM_RX_B.targets.motorvoltage.voltage = 0.0F;
@@ -165,7 +166,7 @@ void SupervisorFSM_R_SetpointHandler(void)
         newSetpoint = 0.0F;
       }
     } else {
-      newSetpoint = SupervisorFSM_RX_B.newSetpoint_i;
+      newSetpoint = SupervisorFSM_RX_B.newSetpoint_m;
     }
 
     SupervisorFSM_RX_B.targets.motorvoltage.voltage = 0.0F;
@@ -270,7 +271,7 @@ static void SupervisorFSM_RX_Voltage(void)
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
           SupervisorFSM_RX_IN_Velocity;
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
-        SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+        SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
         SupervisorFSM_R_SetpointHandler();
@@ -282,7 +283,7 @@ static void SupervisorFSM_RX_Voltage(void)
     } else if (!SupervisorFSM_IsNewCtrl_Voltage()) {
       if (SupervisorFSM_IsNewCtrl_Current()) {
         // Chart: '<S2>/ControlMode_SM_motor0'
-        SupervisorFSM_RX_B.newSetpoint_i =
+        SupervisorFSM_RX_B.newSetpoint_m =
           SupervisorFS_rtu_ControlOutputs->Iq_fbk.current;
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
           SupervisorFSM_RX_IN_Current;
@@ -298,7 +299,7 @@ static void SupervisorFSM_RX_Voltage(void)
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
 
         // Chart: '<S2>/ControlMode_SM_motor0'
-        SupervisorFSM_RX_B.newSetpoint_i =
+        SupervisorFSM_RX_B.newSetpoint_m =
           SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
@@ -546,7 +547,7 @@ void Superv_ControlModeHandlerMotor0(void)
       if ((!SupervisorFSM_RX_IsNewCtrl_Idle()) &&
           (!SupervisorFS_IsNewCtrl_Position())) {
         if (SupervisorFSM_IsNewCtrl_Current()) {
-          SupervisorFSM_RX_B.newSetpoint_i =
+          SupervisorFSM_RX_B.newSetpoint_m =
             SupervisorFS_rtu_ControlOutputs->Iq_fbk.current;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Current;
@@ -557,7 +558,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_IsNewCtrl_Voltage()) {
-          SupervisorFSM_RX_B.newSetpoint_i = SupervisorFS_rtu_ControlOutputs->Vq;
+          SupervisorFSM_RX_B.newSetpoint_m = SupervisorFS_rtu_ControlOutputs->Vq;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Voltage;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
@@ -570,7 +571,7 @@ void Superv_ControlModeHandlerMotor0(void)
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Velocity;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
-          SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+          SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
           SupervisorFSM_R_SetpointHandler();
@@ -587,7 +588,7 @@ void Superv_ControlModeHandlerMotor0(void)
     if (guard10) {
       if (!SupervisorFS_IsNewCtrl_Velocity()) {
         if (SupervisorFSM_IsNewCtrl_Voltage()) {
-          SupervisorFSM_RX_B.newSetpoint_i = SupervisorFS_rtu_ControlOutputs->Vq;
+          SupervisorFSM_RX_B.newSetpoint_m = SupervisorFS_rtu_ControlOutputs->Vq;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Voltage;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
@@ -597,7 +598,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_IsNewCtrl_Current()) {
-          SupervisorFSM_RX_B.newSetpoint_i =
+          SupervisorFSM_RX_B.newSetpoint_m =
             SupervisorFS_rtu_ControlOutputs->Iq_fbk.current;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Current;
@@ -611,7 +612,7 @@ void Superv_ControlModeHandlerMotor0(void)
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Position;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
-          SupervisorFSM_RX_B.newSetpoint_i =
+          SupervisorFSM_RX_B.newSetpoint_m =
             SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
@@ -641,7 +642,7 @@ void Superv_ControlModeHandlerMotor0(void)
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Position;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
-          SupervisorFSM_RX_B.newSetpoint_i =
+          SupervisorFSM_RX_B.newSetpoint_m =
             SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
@@ -649,7 +650,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_IsNewCtrl_Current()) {
-          SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+          SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Current;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Current;
@@ -659,7 +660,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_IsNewCtrl_Voltage()) {
-          SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+          SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Voltage;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
@@ -672,7 +673,7 @@ void Superv_ControlModeHandlerMotor0(void)
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Velocity;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
-          SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+          SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
           SupervisorFSM_R_SetpointHandler();
@@ -691,7 +692,7 @@ void Superv_ControlModeHandlerMotor0(void)
           (!SupervisorFS_IsNewCtrl_Position())) {
         if (!SupervisorFSM_IsNewCtrl_Current()) {
           if (SupervisorFSM_IsNewCtrl_Voltage()) {
-            SupervisorFSM_RX_B.newSetpoint_i =
+            SupervisorFSM_RX_B.newSetpoint_m =
               SupervisorFS_rtu_ControlOutputs->Vq;
             SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
               SupervisorFSM_RX_IN_Voltage;
@@ -705,7 +706,7 @@ void Superv_ControlModeHandlerMotor0(void)
             SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
               SupervisorFSM_RX_IN_Velocity;
             SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
-            SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+            SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
 
             // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
             SupervisorFSM_R_SetpointHandler();
@@ -722,7 +723,7 @@ void Superv_ControlModeHandlerMotor0(void)
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Position;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
-          SupervisorFSM_RX_B.newSetpoint_i =
+          SupervisorFSM_RX_B.newSetpoint_m =
             SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
@@ -742,7 +743,7 @@ void Superv_ControlModeHandlerMotor0(void)
     if (guard6) {
       SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX = SupervisorFSM_RX_IN_Velocity;
       SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
-      SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
+      SupervisorFSM_RX_B.newSetpoint_m = 0.0F;
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       SupervisorFSM_R_SetpointHandler();
@@ -1046,7 +1047,7 @@ static void SupervisorF_hardwareConfigMotor(void)
 {
   rtw_configMotor(SupervisorFSM_RX_B.motorConfig.rotor_encoder_resolution,
                   SupervisorFSM_RX_B.motorConfig.pole_pairs, static_cast<uint8_T>
-                  (SupervisorFSM_RX_B.motorConfig.has_hall_sens), 1U, 1U);
+                  (SupervisorFSM_RX_B.motorConfig.has_hall_sens), 1U, 21845U);
 }
 
 // System initialize for function-call system: '<Root>/CAN Message Handler'
@@ -1329,7 +1330,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
       rtu_ExternalFlags->fault_button;
     SupervisorFSM_RX_DW.is_active_c2_SupervisorFSM_RX = 1U;
     SupervisorFSM_RX_DW.is_active_STATE_HANDLER = 1U;
-    SupervisorFSM_RX_DW.is_STATE_HANDLER = SupervisorFS_IN_NotConfigured_m;
+    SupervisorFSM_RX_DW.is_STATE_HANDLER = SupervisorFS_IN_NotConfigured_d;
     SupervisorFSM_RX_B.BoardSt = BoardState_NotConfigured;
     SupervisorFSM_RX_DW.is_active_FAULT_HANDLER = 1U;
     SupervisorFSM_RX_DW.is_active_FaultButtonPressed = 1U;
@@ -1349,7 +1350,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
 
     // End of Outputs for SubSystem: '<Root>/Limits Handler'
     SupervisorFSM_RX_B.messageIndex = 1;
-    while (SupervisorFSM_RX_B.messageIndex < 5) {
+    while (SupervisorFSM_RX_B.messageIndex <= CAN_MAX_NUM_PACKETS) {
       // Outputs for Function Call SubSystem: '<Root>/CAN Message Handler'
       SupervisorFSM_CANMessageHandler();
 
@@ -1369,7 +1370,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
         SupervisorFSM_RX_B.BoardSt = BoardState_Fault;
         break;
 
-       case SupervisorFS_IN_NotConfigured_m:
+       case SupervisorFS_IN_NotConfigured_d:
         SupervisorFSM_RX_B.BoardSt = BoardState_NotConfigured;
         if (SupervisorFSM_isBoardConfigured()) {
           SupervisorFSM_RX_DW.is_STATE_HANDLER = SupervisorFSM_RX_IN_Configured;
@@ -1456,7 +1457,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
         (SupervisorFSM_RX_DW.is_CAN_MESSAGES_FOR_LOOP ==
          SupervisorFSM_RX_IN_state1)) {
       SupervisorFSM_RX_B.messageIndex = 1;
-      while (SupervisorFSM_RX_B.messageIndex < 5) {
+      while (SupervisorFSM_RX_B.messageIndex <= CAN_MAX_NUM_PACKETS) {
         // Outputs for Function Call SubSystem: '<Root>/CAN Message Handler'
         SupervisorFSM_CANMessageHandler();
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.74
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,9 @@
 #define RTW_HEADER_SupervisorFSM_RX_h_
 #include "rtwtypes.h"
 #include "SupervisorFSM_RX_types.h"
+
+// Includes for objects with custom storage classes
+#include "rtw_defines.h"
 
 // user code (top of header file)
 #include "rtw_enable_disable_motors.h"
@@ -40,7 +43,7 @@ struct B_SupervisorFSM_RX_c_T {
   SV_Limits newLimit;                  // '<S1>/CAN Event Dispatcher'
   BUS_MSG_DESIRED_TARGETS newSetpoint; // '<S1>/CAN Event Dispatcher'
   EstimationConfig estimationConfig;   // '<S1>/CAN Event Dispatcher'
-  real32_T newSetpoint_i;              // '<S2>/ControlMode_SM_motor0'
+  real32_T newSetpoint_m;              // '<S2>/ControlMode_SM_motor0'
   int32_T messageIndex;                // '<Root>/SupervisorRX State Handler'
   ControlModes requiredControlMode;    // '<S1>/CAN Event Dispatcher'
   ControlModes newPIDType;             // '<S1>/CAN Event Dispatcher'
@@ -61,21 +64,21 @@ struct B_SupervisorFSM_RX_c_T {
 
 struct DW_SupervisorFSM_RX_f_T {
   ConfigurationParameters UnitDelay_DSTATE;// '<Root>/Unit Delay'
-  uint8_T is_active_c2_SupervisorFSM_RX;// '<Root>/SupervisorRX State Handler'
   uint8_T is_STATE_HANDLER;            // '<Root>/SupervisorRX State Handler'
+  uint8_T is_OverCurrent;              // '<Root>/SupervisorRX State Handler'
+  uint8_T is_FaultButtonPressed;       // '<Root>/SupervisorRX State Handler'
+  uint8_T is_CAN_MESSAGES_FOR_LOOP;    // '<Root>/SupervisorRX State Handler'
+  uint8_T is_active_c2_SupervisorFSM_RX;// '<Root>/SupervisorRX State Handler'
   uint8_T is_active_STATE_HANDLER;     // '<Root>/SupervisorRX State Handler'
   uint8_T is_active_FAULT_HANDLER;     // '<Root>/SupervisorRX State Handler'
-  uint8_T is_OverCurrent;              // '<Root>/SupervisorRX State Handler'
-  uint8_T is_active_OverCurrent;       // '<Root>/SupervisorRX State Handler'
-  uint8_T is_FaultButtonPressed;       // '<Root>/SupervisorRX State Handler'
   uint8_T is_active_FaultButtonPressed;// '<Root>/SupervisorRX State Handler'
-  uint8_T is_CAN_MESSAGES_FOR_LOOP;    // '<Root>/SupervisorRX State Handler'
+  uint8_T is_active_OverCurrent;       // '<Root>/SupervisorRX State Handler'
   uint8_T is_active_CAN_MESSAGES_FOR_LOOP;// '<Root>/SupervisorRX State Handler' 
   uint8_T is_active_c11_SupervisorFSM_RX;// '<S1>/CAN Event Dispatcher'
   uint8_T is_active_c3_SupervisorFSM_RX;// '<S4>/Chart'
   uint8_T is_active_c14_SupervisorFSM_RX;// '<S3>/Chart'
-  uint8_T is_active_c12_SupervisorFSM_RX;// '<S2>/ControlMode_SM_motor0'
   uint8_T is_c12_SupervisorFSM_RX;     // '<S2>/ControlMode_SM_motor0'
+  uint8_T is_active_c12_SupervisorFSM_RX;// '<S2>/ControlMode_SM_motor0'
   uint8_T is_active_c4_SupervisorFSM_RX;// '<S5>/Chart1'
   boolean_T ExternalFlags_fault_button_prev;// '<Root>/SupervisorRX State Handler' 
   boolean_T ExternalFlags_fault_button_star;// '<Root>/SupervisorRX State Handler' 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.74
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 4.74
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:29 2022
+// Model version                  : 5.2
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:04 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,6 @@
 #ifndef RTW_HEADER_SupervisorFSM_RX_types_h_
 #define RTW_HEADER_SupervisorFSM_RX_types_h_
 #include "rtwtypes.h"
-
-// Model Code Variants
 #ifndef DEFINED_TYPEDEF_FOR_JointPositions_
 #define DEFINED_TYPEDEF_FOR_JointPositions_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.12
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
+// Model version                  : 5.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.12
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
+// Model version                  : 5.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.12
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
+// Model version                  : 5.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,6 +19,7 @@
 #ifndef RTW_HEADER_SupervisorFSM_TX_private_h_
 #define RTW_HEADER_SupervisorFSM_TX_private_h_
 #include "rtwtypes.h"
+#include "SupervisorFSM_TX_types.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application07/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 4.12
-// Simulink Coder version         : 9.7 (R2022a) 13-Nov-2021
-// C/C++ source code generated on : Thu Sep 15 11:03:44 2022
+// Model version                  : 5.0
+// Simulink Coder version         : 9.8 (R2022b) 13-May-2022
+// C/C++ source code generated on : Mon Sep 26 16:37:23 2022
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -19,8 +19,6 @@
 #ifndef RTW_HEADER_SupervisorFSM_TX_types_h_
 #define RTW_HEADER_SupervisorFSM_TX_types_h_
 #include "rtwtypes.h"
-
-// Model Code Variants
 #ifndef DEFINED_TYPEDEF_FOR_JointPositions_
 #define DEFINED_TYPEDEF_FOR_JointPositions_
 


### PR DESCRIPTION
What's new:

- Make the number of CAN packets that we can manage at time instance configurable.
- Update the glue code replacing the `maxNumberOfPacketsCAN` user-defined constant with the `CAN_MAX_NUM_PACKETS` generated from Matlab.
- ⚠️ Remove the [last commit][1] done in https://github.com/robotology/icub-firmware/pull/300. It has been removed because it introduces a bug (🐞) that prevents the wrist setup from working properly.

**Note:**
- Tested on `lego-setup`
- Tested on `wrist-setup`
- I used Matlab R2022b to generate the new code

@valegagge @pattacini 

[1]: https://github.com/robotology/icub-firmware/pull/300/commits/f86f45df32c46c6b62cfab26d0eb38804a175716