### PR TITLE
Added a reading test for sensor `embot::hw::tlv493d` 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/cfg/stm32hal.startup.pmc.s
+++ b/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/cfg/stm32hal.startup.pmc.s
@@ -33,7 +33,7 @@
 ;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Stack_Size		EQU     0x400
+Stack_Size		EQU     0x4000
 
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
 Stack_Mem       SPACE   Stack_Size
@@ -44,7 +44,7 @@ __initial_sp
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size      EQU     0x200
+Heap_Size      EQU     0x10000
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
 __heap_base

--- a/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/proj/pmc-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/proj/pmc-embot-os.uvoptx
@@ -103,7 +103,7 @@
         <bEvRecOn>1</bEvRecOn>
         <bSchkAxf>0</bSchkAxf>
         <bTchkAxf>0</bTchkAxf>
-        <nTsel>0</nTsel>
+        <nTsel>1</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -114,9 +114,14 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile></tIfile>
-        <pMon>BIN\UL2CM3.DLL</pMon>
+        <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
+        <SetRegEntry>
+          <Number>0</Number>
+          <Key>ULP2CM3</Key>
+          <Name>-UAny -O206 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC160000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512_Dual.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474VEHx$CMSIS\Flash\STM32G4xx_512_Dual.FLM)</Name>
+        </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>UL2CM3</Key>
@@ -130,7 +135,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>DLGTARM</Key>
-          <Name>(1010=-1,-1,-1,-1,0)(6017=-1,-1,-1,-1,0)(1008=-1,-1,-1,-1,0)(6016=-1,-1,-1,-1,0)(1012=-1,-1,-1,-1,0)</Name>
+          <Name>(1010=-1,-1,-1,-1,0)(1007=-1,-1,-1,-1,0)(1008=-1,-1,-1,-1,0)(1009=-1,-1,-1,-1,0)(1012=-1,-1,-1,-1,0)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -140,7 +145,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>DLGUARM</Key>
-          <Name>(105=-1,-1,-1,-1,0)</Name>
+          <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
       <Breakpoint/>
@@ -148,42 +153,7 @@
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>_ads_config</ItemText>
-        </Ww>
-        <Ww>
-          <count>1</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>r0</ItemText>
-        </Ww>
-        <Ww>
-          <count>2</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>v1</ItemText>
-        </Ww>
-        <Ww>
-          <count>3</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>acq,0x0A</ItemText>
-        </Ww>
-        <Ww>
-          <count>4</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_ready</ItemText>
-        </Ww>
-        <Ww>
-          <count>5</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_start</ItemText>
-        </Ww>
-        <Ww>
-          <count>6</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_delta,0x0A</ItemText>
-        </Ww>
-        <Ww>
-          <count>7</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>timeadc_duration_of_acquisition_start,0x0A</ItemText>
+          <ItemText>SystemCoreClock,0x0A</ItemText>
         </Ww>
       </WatchWindow1>
       <Tracepoint>
@@ -209,7 +179,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
+        <aSer4>1</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -240,7 +210,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -344,7 +314,7 @@
 
   <Group>
     <GroupName>embot-hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -432,6 +402,30 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>5</GroupNumber>
+      <FileNumber>14</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_tlv493d.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_tlv493d.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>5</GroupNumber>
+      <FileNumber>15</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_i2c.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_i2c.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -442,7 +436,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>14</FileNumber>
+      <FileNumber>16</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -454,7 +448,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>15</FileNumber>
+      <FileNumber>17</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -466,7 +460,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>16</FileNumber>
+      <FileNumber>18</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -478,7 +472,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>17</FileNumber>
+      <FileNumber>19</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -490,7 +484,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>18</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -502,7 +496,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -514,7 +508,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -526,7 +520,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -546,7 +540,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -558,7 +552,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -578,7 +572,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -592,13 +586,13 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/proj/pmc-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/proj/pmc-embot-os.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>pmc</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6150000::V6.15::ARMCLANG</pCCUsed>
+      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32G474VEHx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.2.0</PackID>
+          <PackID>Keil.STM32G4xx_DFP.1.4.0</PackID>
           <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -186,6 +186,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -313,7 +314,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>6</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -467,6 +468,16 @@
               <FileName>embot_hw_button.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_button.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_tlv493d.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_tlv493d.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_i2c.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_i2c.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/src/main-embot-os.cpp
+++ b/emBODY/eBcode/arch-arm/board/pmc/examples/embot-os/src/main-embot-os.cpp
@@ -23,17 +23,22 @@
 
 
 constexpr embot::os::Event evtTick = embot::core::binary::mask::pos2mask<embot::os::Event>(0);
-constexpr embot::os::Event evtBTNreleased = embot::core::binary::mask::pos2mask<embot::os::Event>(1);
-
 constexpr embot::core::relTime tickperiod = 1000*embot::core::time1millisec;
+void onTick(embot::os::Thread *t);
 
+#if defined(EMBOT_ENABLE_hw_button)
+constexpr embot::os::Event evtBTNreleased = embot::core::binary::mask::pos2mask<embot::os::Event>(1);
+void onBTNreleased(embot::os::Thread *t);
 constexpr embot::hw::BTN buttonBLUE = embot::hw::BTN::one;
-
 void btncallback(void *p)
 {
     embot::os::Thread *t = reinterpret_cast<embot::os::Thread *>(p);
     t->setEvent(evtBTNreleased);
 }
+#endif
+
+void testHWinit(embot::os::Thread *t);
+void testHWtick(embot::os::Thread *t);
 
 void eventbasedthread_startup(embot::os::Thread *t, void *param)
 {       
@@ -43,12 +48,14 @@ void eventbasedthread_startup(embot::os::Thread *t, void *param)
     embot::os::Action act(embot::os::EventToThread(evtTick, t));
     embot::os::Timer::Config cfg{tickperiod, act, embot::os::Timer::Mode::forever, 0};
     tmr->start(cfg);
-    
-    // init the ext interrupt button
-    embot::hw::button::init(buttonBLUE, {embot::hw::button::Mode::TriggeredOnRelease, {btncallback, t}, 0});
-    
-    embot::core::print("evthread-startup: started timer which sends evtTick to evthread every = " + embot::core::TimeFormatter(tickperiod).to_string());
 
+#if defined(EMBOT_ENABLE_hw_button)    
+    // init the ext interrupt button
+    embot::hw::button::init(buttonBLUE, {embot::hw::button::Mode::TriggeredOnRelease, {btncallback, t}, 0});    
+    embot::core::print("evthread-startup: started timer which sends evtTick to evthread every = " + embot::core::TimeFormatter(tickperiod).to_string());
+#endif
+    
+    testHWinit(t);
     
 }
 
@@ -62,19 +69,15 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
 
     if(true == embot::core::binary::mask::check(eventmask, evtTick)) 
     {
-#if defined(enableTRACE_all)        
-        embot::core::TimeFormatter tf(embot::core::now());        
-        embot::core::print("evthread-onevent: evtTick received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));    
-#endif        
-
+        onTick(t);      
     }
-    
+ 
+#if defined(EMBOT_ENABLE_hw_button)    
     if(true == embot::core::binary::mask::check(eventmask, evtBTNreleased)) 
-    {    
-        embot::core::TimeFormatter tf(embot::core::now());        
-        embot::core::print("evthread-onevent: evtBTNreleased received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));        
+    {  
+        onBTNreleased(t);         
     }
-
+#endif
 }
 
 
@@ -113,8 +116,6 @@ void initSystem(embot::os::Thread *t, void* initparam)
     thr->start(configEV);   
 }
 
-// usart 921600
-
 // --------------------------------------------------------------------------------------------------------------------
 
 int main(void)
@@ -124,7 +125,7 @@ int main(void)
     // 2 i start the scheduler
         
     constexpr embot::os::InitThread::Config initcfg = { 4*1024, initSystem, nullptr };
-    constexpr embot::os::IdleThread::Config idlecfg = { 512, nullptr, nullptr, onIdle };
+    constexpr embot::os::IdleThread::Config idlecfg = { 1024, nullptr, nullptr, onIdle };
     constexpr embot::core::Callback onOSerror = { };
     constexpr embot::os::Config osconfig {embot::core::time1millisec, initcfg, idlecfg, onOSerror};
     
@@ -141,6 +142,154 @@ int main(void)
 
 
 // - other code
+
+#if defined(EMBOT_ENABLE_hw_button)
+void onBTNreleased(embot::os::Thread *t)
+{
+    embot::core::TimeFormatter tf(embot::core::now());        
+    embot::core::print("evthread-onevent: evtBTNreleased received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));     
+}
+#endif
+
+
+void onTick(embot::os::Thread *t)
+{
+#if defined(enableTRACE_all)        
+    embot::core::TimeFormatter tf(embot::core::now());        
+    embot::core::print("evthread-onevent: evtTick received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));    
+#endif  
+
+    testHWtick(t);    
+}
+
+
+
+#define TEST_U27
+
+#include "embot_hw_tlv493d.h"
+
+constexpr embot::hw::TLV493D tlvU27 {embot::hw::TLV493D::six};
+
+#if defined(EMBOT_ENABLE_hw_tlv493d_emulatedMODE)
+const char msgTLV[] = "TLV is emulated";
+#else
+const char msgTLV[] = "TLV is true";
+#endif
+
+void testHWinit(embot::os::Thread *t)
+{     
+
+}
+
+//struct WaitCBK
+//{
+//    embot::core::Callback & get() { init(); return cbk; }
+//    void wait() { for(;;) { if(done) return; } }
+//    
+//    private:  
+//        
+//    void init() { done = false; }
+//    volatile bool done {true};
+//    static void stop(void *p) { reinterpret_cast<WaitCBK*>(p)->done =  true; }
+//    embot::core::Callback cbk {stop, this};
+//    
+//};
+
+struct Waiter : public embot::core::Callback
+{
+    Waiter() : Callback(stop, this) {}
+        
+    embot::core::Callback & callback() { init(); return *this; }
+    
+    bool wait(embot::core::relTime timeout = embot::core::reltimeWaitForever) 
+    {
+        embot::core::Time deadline {embot::core::now() + timeout};        
+        for(;;) 
+        { 
+            volatile std::int64_t rem = deadline - embot::core::now();
+            if(rem <= 0) { return false; }
+            else if(done) { return true; }
+        } 
+    }
+    
+private:  
+        
+    void init() { done = false; }
+    volatile bool done {true};
+    static void stop(void *p) { reinterpret_cast<Waiter*>(p)->done =  true; }   
+};
+
+void tlv_init()
+{
+    embot::core::TimeFormatter tf(embot::core::now());
+     
+    if(embot::hw::resOK != embot::hw::tlv493d::init(tlvU27, {embot::hw::tlv493d::Config::startupMODE::dontresetCHIP}))
+    {        
+        embot::core::print("ERROR: embot::hw::tlv493d::init() failed @ time = " + tf.to_string());    
+    }  
+    else
+    {
+        embot::core::print("INFO: embot::hw::tlv493d::init() OK @ time = " + tf.to_string());
+        embot::core::print(std::string("INFO: ") + msgTLV);
+    }  
+}
+
+void tlv_get()
+{
+    embot::hw::tlv493d::Position pos {0};
+    Waiter waiter;
+    embot::core::TimeFormatter tf0(embot::core::now());
+    embot::core::print("INFO: embot::hw::tlv493d::acquisition() @ time = " + tf0.to_string());
+    
+    embot::hw::tlv493d::acquisition(tlvU27, waiter.callback()); 
+    
+    bool res = waiter.wait();
+    if(res)
+    {
+        embot::hw::tlv493d::read(tlvU27, pos);
+    }
+    
+    embot::core::TimeFormatter tf(embot::core::now());
+    embot::core::print("INFO: embot::hw::tlv493d::read() = " + std::to_string(pos) + " @ time = " + tf.to_string());    
+}
+
+void tlv_deinit()
+{
+    embot::core::TimeFormatter tf(embot::core::now());
+     
+    if(embot::hw::resOK != embot::hw::tlv493d::deinit(tlvU27))
+    {        
+        embot::core::print("ERROR: embot::hw::tlv493d::deinit() failed @ time = " + tf.to_string());    
+    }  
+    else
+    {
+        embot::core::print("INFO: embot::hw::tlv493d::deinit() OK @ time = " + tf.to_string());
+        embot::core::print(std::string("INFO: ") + msgTLV);
+    }  
+}
+
+void testHWtick(embot::os::Thread *t)
+{
+    static uint32_t cnt {0};
+    
+    if(0 == cnt)
+    {
+        tlv_init();
+    }
+    else if(cnt<4)
+    {   
+        tlv_get();
+    }
+    else if(4 == cnt)
+    {
+        tlv_deinit();
+    }
+    
+    if(++cnt > 4)
+    {
+        cnt = 0;
+    }
+}
 
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_tlv493d.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_tlv493d.h
@@ -48,7 +48,7 @@ namespace embot { namespace hw { namespace tlv493d {
     bool supported(embot::hw::TLV493D h);    
     bool initialised(embot::hw::TLV493D h);    
     result_t init(embot::hw::TLV493D h, const Config &config);
-        
+    result_t deinit(embot::hw::TLV493D h);    
     
     // after that init() returns resOK we can check if it is alive. we can specify a timeout
     bool isalive(embot::hw::TLV493D h, embot::core::relTime timeout = 3*embot::core::time1millisec);


### PR DESCRIPTION
This PR is a second attempt of https://github.com/robotology/icub-firmware/pull/308, So I will report in here the original text.


This PR adds a test project for the reading of the sensor `embot::hw::tlv493d` over I2C on the `pmc` board.

The test project is useful for having a golden reference in the development of an emulated I2C driver able to read the same sensor on board `mtb4fap`.

This PR can be safely merged as it does not conflict w/ code used for boards in iCub.