### PR TITLE
hal-spiencoder: small fix in hal_spiencoder_get_value2 for aksim2 encoder

### DIFF
--- a/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/hal2/src/extra/devices/hal_spiencoder.c
+++ b/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/hal2/src/extra/devices/hal_spiencoder.c
@@ -808,7 +808,7 @@ extern hal_result_t hal_spiencoder_get_value2(hal_spiencoder_t id, hal_spiencode
             diagn->type = hal_spiencoder_diagnostic_type_aksim2_invalid_data;
             diagn->info.aksim2_status_crc |= 0x04;
         }    
-        else if(0x2 == intitem->status_bits)
+        if(0x2 == intitem->status_bits)
         {
             // Warning - the position data is valid, but some operating conditions are close to limits
             diagn->type = hal_spiencoder_diagnostic_type_aksim2_close_to_limits;


### PR DESCRIPTION
Here I'm pushing a minimal fix in the hal_spiencoder_get_value2, which I already tested with @sgiraz.

In this way, we can check all status-bits. 