### PR TITLE
Board `amc`: fix of CAN discovery in `eUpdater`

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/proj/amc-eupdater.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/proj/amc-eupdater.uvoptx
@@ -163,17 +163,17 @@
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>sentpkts,0x0A</ItemText>
+          <ItemText>par,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>s_proc_PROG_rxpackets,0x0A</ItemText>
+          <ItemText>action</ItemText>
         </Ww>
         <Ww>
           <count>2</count>
           <WinNumber>1</WinNumber>
-          <ItemText>appl</ItemText>
+          <ItemText>pImpl</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -197,7 +197,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -957,7 +957,7 @@
 
   <Group>
     <GroupName>updater-code</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1320,18 +1320,6 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</PathWithFileName>
-      <FilenameWithoutPath>embot_hw_chip_KSZ8563.cpp</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>7</GroupNumber>
-      <FileNumber>29</FileNumber>
-      <FileType>8</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_eeprom.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_hw_eeprom.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
@@ -1339,7 +1327,7 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1351,13 +1339,25 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_timer.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_hw_timer.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>7</GroupNumber>
+      <FileNumber>31</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_chip_KSZ8563.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/proj/amc-eupdater.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/proj/amc-eupdater.uvprojx
@@ -569,62 +569,6 @@
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eth.cpp</FilePath>
             </File>
             <File>
-              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
-              <FileOption>
-                <CommonProperty>
-                  <UseCPPCompiler>2</UseCPPCompiler>
-                  <RVCTCodeConst>0</RVCTCodeConst>
-                  <RVCTZI>0</RVCTZI>
-                  <RVCTOtherData>0</RVCTOtherData>
-                  <ModuleSelection>0</ModuleSelection>
-                  <IncludeInBuild>2</IncludeInBuild>
-                  <AlwaysBuild>2</AlwaysBuild>
-                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
-                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
-                  <PublicsOnly>2</PublicsOnly>
-                  <StopOnExitCode>11</StopOnExitCode>
-                  <CustomArgument></CustomArgument>
-                  <IncludeLibraryModules></IncludeLibraryModules>
-                  <ComprImg>1</ComprImg>
-                </CommonProperty>
-                <FileArmAds>
-                  <Cads>
-                    <interw>2</interw>
-                    <Optim>0</Optim>
-                    <oTime>2</oTime>
-                    <SplitLS>0</SplitLS>
-                    <OneElfS>2</OneElfS>
-                    <Strict>2</Strict>
-                    <EnumInt>2</EnumInt>
-                    <PlainCh>2</PlainCh>
-                    <Ropi>2</Ropi>
-                    <Rwpi>2</Rwpi>
-                    <wLevel>0</wLevel>
-                    <uThumb>2</uThumb>
-                    <uSurpInc>2</uSurpInc>
-                    <uC99>2</uC99>
-                    <uGnu>2</uGnu>
-                    <useXO>2</useXO>
-                    <v6Lang>0</v6Lang>
-                    <v6LangP>0</v6LangP>
-                    <vShortEn>2</vShortEn>
-                    <vShortWch>2</vShortWch>
-                    <v6Lto>2</v6Lto>
-                    <v6WtE>2</v6WtE>
-                    <v6Rtti>2</v6Rtti>
-                    <VariousControls>
-                      <MiscControls></MiscControls>
-                      <Define></Define>
-                      <Undefine></Undefine>
-                      <IncludePath></IncludePath>
-                    </VariousControls>
-                  </Cads>
-                </FileArmAds>
-              </FileOption>
-            </File>
-            <File>
               <FileName>embot_hw_eeprom.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eeprom.cpp</FilePath>
@@ -638,6 +582,11 @@
               <FileName>embot_hw_timer.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_timer.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -1252,6 +1201,75 @@
         </Group>
         <Group>
           <GroupName>embot::hw::lowlevel</GroupName>
+          <GroupOption>
+            <CommonProperty>
+              <UseCPPCompiler>0</UseCPPCompiler>
+              <RVCTCodeConst>0</RVCTCodeConst>
+              <RVCTZI>0</RVCTZI>
+              <RVCTOtherData>0</RVCTOtherData>
+              <ModuleSelection>0</ModuleSelection>
+              <IncludeInBuild>2</IncludeInBuild>
+              <AlwaysBuild>2</AlwaysBuild>
+              <GenerateAssemblyFile>2</GenerateAssemblyFile>
+              <AssembleAssemblyFile>2</AssembleAssemblyFile>
+              <PublicsOnly>2</PublicsOnly>
+              <StopOnExitCode>11</StopOnExitCode>
+              <CustomArgument></CustomArgument>
+              <IncludeLibraryModules></IncludeLibraryModules>
+              <ComprImg>1</ComprImg>
+            </CommonProperty>
+            <GroupArmAds>
+              <Cads>
+                <interw>2</interw>
+                <Optim>1</Optim>
+                <oTime>2</oTime>
+                <SplitLS>2</SplitLS>
+                <OneElfS>2</OneElfS>
+                <Strict>2</Strict>
+                <EnumInt>2</EnumInt>
+                <PlainCh>2</PlainCh>
+                <Ropi>2</Ropi>
+                <Rwpi>2</Rwpi>
+                <wLevel>0</wLevel>
+                <uThumb>2</uThumb>
+                <uSurpInc>2</uSurpInc>
+                <uC99>2</uC99>
+                <uGnu>2</uGnu>
+                <useXO>2</useXO>
+                <v6Lang>0</v6Lang>
+                <v6LangP>0</v6LangP>
+                <vShortEn>2</vShortEn>
+                <vShortWch>2</vShortWch>
+                <v6Lto>2</v6Lto>
+                <v6WtE>2</v6WtE>
+                <v6Rtti>2</v6Rtti>
+                <VariousControls>
+                  <MiscControls></MiscControls>
+                  <Define></Define>
+                  <Undefine></Undefine>
+                  <IncludePath></IncludePath>
+                </VariousControls>
+              </Cads>
+              <Aads>
+                <interw>2</interw>
+                <Ropi>2</Ropi>
+                <Rwpi>2</Rwpi>
+                <thumb>2</thumb>
+                <SplitLS>2</SplitLS>
+                <SwStkChk>2</SwStkChk>
+                <NoWarn>2</NoWarn>
+                <uSurpInc>2</uSurpInc>
+                <useXO>2</useXO>
+                <ClangAsOpt>0</ClangAsOpt>
+                <VariousControls>
+                  <MiscControls></MiscControls>
+                  <Define></Define>
+                  <Undefine></Undefine>
+                  <IncludePath></IncludePath>
+                </VariousControls>
+              </Aads>
+            </GroupArmAds>
+          </GroupOption>
           <Files>
             <File>
               <FileName>embot_hw_lowlevel.cpp</FileName>
@@ -1978,11 +1996,6 @@
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eth.cpp</FilePath>
             </File>
             <File>
-              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
-            </File>
-            <File>
               <FileName>embot_hw_eeprom.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eeprom.cpp</FilePath>
@@ -1996,6 +2009,11 @@
               <FileName>embot_hw_timer.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_timer.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3030,11 +3048,6 @@
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eth.cpp</FilePath>
             </File>
             <File>
-              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
-            </File>
-            <File>
               <FileName>embot_hw_eeprom.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eeprom.cpp</FilePath>
@@ -3048,6 +3061,11 @@
               <FileName>embot_hw_timer.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_timer.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -4031,62 +4049,6 @@
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eth.cpp</FilePath>
             </File>
             <File>
-              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
-              <FileOption>
-                <CommonProperty>
-                  <UseCPPCompiler>2</UseCPPCompiler>
-                  <RVCTCodeConst>0</RVCTCodeConst>
-                  <RVCTZI>0</RVCTZI>
-                  <RVCTOtherData>0</RVCTOtherData>
-                  <ModuleSelection>0</ModuleSelection>
-                  <IncludeInBuild>2</IncludeInBuild>
-                  <AlwaysBuild>2</AlwaysBuild>
-                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
-                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
-                  <PublicsOnly>2</PublicsOnly>
-                  <StopOnExitCode>11</StopOnExitCode>
-                  <CustomArgument></CustomArgument>
-                  <IncludeLibraryModules></IncludeLibraryModules>
-                  <ComprImg>1</ComprImg>
-                </CommonProperty>
-                <FileArmAds>
-                  <Cads>
-                    <interw>2</interw>
-                    <Optim>0</Optim>
-                    <oTime>2</oTime>
-                    <SplitLS>0</SplitLS>
-                    <OneElfS>2</OneElfS>
-                    <Strict>2</Strict>
-                    <EnumInt>2</EnumInt>
-                    <PlainCh>2</PlainCh>
-                    <Ropi>2</Ropi>
-                    <Rwpi>2</Rwpi>
-                    <wLevel>0</wLevel>
-                    <uThumb>2</uThumb>
-                    <uSurpInc>2</uSurpInc>
-                    <uC99>2</uC99>
-                    <uGnu>2</uGnu>
-                    <useXO>2</useXO>
-                    <v6Lang>0</v6Lang>
-                    <v6LangP>0</v6LangP>
-                    <vShortEn>2</vShortEn>
-                    <vShortWch>2</vShortWch>
-                    <v6Lto>2</v6Lto>
-                    <v6WtE>2</v6WtE>
-                    <v6Rtti>2</v6Rtti>
-                    <VariousControls>
-                      <MiscControls></MiscControls>
-                      <Define></Define>
-                      <Undefine></Undefine>
-                      <IncludePath></IncludePath>
-                    </VariousControls>
-                  </Cads>
-                </FileArmAds>
-              </FileOption>
-            </File>
-            <File>
               <FileName>embot_hw_eeprom.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_eeprom.cpp</FilePath>
@@ -4100,6 +4062,11 @@
               <FileName>embot_hw_timer.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_timer.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_chip_KSZ8563.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_KSZ8563.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eOcfg_sm_cangtw.c
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eOcfg_sm_cangtw.c
@@ -543,10 +543,15 @@ static void s_smcfg_CanGtw_reset(EOsm *s)
 
 static void s_smcfg_CanGtw_on_entry_IDLE(EOsm *s) 
 {
-//    updater_core_trace(NULL, "inside s_smcfg_CanGtw_on_entry_IDLE()");
-    
+#if defined(UPDATER_DEBUG_MODE)
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_entry_IDLE");
+#endif    
     // allocate the service timer.
     s_smcfg_CanGtw_service_timer = eo_timer_New();   
+#if defined(UPDATER_DEBUG_MODE)    
+    // and name it
+    eo_timer_SetName(s_smcfg_CanGtw_service_timer, "EOtmrCANGTW");
+#endif    
     
     // allocate the packets
     s_rxpkt_gtwcan = eo_packet_New(eupdater_cangtw_udp_packet_maxsize);  
@@ -556,8 +561,9 @@ static void s_smcfg_CanGtw_on_entry_IDLE(EOsm *s)
 
 static void s_smcfg_CanGtw_on_entry_STARTUP(EOsm *s) 
 {   
-    // updater_core_trace(NULL, "inside s_smcfg_CanGtw_on_entry_STARTUP() w/ CAN power on");
-    
+#if defined(UPDATER_DEBUG_MODE)
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_entry_STARTUP");
+#endif
     // prepare can bus. then, emit two events which send all the can boards in bootloader mode    
     cangateway_hid_hal_init();
     cangateway_hid_hal_enable();
@@ -578,8 +584,9 @@ static void s_smcfg_CanGtw_on_entry_STARTUP(EOsm *s)
 
 static void s_smcfg_CanGtw_on_entry_RUN(EOsm *s) 
 {   
-    // updater_core_trace("GTW", "inside on_entry_RUN()");
-    
+#if defined(UPDATER_DEBUG_MODE)
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_entry_RUN");
+#endif    
     eupdater_parser_cangtw_activate();
     
     const cangtw_parameters_t * par = eupdater_cangtw_get_parameters();    
@@ -609,7 +616,10 @@ static void s_smcfg_CanGtw_on_entry_RUN(EOsm *s)
 
 
 static void s_smcfg_CanGtw_on_trans_STARTUP_evcanstable(EOsm *s)
-{  
+{
+#if defined(UPDATER_DEBUG_MODE)    
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_trans_STARTUP_evcanstable");
+#endif  
     const cangtw_parameters_t * par = eupdater_cangtw_get_parameters();
     
     if(eobool_true == par->send_ff)
@@ -644,8 +654,9 @@ static void s_smcfg_CanGtw_on_trans_STARTUP_evcanstable(EOsm *s)
 
 static void s_smcfg_CanGtw_on_trans_RUN_evgo2run(EOsm *s)
 {    
-    // updater_core_trace("GTW", "called on_trans_RUN_evgo2run()");
-
+#if defined(UPDATER_DEBUG_MODE)
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_trans_RUN_evgo2run");
+#endif
     const cangtw_parameters_t * par = eupdater_cangtw_get_parameters();    
     
     if(eobool_true == par->clear_can_onentry_gtw)
@@ -663,6 +674,9 @@ static void s_smcfg_CanGtw_on_trans_RUN_evgo2run(EOsm *s)
 
 static void s_smcfg_CanGtw_on_trans_RUN_evrxeth(EOsm *s)
 {
+#if defined(UPDATER_DEBUG_MODE)     
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_trans_RUN_evrxeth");
+#endif
     // retrieve the packet       
     if(eores_OK == eo_socketdtg_Get(eupdater_sock_cangateway, s_rxpkt_gtwcan, eok_reltimeINFINITE))    
     {   
@@ -678,6 +692,9 @@ static void s_smcfg_CanGtw_on_trans_RUN_evrxeth(EOsm *s)
 
 static void s_smcfg_CanGtw_on_trans_RUN_evrxcan1(EOsm *s)
 {  
+#if defined(UPDATER_DEBUG_MODE)  
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_trans_RUN_evrxcan1");    
+#endif
     // get can frame from the specified port and forward a single can 
     s_can_get(hal_can_port1);
     
@@ -688,6 +705,9 @@ static void s_smcfg_CanGtw_on_trans_RUN_evrxcan1(EOsm *s)
 
 static void s_smcfg_CanGtw_on_trans_RUN_evrxcan2(EOsm *s)
 {
+#if defined(UPDATER_DEBUG_MODE)  
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_smcfg_CanGtw_on_trans_RUN_evrxcan2");  
+#endif
     // get can frame from the specified port and forward a single can 
     s_can_get(hal_can_port2);
     
@@ -811,6 +831,9 @@ static void s_parse_upd_packet(EOpacket* pkt)
 //    hal_led_toggle((hal_can_port1 == port) ? hal_led4 : hal_led5);
     embot::hw::led::toggle((hal_can_port1 == port) ? embot::hw::LED::five: embot::hw::LED::six);   
     hal_can_put(port, &frame, hal_can_send_normprio_now);
+#if defined(UPDATER_DEBUG_MODE)     
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_parse_upd_packet() tx a can frame");
+#endif
 }
 
 static void s_can_get(hal_can_port_t port)
@@ -823,15 +846,21 @@ static void s_can_get(hal_can_port_t port)
 
     eo_packet_Payload_Get(s_txpkt_gtwcan, (uint8_t**)&simpleudpframe, &size);
     
-  
+#if defined(UPDATER_DEBUG_MODE)     
+   embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_can_get()");
+#endif 
+    
     res = hal_can_get(port, &frame, &remaining);
     
     if(eobool_false == eupdater_parser_cangtw_isactivated())
     {
-    //    updater_core_trace("GTW", "called s_can_get() but the gateway is not active yet");
 #if     defined(_DEBUG_MODE_PRINTCAN_)          
         s_print_canframe(0, 0, port, &frame);   
 #endif        
+
+#if defined(UPDATER_DEBUG_MODE)  
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_can_get() GTW not activated");        
+#endif
         return;
     }
 
@@ -867,7 +896,9 @@ static void s_can_get(hal_can_port_t port)
 #if     defined(_DEBUG_MODE_PRINTCAN_)                
         s_print_canframe(0, 0, port, &frame);        
 #endif
-        
+#if defined(UPDATER_DEBUG_MODE) 
+           embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_can_get() pkt in skt");
+#endif        
     }
 }
 
@@ -909,6 +940,9 @@ static void s_send_blmsg(EOsm *s)
 {
     eOsmDynamicDataCanGtw_t *ram = (eOsmDynamicDataCanGtw_t*) eo_sm_GetDynamicData(s);
     ram->number_of_sent_canblmsg ++;
+#if defined(UPDATER_DEBUG_MODE)     
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_send_blmsg()");
+#endif
     
 
     if(NULL != CANMSG2SEND)

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eupdater-info.c
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eupdater-info.c
@@ -88,16 +88,16 @@ constexpr eEmoduleExtendedInfo_t eupdater_modinfo_extended  __attribute__((secti
                 .signature  = ee_procUpdater,
                 .version    = 
                 { 
-                    .major = 2, 
-                    .minor = 23
+                    .major = 3, 
+                    .minor = 0
                 },  
                 .builddate  = 
                 {
                     .year  = 2022,
-                    .month = 4,
-                    .day   = 8,
-                    .hour  = 18,
-                    .min   = 36
+                    .month = 11,
+                    .day   = 25,
+                    .hour  = 16,
+                    .min   = 42
                 }
             },
             .rom        = 

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eupdater_cangtw.c
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eupdater_cangtw.c
@@ -59,6 +59,7 @@
 
 #include "updater-core.h"
 
+#include "embot_core.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 // - declaration of external variables 
@@ -177,7 +178,7 @@ extern void eupdater_cangtw_init(void)
     
     // init the gtw task
     #warning MARCOACCAME: non va bene 100, uso 24
-    eupdater_task_cangateway = eom_task_New(eom_mtask_EventDriven, 24, 2*1024, s_cangateway_startup, s_cangateway_run,  32, 
+    eupdater_task_cangateway = eom_task_New(eom_mtask_EventDriven, 24, 6*1024, s_cangateway_startup, s_cangateway_run,  32, 
                                     eok_reltimeINFINITE, NULL, 
                                     task_cangateway, "cangateway");    
     
@@ -185,7 +186,10 @@ extern void eupdater_cangtw_init(void)
 }
 
 extern void eupdater_cangtw_start(eOipv4addr_t remipaddr, const cangtw_parameters_t *params)
-{     
+{
+#if defined(UPDATER_DEBUG_MODE)       
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": eupdater_cangtw_start()");
+#endif 
     if(NULL == params)
     {
        params = &default_params;      
@@ -351,6 +355,43 @@ static void s_cangateway_startup(EOMtask *p, uint32_t t)
     osal_semaphore_increment(startup_done_semaphore, osal_callerTSK);
 }
 
+#if defined(UPDATER_DEBUG_MODE) 
+const char *evtstr[] =
+{
+    "sock_rec", 
+    "can1_rec",
+    "can2_rec",
+    "start",
+    "canstable",
+    "go2run"    
+};
+
+uint8_t evt2index(uint32_t e)
+{
+    uint8_t r = 255;
+    switch(e)
+    {
+        case event_cangtw_sock_rec: r = 0; break;
+        case event_cangtw_can1_rec: r = 1; break;
+        case event_cangtw_can2_rec: r = 2; break;
+        case event_cangtw_start: r = 3; break;
+        case event_cangtw_canstable: r = 4; break;
+        case event_cangtw_go2run: r = 5; break;
+        
+        default: r = 255; break;        
+    }
+
+    return r;    
+}
+
+const char * evtname(uint32_t t)
+{
+    uint8_t i = evt2index(t);
+    
+    return (255 == i) ? "unknown" : evtstr[i];
+}
+#endif
+
 static void s_cangateway_run(EOMtask *p, uint32_t t)
 {
     eOevent_t evt = (eOevent_t) t;
@@ -361,31 +402,61 @@ static void s_cangateway_run(EOMtask *p, uint32_t t)
     
     if(eobool_true == eo_common_event_check(evt, event_cangtw_start))
     {
+#if defined(UPDATER_DEBUG_MODE)         
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + 
+            ": s_cangateway_run() evt = " + 
+            std::string(evtname(event_cangtw_start)));
+#endif
         eo_sm_ProcessEvent(s_sm_cangtw, eo_sm_cangtw_evstart);        
     }
 
     if(eobool_true == eo_common_event_check(evt, event_cangtw_canstable))
     {
+#if defined(UPDATER_DEBUG_MODE)         
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + 
+            ": s_cangateway_run() evt = " + 
+            std::string(evtname(event_cangtw_canstable)));
+#endif            
         eo_sm_ProcessEvent(s_sm_cangtw, eo_sm_cangtw_evcanstable);        
     }    
     
     if(eobool_true == eo_common_event_check(evt, event_cangtw_go2run))
     {
+#if defined(UPDATER_DEBUG_MODE)         
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + 
+            ": s_cangateway_run() evt = " + 
+            std::string(evtname(event_cangtw_go2run))); 
+#endif        
         eo_sm_ProcessEvent(s_sm_cangtw, eo_sm_cangtw_evgo2run);        
     }
     
     if(eobool_true == eo_common_event_check(evt, event_cangtw_sock_rec))
     {
+#if defined(UPDATER_DEBUG_MODE)          
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + 
+            ": s_cangateway_run() evt = " + 
+            std::string(evtname(event_cangtw_sock_rec)));
+#endif             
         eo_sm_ProcessEvent(s_sm_cangtw, eo_sm_cangtw_evrxeth);        
     }
     
     if(eobool_true == eo_common_event_check(evt, event_cangtw_can1_rec))
     {
+#if defined(UPDATER_DEBUG_MODE)          
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + 
+            ": s_cangateway_run() evt = " + 
+            std::string(evtname(event_cangtw_can1_rec)));
+#endif             
         eo_sm_ProcessEvent(s_sm_cangtw, eo_sm_cangtw_evrxcan1);        
     }    
     
     if(eobool_true == eo_common_event_check(evt, event_cangtw_can2_rec))
     {
+#if defined(UPDATER_DEBUG_MODE)          
+        embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + 
+            ": s_cangateway_run() evt = " + 
+            std::string(evtname(event_cangtw_can2_rec)));
+#endif             
         eo_sm_ProcessEvent(s_sm_cangtw, eo_sm_cangtw_evrxcan2);        
     }  
   

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eupdater_parser.c
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/eupdater_parser.c
@@ -460,7 +460,7 @@ static void s_stayforever(eOipv4addr_t remaddress)
 #if !defined(_MAINTAINER_APPL_)
 #ifdef _START_CANGTW_WHEN_STAY_FOREVER_    
     // if updater we also start the can gateway
-    eupdater_cangtw_start(remaddress);
+    eupdater_cangtw_start(remaddress, NULL);
 #endif  
     // i init the 5v0 as soon as i know i stay in here forever.
     // BUT it dont init the can so that things are not changed with respect to prev version

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/updater-core.c
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/eupdater/updater-core.c
@@ -495,7 +495,9 @@ static uint8_t s_uprot_proc_CANGATEWAY(eOuprot_opcodes_t opc, uint8_t *pktin, ui
         
         pp = &params;
     }
-    
+#if defined(UPDATER_DEBUG_MODE)  
+    embot::core::print(embot::core::TimeFormatter(embot::core::now()).to_string() + ": s_uprot_proc_CANGATEWAY() -> eupdater_cangtw_start()");
+#endif    
     eupdater_cangtw_start(remaddr, pp);    
     
     // no reply for now ...

--- a/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/updater-embot-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eupdater/src/updater-embot-main.cpp
@@ -56,15 +56,17 @@ void onIdle(embot::os::Thread *t, void* idleparam)
 void initSystem(embot::os::Thread *t, void* initparam)
 {
     embot::core::print("eUpdater: this is me");    
-        
-    embot::os::theTimerManager::getInstance().start({});     
+    
+    embot::os::theTimerManager::Config tcfg {};
+    tcfg.stacksize = 8*1024;    
+    embot::os::theTimerManager::getInstance().start(tcfg);     
     embot::os::theCallbackManager::getInstance().start({});  
     embot::os::EOM::initialise(eomcfg);
     
     // ok, now you can run whatever you want ...
     s_initialiser();        
                 
-        embot::core::print("eUpdater: quitting the INIT thread. Normal scheduling starts");    
+    embot::core::print("eUpdater: quitting the INIT thread. Normal scheduling starts");    
 }
 
 
@@ -253,11 +255,7 @@ static void s_eom_eupdater_main_init(void)
     // eeprom is used for shared services but is initted also inside there
     //hal_eeprom_init(hal_eeprom_i2c_01, NULL);
     embot::hw::eeprom::init(embot::hw::EEPROM::one, {});
-    // flash MUST be unlocked if one wants to erase code space (program application, updater, loader)
-    //#warning FLASH MUST BE hal_flash_unlock() >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-    #warning -> FLASH programming MUST BE TESTED <-
-    //hal_flash_unlock();
-    
+
 
 #if !defined(_MAINTAINER_APPL_)    
     eo_armenv_Initialise((const eEmoduleInfo_t*)&eupdater_modinfo_extended, NULL);
@@ -327,7 +325,7 @@ static void s_eom_eupdater_main_init(void)
     // the eth command task 
 //    updater_core_trace("MAIN", "starting ::taskethcommand");                       
     //#warning MARCOACCAME: non va bene 101, uso 25
-    s_task_ethcommand = eom_task_New(eom_mtask_MessageDriven, 25, 2*1024, s_ethcommand_startup, s_ethcommand_run,  16, 
+    s_task_ethcommand = eom_task_New(eom_mtask_MessageDriven, 25, 6*1024, s_ethcommand_startup, s_ethcommand_run,  16, 
                                     eok_reltimeINFINITE, NULL, 
                                     task_ethcommand, "ethcommand");
     s_task_ethcommand = s_task_ethcommand;

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvoptx
@@ -187,7 +187,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -1607,7 +1607,7 @@
 
   <Group>
     <GroupName>embot-hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/embot-os-hw/proj/amc-embot-os-hw.uvprojx
@@ -582,11 +582,113 @@
               <FileName>embot_os_theCallbackManager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\os\embot_os_theCallbackManager.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_os_theTimerManager.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\os\embot_os_theTimerManager.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_os_Thread.cpp</FileName>
@@ -597,6 +699,57 @@
               <FileName>embot_os_Timer.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\os\embot_os_Timer.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_os_rtos.cpp</FileName>

--- a/emBODY/eBcode/arch-arm/board/pmc/appfap/src/pmc-appfap.cpp
+++ b/emBODY/eBcode/arch-arm/board/pmc/appfap/src/pmc-appfap.cpp
@@ -250,15 +250,7 @@ void myEVT::userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask 
     if(true == embot::app::application::theCANparserBasic::getInstance().process(frame, outframes))
     {
     }
-<<<<<<< HEAD
-<<<<<<< HEAD
     else if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
-=======
-    if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
->>>>>>> 3103b9f75 (added a fap reader project for the pmc board)
-=======
-    else if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
->>>>>>> 21fb3879e (corrected)
     {
     }
 

--- a/emBODY/eBcode/arch-arm/board/pmc/appfap/src/pmc-appfap.cpp
+++ b/emBODY/eBcode/arch-arm/board/pmc/appfap/src/pmc-appfap.cpp
@@ -251,10 +251,14 @@ void myEVT::userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask 
     {
     }
 <<<<<<< HEAD
+<<<<<<< HEAD
     else if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
 =======
     if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
 >>>>>>> 3103b9f75 (added a fap reader project for the pmc board)
+=======
+    else if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
+>>>>>>> 21fb3879e (corrected)
     {
     }
 

--- a/emBODY/eBcode/arch-arm/board/pmc/appfap/src/pmc-appfap.cpp
+++ b/emBODY/eBcode/arch-arm/board/pmc/appfap/src/pmc-appfap.cpp
@@ -250,7 +250,11 @@ void myEVT::userdefOnEventRXcanframe(embot::os::Thread *t, embot::os::EventMask 
     if(true == embot::app::application::theCANparserBasic::getInstance().process(frame, outframes))
     {
     }
+<<<<<<< HEAD
     else if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
+=======
+    if(true == embot::app::application::theCANparserPOS::getInstance().process(frame, outframes))
+>>>>>>> 3103b9f75 (added a fap reader project for the pmc board)
     {
     }
 

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_Action.cpp
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_Action.cpp
@@ -34,11 +34,11 @@ namespace embot { namespace os {
     
     bool EventToThread::isvalid() const
     {
-        if((nullptr == task) || (0 == event)) 
+        if((nullptr == thread) || (0 == event)) 
         { 
             return false; 
         }
-        else if(Thread::Type::eventTrigger != task->getType()) 
+        else if(Thread::Type::eventTrigger != thread->getType()) 
         { 
             return false; 
         }
@@ -54,14 +54,14 @@ namespace embot { namespace os {
         {
             return false;
         }
-        task->setEvent(event);
+        thread->setEvent(event);
         return true;
     }
     
     bool MessageToThread::isvalid() const
     {
-        if((nullptr == task) || (nullptr == message)) { return false; }
-        else if(Thread::Type::messageTrigger != task->getType()) { return false; }
+        if((nullptr == thread) || (nullptr == message)) { return false; }
+        else if(Thread::Type::messageTrigger != thread->getType()) { return false; }
         else { return true; }
     } 
     
@@ -71,14 +71,14 @@ namespace embot { namespace os {
         {
             return false;
         }
-        task->setMessage(message, timeout);
+        thread->setMessage(message, timeout);
         return true;
     } 
         
     bool ValueToThread::isvalid() const
     {
-        if((nullptr == task) || (0 == value)) { return false; }
-        else if(Thread::Type::valueTrigger != task->getType()) { return false; }
+        if((nullptr == thread) || (0 == value)) { return false; }
+        else if(Thread::Type::valueTrigger != thread->getType()) { return false; }
         else { return true; }
     } 
     
@@ -88,14 +88,14 @@ namespace embot { namespace os {
         {
             return false;
         }
-        task->setValue(value, timeout);
+        thread->setValue(value, timeout);
         return true;
     } 
     
     bool CallbackToThread::isvalid() const 
     {
         if((false == callback.isvalid())) { return false; }
-        //else if(Thread::Type::callbackTrigger != task->getType()) { return false; }
+        //else if(Thread::Type::callbackTrigger != thread->getType()) { return false; }
         else { return true; }
     } 
     
@@ -106,9 +106,9 @@ namespace embot { namespace os {
         {
             return false;
         }
-        if((nullptr != task) && (embot::os::Thread::Type::callbackTrigger == task->getType()))
+        if((nullptr != thread) && (embot::os::Thread::Type::callbackTrigger == thread->getType()))
         {
-            task->setCallback(callback, timeout);
+            thread->setCallback(callback, timeout);
         }
         else
         {

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_Action.h
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_Action.h
@@ -30,10 +30,10 @@ namespace embot { namespace os {
     struct EventToThread
     {
         os::Event event {0};
-        Thread* task {nullptr};  
+        Thread* thread {nullptr};  
         
         EventToThread() = default;
-        EventToThread(os::Event e, Thread* t) : event(e), task(t) {}
+        EventToThread(os::Event e, Thread* t) : event(e), thread(t) {}
         bool isvalid() const;
         bool execute();
     };
@@ -41,10 +41,10 @@ namespace embot { namespace os {
     struct MessageToThread
     {
         os::Message message {nullptr};
-        Thread* task {nullptr};
+        Thread* thread {nullptr};
         
         MessageToThread() = default;  
-        MessageToThread(os::Message m, Thread* t) : message(m), task(t) {}    
+        MessageToThread(os::Message m, Thread* t) : message(m), thread(t) {}    
         bool isvalid() const;
         bool execute(core::relTime timeout = core::reltimeWaitForever);
     };
@@ -53,10 +53,10 @@ namespace embot { namespace os {
     struct ValueToThread
     {
         os::Value value {0};
-        Thread* task {nullptr};
+        Thread* thread {nullptr};
         
         ValueToThread() = default;  
-        ValueToThread(os::Value v, Thread* t) : value(v), task(t) {}    
+        ValueToThread(os::Value v, Thread* t) : value(v), thread(t) {}    
         bool isvalid() const;
         bool execute(core::relTime timeout = core::reltimeWaitForever);
     };    
@@ -64,11 +64,11 @@ namespace embot { namespace os {
     struct CallbackToThread
     {
         core::Callback callback {nullptr, nullptr};
-        Thread* task {nullptr};  
+        Thread* thread {nullptr};  
 
         CallbackToThread() = default;        
-        CallbackToThread(core::fpCaller c, void *a, Thread *t) : callback(c, a), task(t) {}  
-        CallbackToThread(core::Callback cbk, Thread *t) : callback(cbk), task(t) {}                   
+        CallbackToThread(core::fpCaller c, void *a, Thread *t) : callback(c, a), thread(t) {}  
+        CallbackToThread(core::Callback cbk, Thread *t) : callback(cbk), thread(t) {}                   
         bool isvalid() const;
         bool execute(core::relTime timeout = core::reltimeWaitForever);
     };  
@@ -89,6 +89,7 @@ namespace embot { namespace os {
                
         Action() { clear(); } 
         Action(const CallbackToThread &c) { load(c); }
+        Action(const core::Callback cbk, Thread *t) { load({cbk, t}); }
         Action(const MessageToThread &m) { load(m); }
         Action(const ValueToThread &v) { load(v); }
         Action(const EventToThread &e) { load(e); }        

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_Timer.cpp
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_Timer.cpp
@@ -39,184 +39,178 @@
 // - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
 // --------------------------------------------------------------------------------------------------------------------
 
-
-
-namespace embot { namespace os { namespace timertools {
-        
-    struct TMR 
-    {
-        Timer *owner {nullptr};
-        embot::os::rtos::timer_t *rtostimer {nullptr};
-        Timer::Config tconfig {};         
-        Timer::Status sta {Timer::Status::idle};             
-        std::uint32_t maxshots {0};
-        std::uint32_t count {0};        
-        bool canexecuteaction {false}; 
-        bool onemoretime {false};                 
-        
-        TMR(Timer *own)   
-        {
-            owner = own;
-            reset(Timer::Status::idle, true);
-            rtostimer = embot::os::rtos::timer_new();
-        }
-        
-        ~TMR()   
-        {
-            stop();
-            // do reverse deallocation and cleaning
-            embot::os::rtos::timer_delete(rtostimer);
-            rtostimer = nullptr;
-            reset(Timer::Status::idle, true);              
-            canexecuteaction = false;  
-            owner = nullptr;            
-        }
-        
-        void reset(Timer::Status st, bool alsoconfig)
-        {
-            sta = st;
-            canexecuteaction = false;
-            onemoretime = false;
-            if(alsoconfig)
-            {
-                tconfig.clear();
-                tconfig.onexpiry.clear();
-            }
-        }
-        
-        Timer::Status getstatus()
-        {
-            return sta;
-        }
-
-        bool load(const Timer::Config &config)
-        {            
-            // config must be valid 
-            if(false == config.isvalid())
-            {
-                return false;
-            }
-            
-            // make sure the timer is stopped
-            stop();
-            
-            // copy the config
-            tconfig = config;
-                                                    
-            return true;
-        }  
-        
-        
-        bool start(const Timer::Config &config, bool forcerestart)
-        {            
-            // config must be valid 
-            if(false == config.isvalid())
-            {
-                return false;
-            }
-                                                    
-            bool ret = false;
-                        
-            // start it only if it is not counting. if we have forcerestart we re-start it anyway
-            // both osal and cmsisos2 allow to restart a running timer
-            if((true == forcerestart) || (Timer::Status::counting != getstatus()))
-            {
-                tconfig = config;
-                             
-                canexecuteaction = false;                              
-
-                embot::os::rtos::timerMode mode = (Timer::Mode::oneshot == tconfig.mode) ? (embot::os::rtos::timerMode::oneshot) : (embot::os::rtos::timerMode::forever);
-                 
-                if(true == embot::os::rtos::timer_start(rtostimer, mode, tconfig.countdown, OnExpiryCbk, this))               
-                {
-                    sta = Timer::Status::counting;
-                    count = 0;
-                    maxshots = ( (Timer::Mode::someshots == tconfig.mode) ? (tconfig.numofshots) : (0) );
-                    onemoretime = false;
-                    ret = true;
-                }
-                else
-                {
-                    sta  = Timer::Status::idle;
-                    onemoretime =  false;
-                    ret = false;
-                }
-            }
-                    
-            return ret;
-        }  
-        
-        bool start()
-        {
-            constexpr bool forcerestart = true;
-            return start(tconfig, forcerestart);
-        }
-
-        // keep it simple. it is executed by osal inside the systick  and by cmsisos2 inside a small thread
-#if defined(EMBOT_USE_rtos_cmsisos2)        
-        static void OnExpiryCbk(void *par) 
-#else
-        static void OnExpiryCbk(embot::os::rtos::timer_t *rtostmr, void *par)
-#endif        
-        {
-            TMR *otm = reinterpret_cast<TMR*>(par);
-            otm->canexecuteaction = true;
-            embot::os::theTimerManager &tm = embot::os::theTimerManager::getInstance();
-            if(true == tm.started())
-            {
-                tm.onexpiry(*otm->owner);
-            }
-            else
-            {
-                otm->owner->execute();
-            }
-            if(otm->tconfig.mode == Timer::Mode::someshots)
-            {
-                otm->count ++;
-                if(otm->count >= otm->maxshots)
-                {
-                    otm->onemoretime = true;
-                    otm->stop();
-                }
-            }            
-        }          
-
-
-        bool stop()
-        {
-            if(Timer::Status::counting == getstatus())
-            {                                
-                // stop the rtos timer. operation is null safe.
-                embot::os::rtos::timer_stop(rtostimer);
-            }
-          
-            if(false == onemoretime)
-            {
-                reset(Timer::Status::idle, false);   
-                canexecuteaction = false;   
-            }
-            
-            return true;            
-        }
-        
-    }; 
-        
-    
-}}} // namespace embot { namespace os {
-
      
 struct embot::os::Timer::Impl
-{          
-    embot::os::timertools::TMR *tmr;
+{ 
+    const char *name {Timer::noname};
+    Timer *owner {nullptr};
+    embot::os::rtos::timer_t *rtostimer {nullptr};
+    Timer::Config tconfig {};         
+    Timer::Status sta {Timer::Status::idle};             
+    size_t maxshots {0};
+    size_t count {0};        
+    bool canexecuteaction {false}; 
+    bool butitisthelastexecution {false};  
     
-    Impl(Timer *own) 
+    
+    Impl(Timer *own)   
     {
-        tmr = new embot::os::timertools::TMR(own);
+        owner = own;
+        reset(Timer::Status::idle, true);
+        rtostimer = embot::os::rtos::timer_new();
     }
-    ~Impl()
+    
+    ~Impl()   
     {
-        delete tmr;
+        stop();
+        // do reverse deallocation and cleaning
+        embot::os::rtos::timer_delete(rtostimer);
+        rtostimer = nullptr;
+        reset(Timer::Status::idle, true);              
+        canexecuteaction = false;  
+        owner = nullptr;            
     }
+    
+    void reset(Timer::Status st, bool alsoconfig)
+    {
+        sta = st;
+        count = 0;
+        maxshots = 0;
+        canexecuteaction = false;
+        butitisthelastexecution = false;
+        if(alsoconfig)
+        {
+            tconfig.clear();
+            tconfig.onexpiry.clear();
+        }
+    }
+    
+    Timer::Status status() const
+    {
+        return sta;
+    }
+
+    bool load(const Timer::Config &config)
+    {            
+        // config must be valid 
+        if(false == config.isvalid())
+        {
+            return false;
+        }
+        
+        // make sure the timer is stopped
+        stop();
+        
+        // copy the config
+        tconfig = config;
+                                                
+        return true;
+    }  
+            
+    bool start(const Timer::Config &config, bool forcerestart)
+    {            
+        // config must be valid 
+        if(false == config.isvalid())
+        {
+            return false;
+        }
+                                                
+        bool ret = false;
+                    
+        // start it only if it is not counting. if we have forcerestart we re-start it anyway
+        // both osal and cmsisos2 allow to restart a running timer
+        if((true == forcerestart) || (Timer::Status::counting != status()))
+        {
+            tconfig = config;
+            count = 0;             
+            canexecuteaction = false; 
+            butitisthelastexecution = false;  
+            sta = Timer::Status::idle;
+            maxshots = 0;                
+                            
+            embot::os::rtos::timerMode mode = (Timer::Mode::oneshot == tconfig.mode) ? (embot::os::rtos::timerMode::oneshot) : (embot::os::rtos::timerMode::forever);
+             
+            if(true == embot::os::rtos::timer_start(rtostimer, mode, tconfig.countdown, OnRTOStimerExpiry, this))               
+            {
+                sta = Timer::Status::counting;
+                maxshots = (Timer::Mode::someshots == tconfig.mode) ? tconfig.numofshots : 0;                  
+                ret = true;
+            }
+        }
+                
+        return ret;
+    }  
+    
+    bool start()
+    {
+        constexpr bool forcerestart = true;
+        return start(tconfig, forcerestart);
+    }
+
+    // keep it simple. it is executed by the internals of the RTOS: inside SysTick_Handler() for osal or inside small thread for cmsisos2
+#if defined(EMBOT_USE_rtos_cmsisos2)        
+    static void OnRTOStimerExpiry(void *par) 
+#else
+    static void OnRTOStimerExpiry(embot::os::rtos::timer_t *rtostmr, void *par)
+#endif        
+    {
+        // this funtion is called at the expiry of the rtos timer.
+        // if we use osal, it is called inside the systick handler. if we use cmsisos2 it is called inside its timer thread.
+        // so, .. keep it as lean as possible
+        
+        // note: in here we just prepare whatever we need so that theTimerManager can correctly call Timer::execute()
+        //       we executed directly only if the theTimerManager is not started. for instance because we dont want to use it.            
+        
+        static embot::os::theTimerManager &tm = embot::os::theTimerManager::getInstance();
+        
+        Impl *impl = reinterpret_cast<Impl*>(par);
+        Timer *tmr = impl->owner;
+        
+        // preparation of basic data.   
+        // we just: tell the future call of Timer::execute() that it can execute the callback, and increment the count  
+        // for Mode::forever that is all it is required             
+        impl->canexecuteaction = true;
+        impl->count ++;  
+        impl->butitisthelastexecution = false;
+        
+        // for Mode::oneshot / Mode::someshots we need to do something else
+        // such as: tell Timer::execute() that it must stop the Timer after the execution of the callback
+        
+        if(impl->tconfig.mode == Timer::Mode::oneshot)
+        {
+            impl->butitisthelastexecution = true;
+            // no need to stop the rtos timer in one shot mode. it is already stopped.   
+            // we shall however call Timer::stop() only inside Timer::execute()                 
+        }
+        else if(impl->tconfig.mode == Timer::Mode::someshots)
+        {
+            if(impl->count >= impl->maxshots)
+            {
+                impl->butitisthelastexecution = true;
+                // we need to stop the rtos timer because it was started w/ embot::os::rtos::timerMode::forever
+                embot::os::rtos::timer_stop(impl->rtostimer);
+                // we shall however call Timer::stop() only inside Timer::execute() 
+            }
+        }  
+        
+        // and now ask theTimerManager to get possession of the timer so that it can call its Timer::execute()
+        // if theTimerManager is started it will be its thread to execute the callback, else the callback will be executed just now
+        tm.execute(*tmr);        
+    }          
+
+
+    bool stop()
+    {
+        if(Timer::Status::counting == status())
+        {                                
+            // stop the rtos timer. operation is null safe. also, it can stopped twice safely
+            embot::os::rtos::timer_stop(rtostimer);
+            // reset the internal data structure
+            reset(Timer::Status::idle, false);   
+        }           
+        return true;   
+    }    
+    
 };
 
 
@@ -237,65 +231,70 @@ embot::os::Timer::~Timer()
     delete pImpl;
 }
 
+bool embot::os::Timer::name(const char *na)
+{
+    if(nullptr != na)
+    {
+        pImpl->name = na;
+    }
+    
+    return true;
+}
+
+const char * embot::os::Timer::name() const
+{
+    return pImpl->name;
+}
+
+size_t embot::os::Timer::shots() const
+{
+    return pImpl->count;
+}
+
 bool embot::os::Timer::start(const Config &config, bool forcerestart)
 {
-    return pImpl->tmr->start(config, forcerestart);
+    return pImpl->start(config, forcerestart);
 }
 
 bool embot::os::Timer::load(const Config &config)
 {
-    return pImpl->tmr->load(config);
+    return pImpl->load(config);
 }
 
 bool embot::os::Timer::start()
 {
-    return pImpl->tmr->start();
+    return pImpl->start();
 }
 
 bool embot::os::Timer::stop()
 {
-    return pImpl->tmr->stop();
+    return pImpl->stop();
 }
 
-embot::os::Timer::Status embot::os::Timer::getStatus() const
+embot::os::Timer::Status embot::os::Timer::status() const
 {
-    return pImpl->tmr->getstatus();   
+    return pImpl->status();   
 }
 
-//embot::os::Timer::Mode embot::os::Timer::getMode() const
-//{
-//    return pImpl->tmr->getmode();  
-//}
-
-//embot::core::relTime embot::os::Timer::getCountdown() const
-//{
-//    return pImpl->tmr->period;
-//}
-
-//const embot::os::Action& embot::os::Timer::getAction() const
-//{
-//    return pImpl->tmr->tconfig.onexpiry;
-//}
-
-const embot::os::Timer::Config& embot::os::Timer::getConfig() const
+const embot::os::Timer::Config& embot::os::Timer::config() const
 {
-    return pImpl->tmr->tconfig;
+    return pImpl->tconfig;
 }
 
 bool embot::os::Timer::execute()
 {
-    bool canexecute = pImpl->tmr->canexecuteaction;
-    if(true == canexecute)
+    bool executed = false;
+    if(true == pImpl->canexecuteaction)
     {
-        pImpl->tmr->tconfig.onexpiry.execute();  
-        pImpl->tmr->canexecuteaction = false;   
-        if(true == pImpl->tmr->onemoretime)
-        {
-            pImpl->tmr->onemoretime = false;
-            pImpl->tmr->reset(Timer::Status::idle, false);   
+        executed = true;
+        pImpl->tconfig.onexpiry.execute();  
+        pImpl->canexecuteaction = false;   
+        if(true == pImpl->butitisthelastexecution)
+        {   // if in here, we have already managed the rtos timer inside OnRTOStimerExpiry() so, it is enough to use reset() 
+            pImpl->reset(Timer::Status::idle, false);   
         }
     }
-    return canexecute;
+    return executed;
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_Timer.h
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_Timer.h
@@ -18,8 +18,8 @@
 
 // - include guard ----------------------------------------------------------------------------------------------------
 
-#ifndef _EMBOT_OS_TIMER_H_
-#define _EMBOT_OS_TIMER_H_
+#ifndef __EMBOT_OS_TIMER_H_
+#define __EMBOT_OS_TIMER_H_
 
 #include "embot_core.h"
 
@@ -29,6 +29,8 @@
 
 namespace embot { namespace os {
     
+    class theTimerManager;
+    
     class Timer
     {
     public:
@@ -37,46 +39,57 @@ namespace embot { namespace os {
         
         enum class Mode { oneshot = 0, someshots = 1, forever = 2 }; 
         
+        static constexpr char noname[] {"os::Timer::JohnDoe"};
+        
         struct Config
         {
             core::relTime   countdown {0};          // time to count before execute the action
             os::Action      onexpiry {};            // the action executed at expiry of the countdown
-            Mode            mode {Mode::oneshot};   // the mode. we allow one shot, infinite shots or a limited number
-            std::uint32_t   numofshots {0};         // in case of limited number this number tells how many. not zero....
-
-            Config() = default;
-            Config(core::relTime c, const os::Action &a, Mode m = Mode::oneshot, std::uint32_t n = 0) : countdown(c), onexpiry(a), mode(m), numofshots(n) {} 
-            void clear() { countdown = 0;  onexpiry.clear(); mode = Mode::oneshot; numofshots = 0;}
-            bool isvalid() const 
+            Mode            mode {Mode::oneshot};   // we allow one shot, infinite shots or a limited number
+            size_t          numofshots {0};         // in case of limited number this number tells how many. not zero ....
+            
+            constexpr Config() = default;
+            constexpr Config(core::relTime c, const os::Action &a, Mode m = Mode::oneshot, size_t n = 0) 
+                : countdown(c), onexpiry(a), mode(m), numofshots(n) {} 
+            void clear() { countdown = 0;  onexpiry.clear(); mode = Mode::oneshot; numofshots = 0; }
+            constexpr bool isvalid() const 
             { 
-                if((0 == countdown) || (false == onexpiry.isvalid()) || ((Mode::someshots == mode) && (0 == numofshots))) 
-                { 
-                    return false; 
-                }
-                else 
-                { 
-                    return true; 
-                }  
+                bool notvalid {(0 == countdown) || (false == onexpiry.isvalid()) || ((Mode::someshots == mode) && (0 == numofshots))};
+                return !notvalid;
             }
         };
       
         Timer();
         ~Timer();
         
-    
-        bool start(const Config &config, bool forcerestart = false); // standard mode: it loads a config and starts the timer      
+        // it sets a name. if the name is not set, name() will return Timer::noname
+        bool name(const char *na);
         
-        bool load(const Config &config); // it just loads a config w/out starting anything. if Status::counting it stops the timer before loading config 
-        bool start(); // it start/restart the loaded config 
+        // it loads a config and starts the timer
+        bool start(const Config &config, bool forcerestart = false);      
+        
+        // it loads a config w/out starting. if Status::counting == status(), it calls stop() before loading config
+        bool load(const Config &config);  
+        
+        // it starts using the loaded config. if Status::counting == status() it calls stop() before starting
+        bool start();   
+        
+        // it stops the timer. it does not unload the config 
+        bool stop();        
 
-        bool stop(); // it stops the timer. it does not unload the config 
-                          
-        Status getStatus() const;              
-        const Config& getConfig() const;
+        // it gets the name
+        const char * name() const;
+        // it gets the loaded config         
+        const Config& config() const;
+        // it gets status
+        Status status() const;          
+        // it gets the number of executed shots. the number is nonzero only if Status::counting == status()
+        size_t shots() const;
         
-    public: 
-        bool execute(); // to be called by the TimerManager only. if a brave user calls it ... it does nothing because ... black magic woman   
-                
+    private:         
+        // it must be called only by the os::theTimerManager so that it can execute the timer
+        bool execute();       
+        friend class theTimerManager;                
 
     private:        
         struct Impl;

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_theTimerManager.cpp
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_theTimerManager.cpp
@@ -41,7 +41,7 @@ struct embot::os::theTimerManager::Impl
     
     Impl() 
     {              
-    }
+    }    
     
     static void processtimer(Thread *t, os::Message m, void *o)
     {
@@ -49,9 +49,9 @@ struct embot::os::theTimerManager::Impl
         {
             embot::os::Timer *tmr = reinterpret_cast<embot::os::Timer*>(m);
             tmr->execute();            
-        }
-            
+        }            
     }
+
 };
 
 
@@ -107,11 +107,11 @@ bool embot::os::theTimerManager::started() const
     return (nullptr == pImpl->thread) ? false : true;
 }
 
-bool embot::os::theTimerManager::onexpiry(const Timer &timer)
+bool embot::os::theTimerManager::execute(Timer &timer) const
 {
     if(nullptr == pImpl->thread)
     {
-        return false;
+        return timer.execute();
     }
     
     pImpl->thread->setMessage(reinterpret_cast<embot::os::Message>(const_cast<Timer*>(&timer)), embot::core::reltimeWaitNone);

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_theTimerManager.h
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_theTimerManager.h
@@ -18,8 +18,8 @@
 
 // - include guard ----------------------------------------------------------------------------------------------------
 
-#ifndef _EMBOT_OS_THETIMERMANAGER_H_
-#define _EMBOT_OS_THETIMERMANAGER_H_
+#ifndef __EMBOT_OS_THETIMERMANAGER_H_
+#define __EMBOT_OS_THETIMERMANAGER_H_
 
 #include "embot_core.h"
 #include "embot_os_common.h"
@@ -51,16 +51,16 @@ namespace embot { namespace os {
         
         bool start(const Config &config);   
 
-        // this funtion is called by the timer. if false the expiration of the timer is processed internally and not w/ onexpiry()
         bool started() const;        
-        
-        // this funtion is called only by the timer. if called by someone else it returns false
-        // because the action of the timer is enabled only by internals of the timer itself.
-        bool onexpiry(const Timer &timer);
+ 
+    private:        
+        // this funtion must be called only by the os::Timer on its expiry
+        bool execute(Timer &timer) const;
+        friend class Timer;
 
     private:
         theTimerManager();  
-        ~theTimerManager(); // i dont want a fool can delete it
+        ~theTimerManager(); 
 
     private:    
         struct Impl;


### PR DESCRIPTION
This PR fixes a the discovery of CAN boards below the `amc` board. 

The strange behavior which is fixed is the following.
The `FirmwareUpdater` the first time it calls a CAN discovery cannot not see any board, the second time it sees the boards twice and from the third time it can see everything normal.

From extensive tests and comparison vs the `ems` board I found out that the adaptation of the `EOtimer` to use `embot::os` objects is wrong for the case of single shot. It happens that an expired `EOtimer` cannot be rearmed. 
In the `eUpdater` the same `EOtimer` is used twice in a raw in one shot mode to enter in delayed time two states of the state machine of the maintenance mod. The failure of the action of the second timer causes the wrong CAN discovery.  

A fix in `embot::os::EOM` can now solve the problem.

I have also added some more feature to `embot::os::Timer` for the sake of debugging and I have also cleaned up a bit.

I have tested the changes on an `amc` and they work fine.
