### PR TITLE
AMC–BLDC: Add the copier for codegen

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/utils/copier/README.md
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/utils/copier/README.md
@@ -1,0 +1,77 @@
+## How to use the copy script
+
+To use the copy script, run `python copier.py`. The program expects a file called `directories.json` to be in the same directory.
+
+## `directories.json`
+
+The json file is verified before running the script. If something is wrong, you will most likely get an error showing the problem. 
+
+The structure of the json goes as follows:
+
+#### Source 
+
+```json
+"source_directory": [
+    "...",
+]
+```
+
+It's the directory where the generated code resides. This should point to the `codegen` directory of the Model repository.
+
+You can input the location by pieces in an array. The code will join the strings together.
+
+#### Target
+
+```json
+"target_directory": [
+    "...",
+]
+```
+
+It's the directory where to paste the code. This should point to the `src/model-based-design` directory of the respective `icub-firmware` repo.
+
+You can input the location by pieces in an array. The code will join the strings together.
+
+#### Subdirectories
+
+```json
+"subdirectories_to_copy": [
+    {"..."},
+]
+```
+
+This holds the information of the subdirectories that will be copied from source to target. 
+
+Each entry in the `subdirectories_to_copy` should be another dictionary following this structure:
+
+```json
+{
+    "source_directory": "...",
+    "source_directory_parent": "...",
+    "target_directory": "...",            
+    "files": [
+        "...",
+    ]
+}
+```
+
+`source_directory`: name of the subdirectory in the source. This subdirectory can be anywhere in the file structure of the source. The copier will search for it through the entire file hierarchy.
+
+`source_directory_parent` [optional]: if there are several subdirectories with the same name, you can specify the parent to select which one to choose.
+
+For example, if inside the source there is a directory called `src/files` and `lib/files`, using `files` as source and `src` in the parent field will select the former of the two.
+
+`target_directory`: name of the directory in which to paste the files. This directory must exist already in the target. If you are copying into a new directory first create the empty target and then run the script.
+
+`files`: selectors for the files. The script will only copy files whose names match the given selectors. 
+
+For example, if you only want `.cpp` and `.h` files that begin with `helloworld` you could do the following:
+
+```json
+"files": [
+    "helloworld*.cpp",
+    "helloworld*.h"
+]
+```
+
+Any file that doesn't follow this naming will be excluded from being copied.

--- a/emBODY/eBcode/arch-arm/board/amcbldc/utils/copier/copier.py
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/utils/copier/copier.py
@@ -1,0 +1,104 @@
+"""
+ Copyright (C) 2022 iCub Tech - Istituto Italiano di Tecnologia
+ Author:  Simone Girardi
+ email:   simone.girardi@iit.it
+"""
+
+import os.path
+import os
+import glob
+import shutil
+import json
+
+SECTION="-------------------"
+BIG_SECTION="*******************"
+
+# Checking if the directory is empty or not
+def is_empty(dir):
+    try:
+        if not os.listdir(dir):
+            print(dir + " is an empty directory.")
+            print("Aborting...")
+            return True
+        else:
+            return False
+    except FileNotFoundError:
+        print(dir + " directory does not exist.")
+        print("Aborting...")
+        return True
+
+def find_subdirectory(main_directory, subdirectory, parent = None):
+    for root, dirs, files in os.walk(main_directory):
+        for dir in dirs:
+            if dir == subdirectory:
+                dir_parent = root.split('\\')[-1]
+                if parent is None or dir_parent == parent:
+                    return os.path.join(root, subdirectory)
+    return ""
+
+def check_dictionary_type(dictionary, key, type):
+    if not key in dictionary:
+        raise Exception(f"No {key} found")
+    if not isinstance(dictionary[key], type):
+        raise Exception(f"Invalid {key}")
+
+def parse_instructions(dictionary):
+    check_dictionary_type(dictionary, "source_directory", list)
+    check_dictionary_type(dictionary, "target_directory", list)
+    check_dictionary_type(dictionary, "subdirectories_to_copy", list)
+
+    # check if placeholders have been replace in json
+    if dictionary["source_directory"][1].startswith("<") or dictionary["target_directory"][1].startswith("<"):
+        print("The file dictionaries.json contains placeholders surrounded with \"<...>\". Replace them before continue.")
+        print("Aborting...")
+        return -1
+
+    source_directory = os.path.join(*dictionary["source_directory"])
+    target_directory = os.path.join(*dictionary["target_directory"])
+    subdirectories_to_copy = dictionary["subdirectories_to_copy"]
+
+    if is_empty(source_directory):
+        return -1
+
+    if is_empty(target_directory):
+        return -1
+
+    for subdirectory in subdirectories_to_copy:
+        parent = subdirectory["source_directory_parent"] if "source_directory_parent" in subdirectory else None
+        source_subdir = find_subdirectory(source_directory, subdirectory["source_directory"], parent)
+        target_subdir = find_subdirectory(target_directory, subdirectory["target_directory"])
+
+        copy_files(source_subdir, target_subdir, subdirectory["files"], True)
+    print(BIG_SECTION)
+
+def copy_files(source_dir, target_dir, file_selectors, overwrite):
+    if not (os.path.isdir(source_dir) and os.path.isdir(target_dir)):
+        raise Exception(f"""Invalid path given (Source: {source_dir}, Target: {target_dir}).
+        If target is empty, consider creating the empty directory in the desired destination before running the copier.""")
+    print(BIG_SECTION)
+    print(f"Copying files from {source_dir} to {target_dir}")
+    print(SECTION)
+    files_to_copy = []
+    for file_selector in file_selectors:
+        selected_files = glob.glob(os.path.join(source_dir, file_selector))
+        print(f"Selector {file_selector} matched with the following files: {selected_files}")
+        files_to_copy = files_to_copy + selected_files
+    files_to_copy = set(files_to_copy)
+    print(SECTION)
+    for source_file in files_to_copy:
+        file_basename = os.path.basename(source_file)
+        target_file = os.path.join(target_dir, file_basename)
+        if overwrite or (not os.path.exists(target_file)):
+            shutil.copy(source_file, target_file)
+            print(f"Copying  {file_basename} from {source_dir} to {target_dir}")
+        else:
+            print(f"Skipping {file_basename} from {source_dir} since overwriting is not allowed")
+        print("\n")
+
+def main():
+    with open("directories.json") as file:
+        json_instructions = json.load(file)
+    parse_instructions(json_instructions)
+    
+if __name__ == "__main__":
+    main()

--- a/emBODY/eBcode/arch-arm/board/amcbldc/utils/copier/directories.json
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/utils/copier/directories.json
@@ -1,0 +1,105 @@
+{
+    "source_directory": [
+        "C:",
+        "<\\path-to-icub-firmware-models-parent-folder>",
+        "icub-firmware-models\\boards\\amcbldc",
+        "codegen"
+    ],
+    "target_directory": [
+        "C:",
+        "<\\path-to-icub-firmware-parent-folder>",
+        "icub-firmware\\emBODY\\eBcode\\arch-arm\\board\\amcbldc\\application\\src",
+        "model-based-design"
+    ],
+    "subdirectories_to_copy": [
+        {
+            "source_directory": "_sharedutils",
+            "source_directory_parent": "ert",
+            "target_directory": "sharedutils",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "AMC_BLDC_ert_rtw",
+            "target_directory": "amc-bldc",            
+            "files": [
+                "AMC*.cpp",
+                "AMC*.h"
+            ]
+        },
+        {
+            "source_directory": "can_decoder",
+            "source_directory_parent": "ert",
+            "target_directory": "can-decoder",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "can_encoder",
+            "source_directory_parent": "ert",
+            "target_directory": "can-encoder",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "control_foc",
+            "source_directory_parent": "ert",
+            "target_directory": "control-foc",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "control_outer",
+            "source_directory_parent": "ert",
+            "target_directory": "control-outer",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "estimation_velocity",
+            "source_directory_parent": "ert",
+            "target_directory": "estimator",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "filter_current",
+            "source_directory_parent": "ert",
+            "target_directory": "filter-current",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "SupervisorFSM_RX",
+            "source_directory_parent": "ert",
+            "target_directory": "supervisor-rx",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        },
+        {
+            "source_directory": "SupervisorFSM_TX",
+            "source_directory_parent": "ert",
+            "target_directory": "supervisor-tx",            
+            "files": [
+                "*.cpp",
+                "*.h"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
What's new

- Add the copier within the `icub-firmware\emBODY\eBcode\arch-arm\board\amcbldc\utils` folder
- The copier now does more checks in order to avoid mistakes when copying the generated code from `icub-firmware-models`
- The dictionaries.json file contains 2 templated strings that any user has to replace with the path to the parent folder of the repositories (`icub-firmware-models` and `icub-firmware`)

**Note**
- The proposal is that each board that may be affected by the generated code from Simulink should contain a copy of this copier with the dictionaries.json file properly updated.

cc @pattacini 