### PR TITLE
AMCBLDC: Fix computation of angle when using quadrature encoder

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/motorhal/encoder.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/motorhal/encoder.c
@@ -200,7 +200,9 @@ uint32_t encoderGetCounter(void)
     return (uint32_t)__HAL_TIM_GET_COUNTER(&htim2);
 }
 
-
+/*******************************************************************************************************************//**
+ * @brief   Reset encoder value
+ */
 void encoderReset()
 {
     __HAL_TIM_SET_COUNTER(&htim2, 0);
@@ -213,6 +215,7 @@ void encoderReset()
  */
 uint16_t encoderGetElectricalAngle(void)
 {
+    
     if (MainConf.encoder.resolution == 0)
     {
         return encoderForcedValue;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/motorhal/pwm.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/motorhal/pwm.c
@@ -120,17 +120,22 @@ extern void set_ADC_callback(pwm_ADC_callback_t *cbk)
 
 #if defined(USE_STM32HAL) && defined(__cplusplus)
 
+constexpr int16_t numHallSectors = 6;
+constexpr float_t iCubDeg = 65536.0; // Range of angular values that can be represented with the encoder
+constexpr float_t Deg2iCub = iCubDeg / 360.0;
+constexpr int16_t hallAngleStep = 60.0 * Deg2iCub; // 60 degrees scaled by the range of possible values
+constexpr int16_t minHallAngleDelta = 30.0 * Deg2iCub; // 30 degrees scaled by the range of possible values
 
 constexpr uint16_t hallAngleTable[] =
 {
     /* ABC  (°)  */
     /* LLL ERROR */ 0,
-    /* LLH  240  */ static_cast<uint16_t>(240.0 * 65536.0 / 360.0), /* 43690 */
-    /* LHL  120  */ static_cast<uint16_t>(120.0 * 65536.0 / 360.0), /* 21845 */
-    /* LHH  180  */ static_cast<uint16_t>(180.0 * 65536.0 / 360.0), /* 32768 */
-    /* HLL    0  */ static_cast<uint16_t>(  0.0 * 65536.0 / 360.0), /*     0 */
-    /* HLH  300  */ static_cast<uint16_t>(300.0 * 65536.0 / 360.0), /* 54613 */
-    /* HHL   60  */ static_cast<uint16_t>( 60.0 * 65536.0 / 360.0), /* 10922 */
+    /* LLH  240  */ static_cast<uint16_t>(240.0 * Deg2iCub), /* 43690 */
+    /* LHL  120  */ static_cast<uint16_t>(120.0 * Deg2iCub), /* 21845 */
+    /* LHH  180  */ static_cast<uint16_t>(180.0 * Deg2iCub), /* 32768 */
+    /* HLL    0  */ static_cast<uint16_t>(  0.0 * Deg2iCub), /*     0 */
+    /* HLH  300  */ static_cast<uint16_t>(300.0 * Deg2iCub), /* 54613 */
+    /* HHL   60  */ static_cast<uint16_t>( 60.0 * Deg2iCub), /* 10922 */
     /* HHH ERROR */ static_cast<uint16_t>(0)
 };
 
@@ -222,9 +227,8 @@ static uint8_t updateHallStatus(void)
     hallStatus = DECODE_HALLSTATUS;
     uint16_t angle = MainConf.pwm.hall_offset + hallAngleTable[hallStatus];
     
-    //int16_t sector = (MainConf.pwm.sector_offset + hallSectorTable[hallStatus]) % 6;
-    // Check which sector [0 ... 5] (30 + angle) / 60 
-    int16_t sector = ((5461 + angle) / 10922) % 6;
+    // Check which sector between [0 ... 5] the rotor is in
+    int16_t sector = ((minHallAngleDelta + angle) / hallAngleStep) % numHallSectors;
     static int16_t sector_old = sector;
     
     hallAngle = angle;
@@ -243,20 +247,23 @@ static uint8_t updateHallStatus(void)
         }
         else
         {
-            
-            bool forward = ((sector-sector_old+6)%6)==1;
+            // Check if the motor is rotating forward (counterclockwise)
+            bool forward = ((sector-sector_old+numHallSectors)%numHallSectors)==1;
         
             if (forward) // forward
             {
                 ++hallCounter;
-                angle -= 5461; // -30 deg
+                angle -= minHallAngleDelta; // -30 deg
             }
             else
             {
                 --hallCounter;
-                angle += 5461; // +30 deg
+                angle += minHallAngleDelta; // +30 deg
             }
-  
+             /*
+            0) Use the Hall sensors to rotate until the wrap-around border is reached,
+             then reset the encoder value
+            */
             if (calibration_step == 0)
             {
                 encoderForce(angle);
@@ -267,38 +274,49 @@ static uint8_t updateHallStatus(void)
                     calibration_step = 1;
                 }
             }
+            /*
+            1) Use the hall sensors to rotate. While rotating, store the encoder angle 
+            every time a sector border is crossed. When all 6 borders are crossed,
+            compute the offset to apply to the encoder by least squares fitting. After
+            the offset is applied set encoderCalibrated to true
+            */
             else if (calibration_step == 1)
             {
                 encoderForce(angle);
             
                 // use the current sector if forward rotation or previous if reverse
-                uint8_t s = forward ? sector : (sector+1)%6;
+                uint8_t sector_index = forward ? sector : (sector+1)%numHallSectors;
             
                 // keep track of the encoder value between sectors
-                border[s] = encoderGetUncalibrated();
+                border[sector_index] = encoderGetUncalibrated();
 
                 // found the s-th border, put a 1 in the mask
-                border_flag |= 1<<s;
-            
-                // After finding all borders compute offset through minimization of MSE
+                border_flag |= 1 << sector_index;
+                
+                // If all sectors are found apply least squares fitting by computing average of
+                // difference between measured values on borders and expected hall angle
                 if (border_flag == 63) // 111111
                 {
                     calibration_step = 2;
                 
-                    int32_t offset = int16_t(MainConf.pwm.hall_offset-5461-border[0]);
-                    offset += int16_t(MainConf.pwm.hall_offset-5461+10923 -border[1]);
-                    offset += int16_t(MainConf.pwm.hall_offset-5461+21845 -border[2]);
-                    offset += int16_t(MainConf.pwm.hall_offset-5461+32768 -border[3]);
-                    offset += int16_t(MainConf.pwm.hall_offset-5461+43691 -border[4]);
-                    offset += int16_t(MainConf.pwm.hall_offset-5461+54613 -border[5]);
+                    int32_t offset = int16_t(border[0] - MainConf.pwm.hall_offset + minHallAngleDelta);
+                    offset += int16_t(border[1] - MainConf.pwm.hall_offset + minHallAngleDelta - hallAngleStep);
+                    offset += int16_t(border[2] - MainConf.pwm.hall_offset + minHallAngleDelta - 2 * hallAngleStep);
+                    offset += int16_t(border[3] - MainConf.pwm.hall_offset + minHallAngleDelta - 3 * hallAngleStep);
+                    offset += int16_t(border[4] - MainConf.pwm.hall_offset + minHallAngleDelta - 4 * hallAngleStep);
+                    offset += int16_t(border[5] - MainConf.pwm.hall_offset + minHallAngleDelta - 5 * hallAngleStep);
                 
-                    offset /= 6;
+                    offset /= numHallSectors;
                      
                     embot::core::print("CALIBRATED\n");
                     
-                    encoderCalibrate(-int16_t(offset));
+                    encoderCalibrate(int16_t(offset));
                 }
             }
+            /*
+            2) Update the forced value even if it is not used when the encoder is calibrated.
+            Reset the encoder angle after a full rotation to avoid desynching
+            */
             else if (calibration_step == 2)
             {
                 encoderForce(angle);


### PR DESCRIPTION
This PR is aimed at the AMCBLDC Hal, to fix:
### Detection of the sector of the phases 
`line 231 in pwm.c`

In this line we compute the sector that the electric angle belongs to = [0, 1, ..., 5].
Casting to int16 would cause sector to have the values [-5 -3 -1 1 3 5], which would mess up the later computations

### Desynching between hall sensors angle and quadrature encoder angle
A reset function of the quadrature encoder angle is applied whenever a full rotation is done.
A full rotation is defined as the transition between sector 5 and sector 0.
This procedure is also used to during calibration step 0, to transition to step 1:
- Step 0:  Rotate using the Hall sensors until there's the switch between sector 5 and 0, reset the encoder, and go to step 1
- Step 1: Rotate using the Hall sensors until we read the uncalibrated encoder value for each of the 6 sectors (or borders);
Then, we compute the offset by taking the average of the 6 values, and apply it.
- Step 2: Store the electric angle evaluated by the hall sensors as always, and reset the encoder if a full rotation is done


cc @sgiraz @pattacini @valegagge 