### PR TITLE
The driver `embot::hw::tlv493d` works on the mtb4fap board using the GPIO-emulated I2C driver

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4fap/bsp/embot_hw_bsp_mtb4fap.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4fap/bsp/embot_hw_bsp_mtb4fap.cpp
@@ -749,7 +749,7 @@ namespace embot { namespace hw { namespace tlv493d {
 // - support map: end of embot::hw::tlv493d
 
 
-// - support map: begin of embot::hw::spi
+// - support map: begin of embot::hw::i2ce
 
 #include "embot_hw_i2ce.h"
 #include "embot_hw_i2ce_bsp.h"
@@ -892,9 +892,9 @@ extern "C"
     // TODO: add in here any irq handler we may beed
 }
 
-#endif // spi
+#endif // i2ce
 
-// - support map: end of embot::hw::spi
+// - support map: end of embot::hw::i2ce
 
 
 

--- a/emBODY/eBcode/arch-arm/board/mtb4fap/examples/embot-os/proj/mtb4fap-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mtb4fap/examples/embot-os/proj/mtb4fap-embot-os.uvoptx
@@ -157,9 +157,9 @@
         <Bp>
           <Number>0</Number>
           <Type>0</Type>
-          <LineNumber>231</LineNumber>
+          <LineNumber>476</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134232650</Address>
+          <Address>134232430</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
@@ -168,156 +168,29 @@
           <BreakIfRCount>1</BreakIfRCount>
           <Filename>..\src\testHW.cpp</Filename>
           <ExecCommand></ExecCommand>
-          <Expression>\\test\../src/testHW.cpp\231</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>206</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134232148</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\test\../src/testHW.cpp\206</Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>193</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134231986</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\test\../src/testHW.cpp\193</Expression>
-        </Bp>
-        <Bp>
-          <Number>3</Number>
-          <Type>0</Type>
-          <LineNumber>238</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134232758</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\test\../src/testHW.cpp\238</Expression>
-        </Bp>
-        <Bp>
-          <Number>4</Number>
-          <Type>0</Type>
-          <LineNumber>201</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>5</Number>
-          <Type>0</Type>
-          <LineNumber>214</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>6</Number>
-          <Type>0</Type>
-          <LineNumber>239</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>7</Number>
-          <Type>0</Type>
-          <LineNumber>246</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\src\testHW.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
+          <Expression>\\test\../src/testHW.cpp\476</Expression>
         </Bp>
       </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>duration,0x0A</ItemText>
+          <ItemText>position,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>found1</ItemText>
+          <ItemText>acquisitiontime,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>2</count>
           <WinNumber>1</WinNumber>
-          <ItemText>found2</ItemText>
+          <ItemText>angle</ItemText>
         </Ww>
         <Ww>
           <count>3</count>
           <WinNumber>1</WinNumber>
-          <ItemText>data2read</ItemText>
-        </Ww>
-        <Ww>
-          <count>4</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>data2write</ItemText>
-        </Ww>
-        <Ww>
-          <count>5</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>adrs</ItemText>
-        </Ww>
-        <Ww>
-          <count>6</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>a</ItemText>
+          <ItemText>res</ItemText>
         </Ww>
       </WatchWindow1>
       <Tracepoint>
@@ -343,7 +216,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
+        <aSer4>1</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>

--- a/emBODY/eBcode/arch-arm/board/mtb4fap/examples/embot-os/proj/mtb4fap-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mtb4fap/examples/embot-os/proj/mtb4fap-embot-os.uvprojx
@@ -10,7 +10,7 @@
       <TargetName>mtb4fap</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -314,7 +314,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -393,57 +393,6 @@
               <FileName>testHW.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\testHW.cpp</FilePath>
-              <FileOption>
-                <CommonProperty>
-                  <UseCPPCompiler>2</UseCPPCompiler>
-                  <RVCTCodeConst>0</RVCTCodeConst>
-                  <RVCTZI>0</RVCTZI>
-                  <RVCTOtherData>0</RVCTOtherData>
-                  <ModuleSelection>0</ModuleSelection>
-                  <IncludeInBuild>2</IncludeInBuild>
-                  <AlwaysBuild>2</AlwaysBuild>
-                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
-                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
-                  <PublicsOnly>2</PublicsOnly>
-                  <StopOnExitCode>11</StopOnExitCode>
-                  <CustomArgument></CustomArgument>
-                  <IncludeLibraryModules></IncludeLibraryModules>
-                  <ComprImg>1</ComprImg>
-                </CommonProperty>
-                <FileArmAds>
-                  <Cads>
-                    <interw>2</interw>
-                    <Optim>1</Optim>
-                    <oTime>2</oTime>
-                    <SplitLS>2</SplitLS>
-                    <OneElfS>2</OneElfS>
-                    <Strict>2</Strict>
-                    <EnumInt>2</EnumInt>
-                    <PlainCh>2</PlainCh>
-                    <Ropi>2</Ropi>
-                    <Rwpi>2</Rwpi>
-                    <wLevel>0</wLevel>
-                    <uThumb>2</uThumb>
-                    <uSurpInc>2</uSurpInc>
-                    <uC99>2</uC99>
-                    <uGnu>2</uGnu>
-                    <useXO>2</useXO>
-                    <v6Lang>0</v6Lang>
-                    <v6LangP>0</v6LangP>
-                    <vShortEn>2</vShortEn>
-                    <vShortWch>2</vShortWch>
-                    <v6Lto>2</v6Lto>
-                    <v6WtE>2</v6WtE>
-                    <v6Rtti>2</v6Rtti>
-                    <VariousControls>
-                      <MiscControls></MiscControls>
-                      <Define></Define>
-                      <Undefine></Undefine>
-                      <IncludePath></IncludePath>
-                    </VariousControls>
-                  </Cads>
-                </FileArmAds>
-              </FileOption>
             </File>
           </Files>
         </Group>
@@ -685,57 +634,6 @@
               <FileName>embot_hw_i2ce.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_i2ce.cpp</FilePath>
-              <FileOption>
-                <CommonProperty>
-                  <UseCPPCompiler>2</UseCPPCompiler>
-                  <RVCTCodeConst>0</RVCTCodeConst>
-                  <RVCTZI>0</RVCTZI>
-                  <RVCTOtherData>0</RVCTOtherData>
-                  <ModuleSelection>0</ModuleSelection>
-                  <IncludeInBuild>2</IncludeInBuild>
-                  <AlwaysBuild>2</AlwaysBuild>
-                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
-                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
-                  <PublicsOnly>2</PublicsOnly>
-                  <StopOnExitCode>11</StopOnExitCode>
-                  <CustomArgument></CustomArgument>
-                  <IncludeLibraryModules></IncludeLibraryModules>
-                  <ComprImg>1</ComprImg>
-                </CommonProperty>
-                <FileArmAds>
-                  <Cads>
-                    <interw>2</interw>
-                    <Optim>1</Optim>
-                    <oTime>2</oTime>
-                    <SplitLS>2</SplitLS>
-                    <OneElfS>2</OneElfS>
-                    <Strict>2</Strict>
-                    <EnumInt>2</EnumInt>
-                    <PlainCh>2</PlainCh>
-                    <Ropi>2</Ropi>
-                    <Rwpi>2</Rwpi>
-                    <wLevel>0</wLevel>
-                    <uThumb>2</uThumb>
-                    <uSurpInc>2</uSurpInc>
-                    <uC99>2</uC99>
-                    <uGnu>2</uGnu>
-                    <useXO>2</useXO>
-                    <v6Lang>0</v6Lang>
-                    <v6LangP>0</v6LangP>
-                    <vShortEn>2</vShortEn>
-                    <vShortWch>2</vShortWch>
-                    <v6Lto>2</v6Lto>
-                    <v6WtE>2</v6WtE>
-                    <v6Rtti>2</v6Rtti>
-                    <VariousControls>
-                      <MiscControls></MiscControls>
-                      <Define></Define>
-                      <Undefine></Undefine>
-                      <IncludePath></IncludePath>
-                    </VariousControls>
-                  </Cads>
-                </FileArmAds>
-              </FileOption>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/stm32g4eval/bsp/embot_hw_bsp_stm32g4eval_config.h
+++ b/emBODY/eBcode/arch-arm/board/stm32g4eval/bsp/embot_hw_bsp_stm32g4eval_config.h
@@ -24,10 +24,12 @@
     #define EMBOT_ENABLE_hw_led
     //#define EMBOT_ENABLE_hw_button
     #define EMBOT_ENABLE_hw_can
-    #define EMBOT_ENABLE_hw_i2c
+//    #define EMBOT_ENABLE_hw_i2c
     #define EMBOT_ENABLE_hw_tlv493d
-    #define EMBOT_ENABLE_hw_tlv493d_emulatedMODE
+    #define EMBOT_ENABLE_hw_tlv493d_i2ceMODE
+//    #define EMBOT_ENABLE_hw_tlv493d_emulatedMODE
     #define EMBOT_ENABLE_hw_flash
+    #define EMBOT_ENABLE_hw_i2ce
         
 #else
     #error this is the bsp config of STM32HAL_BOARD_STM32G4EVAL ...

--- a/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/cfg/stm32hal.startup.stm32g4eval.s
+++ b/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/cfg/stm32hal.startup.stm32g4eval.s
@@ -44,7 +44,7 @@ __initial_sp
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size      EQU     0x8000
+Heap_Size      EQU     0x18000
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
 __heap_base

--- a/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/proj/stm32g4eval-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/proj/stm32g4eval-embot-os.uvoptx
@@ -423,7 +423,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ST-LINKIII-KEIL_SWO</Key>
-          <Name>-U004B003B3137510839383538 -O206 -SF10000 -C0 -A0 -I0 -HNlocalhost -HP7184 -P1 -N00("ARM CoreSight SW-DP (ARM Core") -D00(2BA01477) -L00(0) -TO131091 -TC170000000 -TT10000000 -TP21 -TDS800E -TDT0 -TDC1F -TIEFFFFFFFF -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512_Dual.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512_Dual.FLM)</Name>
+          <Name>-U003A00163038510234333935 -O206 -SF20000 -C0 -A0 -I0 -HNlocalhost -HP7184 -P1 -N00("ARM CoreSight SW-DP (ARM Core") -D00(2BA01477) -L00(0) -TO131091 -TC170000000 -TT10000000 -TP21 -TDS800E -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G4xx_512_Dual.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G4xx_512_Dual.FLM) -WA0 -WE0 -WVCE4 -WS2710 -WM0 -WP2</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -433,7 +433,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z19 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z13 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -455,34 +455,52 @@
         <Bp>
           <Number>0</Number>
           <Type>0</Type>
-          <LineNumber>136</LineNumber>
+          <LineNumber>1292</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
+          <Address>134248240</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>../src/main-embot-os.cpp</Filename>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>..\..\..\..\..\embot\hw\embot_hw_i2ce.cpp</Filename>
           <ExecCommand></ExecCommand>
-          <Expression></Expression>
+          <Expression>\\g4eval\../../../../../embot/hw/embot_hw_i2ce.cpp\1292</Expression>
         </Bp>
       </Breakpoint>
       <WatchWindow1>
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>vals,0x0A</ItemText>
+          <ItemText>s_privatedata</ItemText>
+        </Ww>
+        <Ww>
+          <count>1</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>data2read</ItemText>
+        </Ww>
+        <Ww>
+          <count>2</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>regmap</ItemText>
         </Ww>
       </WatchWindow1>
+      <MemoryWindow1>
+        <Mm>
+          <WinNumber>1</WinNumber>
+          <SubType>0</SubType>
+          <ItemText>regmap</ItemText>
+          <AccSizeX>0</AccSizeX>
+        </Mm>
+      </MemoryWindow1>
       <Tracepoint>
         <THDelay>0</THDelay>
       </Tracepoint>
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -499,7 +517,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
+        <aSer4>1</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -523,7 +541,7 @@
         <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
-        <DbgClock>10000000</DbgClock>
+        <DbgClock>20000000</DbgClock>
       </DebugDescription>
     </TargetOption>
   </Target>
@@ -582,7 +600,7 @@
 
   <Group>
     <GroupName>stm32hal-config</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -770,17 +788,29 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>5</GroupNumber>
+      <FileNumber>18</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_i2ce.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_i2ce.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
     <GroupName>embot-os</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>18</FileNumber>
+      <FileNumber>19</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -792,7 +822,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>19</FileNumber>
+      <FileNumber>20</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -804,7 +834,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>20</FileNumber>
+      <FileNumber>21</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -816,7 +846,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>21</FileNumber>
+      <FileNumber>22</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -828,7 +858,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>22</FileNumber>
+      <FileNumber>23</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -840,7 +870,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>23</FileNumber>
+      <FileNumber>24</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -852,7 +882,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>24</FileNumber>
+      <FileNumber>25</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -864,7 +894,7 @@
     </File>
     <File>
       <GroupNumber>6</GroupNumber>
-      <FileNumber>25</FileNumber>
+      <FileNumber>26</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -878,13 +908,13 @@
 
   <Group>
     <GroupName>osal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>27</FileNumber>
       <FileType>4</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -896,13 +926,25 @@
     </File>
     <File>
       <GroupNumber>7</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</PathWithFileName>
       <FilenameWithoutPath>eventviewer.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>7</GroupNumber>
+      <FileNumber>29</FileNumber>
+      <FileType>4</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</PathWithFileName>
+      <FilenameWithoutPath>osal.cm4.lib</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -916,7 +958,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -928,7 +970,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -940,7 +982,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -960,7 +1002,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/proj/stm32g4eval-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/proj/stm32g4eval-embot-os.uvprojx
@@ -546,6 +546,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_i2c.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_i2ce.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_i2ce.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -605,6 +610,11 @@
               <FileName>eventviewer.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
+            </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
             </File>
           </Files>
         </Group>
@@ -716,7 +726,7 @@
       <TargetName>stm32g4eval</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -1020,7 +1030,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -1297,11 +1307,118 @@
               <FileName>embot_hw_tlv493d.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_tlv493d.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_hw_i2c.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_i2c.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_i2ce.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_i2ce.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
           </Files>
         </Group>
@@ -1357,11 +1474,35 @@
               <FileName>osal.cm4.dbg.lib</FileName>
               <FileType>4</FileType>
               <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.dbg.lib</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds/>
+              </FileOption>
             </File>
             <File>
               <FileName>eventviewer.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\..\libs\midware\eventviewer\src\eventviewer.c</FilePath>
+            </File>
+            <File>
+              <FileName>osal.cm4.lib</FileName>
+              <FileType>4</FileType>
+              <FilePath>..\..\..\..\..\libs\highlevel\abslayer\osal\lib\osal.cm4.lib</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/src/main-embot-os.cpp
+++ b/emBODY/eBcode/arch-arm/board/stm32g4eval/examples/embot-os/src/main-embot-os.cpp
@@ -7,6 +7,10 @@
 
 #define TEST_EMBOT_OS_OSAL
 
+//#define TEST_EMBOT_HW_I2CE
+#define TEST_EMBOT_HW_TLV
+#undef TEST_EMBOT_HISTO
+
 #include "embot_core.h"
 #include "embot_core_binary.h"
 
@@ -25,7 +29,11 @@
 #include "embot_tools.h"
 #include "embot_app_scope.h"
 
-#define enableTRACE_all
+#if defined(TEST_EMBOT_HW_I2CE)
+#include "embot_hw_i2ce.h"
+#endif
+
+//#define enableTRACE_all
 
 constexpr embot::os::Event evtTick = embot::core::binary::mask::pos2mask<embot::os::Event>(0);
 constexpr embot::os::Event evtBTNreleased = embot::core::binary::mask::pos2mask<embot::os::Event>(1);
@@ -38,7 +46,9 @@ constexpr embot::hw::BTN buttonBLUE = embot::hw::BTN::one;
 //embot::tools::Histogram *histoFOCperiod {nullptr};
 //embot::tools::PeriodValidator *validFOCperiod {nullptr};
 
+#if defined(TEST_EMBOT_HISTO)    
 embot::app::scope::SignalHisto *signalhisto {nullptr};
+#endif
 
 void btncallback(void *p)
 {
@@ -55,9 +65,9 @@ void eventbasedthread_startup(embot::os::Thread *t, void *param)
 //    constexpr std::uint64_t focperiodlimitHIGH {48};    // up to 48 usec
 //    constexpr std::uint64_t focperiodSTEP {1};          // in steps of 1 usec
     
-    constexpr std::uint64_t focperiodlimitLOW {1000*1000-50};          // from 0 usec
-    constexpr std::uint64_t focperiodlimitHIGH {1000*1000+50};        // up to 48 usec
-    constexpr std::uint64_t focperiodSTEP {1};          // in steps of 1 usec
+//    constexpr std::uint64_t focperiodlimitLOW {1000*1000-50};          // from 0 usec
+//    constexpr std::uint64_t focperiodlimitHIGH {1000*1000+50};        // up to 48 usec
+//    constexpr std::uint64_t focperiodSTEP {1};          // in steps of 1 usec
     
 //    histoFOCperiod = new embot::tools::Histogram;
 //    histoFOCperiod->init({focperiodlimitLOW, focperiodlimitHIGH, focperiodSTEP});
@@ -77,16 +87,26 @@ void eventbasedthread_startup(embot::os::Thread *t, void *param)
 //    validFOCperiod->init(pvc1sec);
 //    validFOCperiod->init(pvcfoc);
     
-    
+#if defined(TEST_EMBOT_HW_I2CE)
+    embot::hw::i2ce::init(embot::hw::I2CE::one, {});
+#endif
+
+
+#if defined(TEST_EMBOT_HISTO)    
     embot::app::scope::SignalHisto::Config shcfg {0, 100*embot::core::time1microsec, embot::core::time1microsec};
-    signalhisto = new embot::app::scope::SignalHisto(shcfg);    
+    signalhisto = new embot::app::scope::SignalHisto(shcfg);  
+#endif        
     
+#if defined(TEST_EMBOT_HW_TLV)    
     embot::core::print("mainthread-startup: initted driver for tlv493d");  
     // init the tlv493d
     embot::hw::tlv493d::init(embot::hw::TLV493D::one, {embot::hw::tlv493d::Config::startupMODE::resetCHIP});
+
+#endif
             
     
-    embot::core::print("mainthread-startup: started timer which sends evtTick to evthread every = " + embot::core::TimeFormatter(tickperiod).to_string());
+//    embot::core::print("mainthread-startup: started timer which sends evtTick to evthread every = " + embot::core::TimeFormatter(tickperiod).to_string());
+
     
     embot::os::Timer *tmr = new embot::os::Timer;   
     embot::os::Action act(embot::os::EventToThread(evtTick, t));
@@ -106,9 +126,190 @@ void alertdataisready00(void *p)
 
 embot::hw::tlv493d::Position position = 0;
 
-const embot::tools::Histogram::Values * vv {nullptr};
 
+#if defined(TEST_EMBOT_HISTO)
+const embot::tools::Histogram::Values * vv {nullptr};
 std::array<uint64_t, 100> vals {};
+#endif
+
+#if defined(TEST_EMBOT_HW_I2CE)
+
+void testI2Cdiscover()
+{
+
+    static volatile uint32_t therearesome = 0;
+    static volatile uint32_t unluckyyou = 0;
+    std::vector<embot::hw::i2ce::ADR> adrs {};
+    volatile bool foundany = embot::hw::i2ce::discover(embot::hw::I2CE::one, adrs);
+    volatile size_t ss = adrs.size();
+    if(foundany)
+    {
+        therearesome = ss;
+        volatile embot::hw::i2ce::ADR a {0};
+        for(size_t i=0; i<ss; i++)
+        {
+            a = adrs[i];
+            a = a;
+        }
+    }
+    else
+    {
+        unluckyyou++;
+    }
+  
+}
+
+constexpr size_t datasize {10};
+uint8_t data2read[datasize] = {0};
+void testI2Cread()
+{
+//#if defined(TEST_I2C_EMULATED_embot)
+    static volatile embot::core::Time t {0};
+    static volatile embot::core::Time duration {0};
+    
+    volatile embot::hw::result_t r {embot::hw::resNOK};
+    volatile uint8_t nn {0};
+    memset(data2read, 0, sizeof(data2read));
+    embot::core::Data da {data2read, sizeof(data2read)};
+    t = embot::core::now();
+    r = embot::hw::i2ce::receive(embot::hw::I2CE::one, 0xbc, da, 5*embot::core::time1millisec);
+    duration = embot::core::now() - t;
+    if(embot::hw::resNOK == r)
+    {
+        nn++;
+    }
+//#else    
+//    static volatile uint32_t n {0};
+//    volatile bool ok {false};
+//    memset(data2read, 0, sizeof(data2read));
+//    ok = I2C_read(0xbc, sizeof(data2read), data2read);
+//    
+//    if(ok)
+//    {
+//        n++;
+//    }
+//#endif    
+}
+
+
+
+
+// from the tlv registers
+struct RegisterMap
+{
+    static constexpr std::uint8_t readsize = 10;
+    static constexpr std::uint8_t writesize = 4;
+    std::uint8_t readmemory[readsize];
+    std::uint8_t writememory[writesize];
+    bool isvalid() const 
+    {
+        if((0b00000000 != (readmemory[3] & 0b00000011))) { return false; }  // CH must  be 00 else a conversion is ongoing
+        if((0b00110000 != (readmemory[5] & 0b01110000))) { return false; }     // T+FF+PD (pos 4, 5, 6) must be 011 else ...         
+        return true;
+    }
+    constexpr std::uint16_t getXU() const { return static_cast<std::uint16_t>( (static_cast<std::uint16_t>(readmemory[0]) << 4) | static_cast<std::uint16_t>(readmemory[4]>>4) ); }  
+    constexpr std::uint16_t getYU() const { return static_cast<std::int16_t>( (static_cast<std::uint16_t>(readmemory[1]) << 4) | static_cast<std::uint16_t>(readmemory[4]&0x0F) ); }             
+    constexpr std::uint16_t getZU() const { return static_cast<std::uint16_t>( (static_cast<std::uint16_t>(readmemory[2]) << 4) | static_cast<std::uint16_t>(readmemory[5]&0x0F) ); }
+    constexpr std::uint16_t getTU() const { return static_cast<std::uint16_t>( (static_cast<std::uint16_t>(readmemory[3]&0xF0) << 4) | static_cast<std::uint16_t>(readmemory[6]) ); }
+    static constexpr std::int16_t toi16(std::uint16_t u) { return ( (0==(u&0x0800)) ? u : ((0x07ff&u)-2048) ); } 
+    constexpr std::int16_t getX() const { return toi16(getXU()); }
+    constexpr std::int16_t getY() const { return toi16(getYU()); }
+    constexpr std::int16_t getZ() const { return toi16(getZU()); }
+    
+    constexpr std::int16_t getT() const { return toi16(getTU())-340; }
+    
+    constexpr std::uint8_t getInitialWRITE0() const { return 0; }
+    constexpr std::uint8_t getInitialWRITE1() const { return readmemory[7] & 0x18; }
+    constexpr std::uint8_t getInitialWRITE2() const { return readmemory[8]; }
+    constexpr std::uint8_t getInitialWRITE3() const { return readmemory[9] & 0x1f; }
+// ok     void setWRITE(uint8_t paritybit = 0b1, uint8_t i2caddr = 0b00, uint8_t intena = 0b0, uint8_t fastena = 0b1, uint8_t lowena = 0b0, 
+//                      uint8_t tempena = 0b0, uint8_t lpperiod = 0b0, uint8_t parena = 0b0)
+    struct config_t
+    {
+        enum class adr : uint8_t { zero = 0, one = 1, two = 2, three = 3 }; 
+        uint32_t    paritybit   : 1;
+        uint32_t    i2caddr     : 2;
+        uint32_t    intena      : 1; 
+        uint32_t    fastena     : 1;
+        uint32_t    lowena      : 1;
+        uint32_t    tempena     : 1;
+        uint32_t    lpperiod    : 1;
+        uint32_t    parena      : 1;
+        constexpr config_t(uint8_t _paritybit, uint8_t _i2caddr, uint8_t _intena, uint8_t _fastena, uint8_t _lowena, 
+            uint8_t _tempena, uint8_t _lpperiod, uint8_t _parena) :
+            paritybit(_paritybit), i2caddr(_i2caddr), intena(_intena), fastena(_fastena), lowena(_lowena), tempena(_tempena), lpperiod(_lpperiod), parena(_parena)
+        {
+        }
+        constexpr config_t() :
+            paritybit(0b1), i2caddr(0b00), intena(0b0), fastena(0b1), lowena(0b0), tempena(0b0), lpperiod(0b0), parena(0b0)
+        {
+        }
+        constexpr config_t(adr a) :
+            paritybit(0b1), i2caddr(embot::core::tointegral(a)), intena(0b0), fastena(0b1), lowena(0b0), tempena(0b0), lpperiod(0b0), parena(0b0)
+        {
+        }
+    };
+   
+
+    void setWRITE(const config_t &cfg)
+    {
+        writememory[0] = getInitialWRITE0();
+        writememory[1] = getInitialWRITE1() | ((cfg.paritybit&0b1) << 7) | ((cfg.i2caddr&0b11) << 5) | ((cfg.intena&0b1) << 2) | ((cfg.fastena&0b1) << 1) | ((cfg.lowena&0b1));
+        writememory[2] = getInitialWRITE2();
+        writememory[3] = getInitialWRITE3() | ((cfg.tempena&0b1) << 7) | ((cfg.lpperiod&0b1) << 6) | ((cfg.parena&0b1) << 5);
+    }          
+
+    std::int8_t getX08() const { return ( (readmemory[0] & 0x7f) - (128*(readmemory[0]>>7)) ); }  
+    std::int8_t getY08() const { return ( (readmemory[1] & 0x7f) - (128*(readmemory[1]>>7)) ); }
+    
+};
+
+static constexpr RegisterMap::config_t defconfig { };
+
+
+RegisterMap regmap {};
+    
+void testI2Creadwriteread()
+{
+    // at first we read 10 bytes
+    
+    static volatile embot::core::Time t {0};
+    static volatile embot::core::Time duration {0};
+    
+    volatile embot::hw::result_t r {embot::hw::resNOK};
+    volatile uint8_t nn {0};
+    memset(regmap.readmemory, 0, sizeof(regmap.readmemory));
+    embot::core::Data da {regmap.readmemory, sizeof(regmap.readmemory)};
+    t = embot::core::now();
+    r = embot::hw::i2ce::receive(embot::hw::I2CE::one, 0xbc, da, 5*embot::core::time1millisec);
+    duration = embot::core::now() - t;
+    if(embot::hw::resNOK == r)
+    {
+        nn++;
+    }
+    
+    // then we prepare what to write
+
+    regmap.setWRITE({});
+    
+    // then we transmit the four bytes
+
+    embot::core::Data da1 {regmap.writememory, sizeof(regmap.writememory)};
+    t = embot::core::now();
+    r = embot::hw::i2ce::transmit(embot::hw::I2CE::one, 0xbc, da1, 5*embot::core::time1millisec);
+    duration = embot::core::now() - t;
+    if(embot::hw::resNOK == r)
+    {
+        nn++;
+    }
+    
+    // now we read back all data and we compare
+            
+    testI2Cread();
+    
+}
+
+#endif
 
 void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventmask, void *param)
 {   
@@ -116,8 +317,17 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
     {   // timeout ...         
         return;
     }
+
+#if defined(TEST_EMBOT_HW_I2CE)    
+//    testI2Cdiscover();
+//    testI2Cread();
+    testI2Creadwriteread();
+
+#endif
+
     
-    
+#if defined(TEST_EMBOT_HISTO)  
+ 
     signalhisto->on();
     embot::core::wait(30);
     signalhisto->off();
@@ -132,6 +342,7 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
         }
     }
     
+#endif    
 
     if(true == embot::core::binary::mask::check(eventmask, evtTick)) 
     {
@@ -181,9 +392,11 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
         embot::core::print("mainthread-onevent: evtTick received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));    
 #endif  
 
-        embot::core::print("mainthread-onevent: called a fake reading of chip TLV493D which will be effectvively read when board fap arrives");    
+#if defined(TEST_EMBOT_HW_TLV)
+        embot::core::print("mainthread-onevent: called reading of chip TLV493D");    
         embot::core::Callback cbk00(alertdataisready00, t);
         embot::hw::tlv493d::acquisition(embot::hw::TLV493D::one, cbk00);        
+#endif
     }
     
     if(true == embot::core::binary::mask::check(eventmask, evtRead)) 
@@ -193,13 +406,14 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
         embot::core::print("evthread-onevent: evtRead received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));    
 #endif  
 
+#if defined(TEST_EMBOT_HW_TLV)
         if(embot::hw::resOK != embot::hw::tlv493d::read(embot::hw::TLV493D::one, position))
         {
             position = 66666;
         }
-        
+               
         embot::core::print("pos = " + std::to_string(0.01 * position) + "deg");
-        
+#endif        
     }    
     
     if(true == embot::core::binary::mask::check(eventmask, evtBTNreleased)) 
@@ -207,6 +421,8 @@ void eventbasedthread_onevent(embot::os::Thread *t, embot::os::EventMask eventma
         embot::core::TimeFormatter tf(embot::core::now());        
         embot::core::print("evthread-onevent: evtBTNreleased received @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full));        
     }
+    
+
 
 }
 
@@ -221,16 +437,16 @@ embot::os::EventThread* thr {nullptr};
 
 void initSystem(embot::os::Thread *t, void* initparam)
 {
-    embot::core::print("this is a demo which shows that this code can run on a dev board and later on the real pmc board");    
+//    embot::core::print("this is a demo which shows that this code can run on a dev board and later on the real pmc board");    
     
-    embot::core::print("starting the INIT thread");
+//    embot::core::print("starting the INIT thread");
     
-    embot::core::print("creating the system services: timer manager + callback manager");
+ //   embot::core::print("creating the system services: timer manager + callback manager");
     
     embot::os::theTimerManager::getInstance().start({});     
     embot::os::theCallbackManager::getInstance().start({});  
     
-    embot::core::print("creating the LED pulser: it will blink a LED at 1 Hz.");
+//    embot::core::print("creating the LED pulser: it will blink a LED at 1 Hz.");
     static const std::initializer_list<embot::hw::LED> allleds = {embot::hw::LED::one};  
     embot::app::theLEDmanager &theleds = embot::app::theLEDmanager::getInstance();     
     theleds.init(allleds);    
@@ -246,7 +462,7 @@ void initSystem(embot::os::Thread *t, void* initparam)
         eventbasedthread_onevent
     };
     
-    embot::core::print("creating the main thread");
+ //   embot::core::print("creating the main thread");
         
     // create the main thread 
     thr = new embot::os::EventThread;          
@@ -272,7 +488,7 @@ void initSystem(embot::os::Thread *t, void* initparam)
             xx = embot::core::now();
             
             embot::core::TimeFormatter tf(embot::core::now());        
-            embot::core::print("periodic thread: exec @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full)); 
+ //           embot::core::print("periodic thread: exec @ time = " + tf.to_string(embot::core::TimeFormatter::Mode::full)); 
             
         }
     };
@@ -282,7 +498,7 @@ void initSystem(embot::os::Thread *t, void* initparam)
 
 #endif
 
-    embot::core::print("quitting the INIT thread. Normal scheduling starts");    
+//    embot::core::print("quitting the INIT thread. Normal scheduling starts");    
 }
 
 // usart 921600

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_tlv493d.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_tlv493d.cpp
@@ -680,10 +680,15 @@ namespace embot { namespace hw { namespace tlv493d {
     }
     
 
-//#define embot_hw_tlv493d_discover
-#if defined(embot_hw_tlv493d_discover)
+//#define embot_hw_tlv493d_DEBUG_discover_if_ping_fails
+#if defined(embot_hw_tlv493d_DEBUG_discover_if_ping_fails)
     static std::vector<embot::hw::i2c::ADR> addresses;    
     volatile bool ff {false};
+#endif
+    
+//#define embot_hw_tlv493d_DEBUG_readback_at_init
+#if defined(embot_hw_tlv493d_DEBUG_readback_at_init)    
+    uint8_t readback[10] = {0};
 #endif
     
     result_t s_sensor_init(TLV493D h)
@@ -708,9 +713,10 @@ namespace embot { namespace hw { namespace tlv493d {
 #endif
 
         {
-            #if defined(embot_hw_tlv493d_discover)
+            #if defined(embot_hw_tlv493d_DEBUG_discover_if_ping_fails)
             // discover the boards
-            ff = embot::hw::i2c::discover(s_privatedata.config[index].i2cdes.bus, addresses);
+            addresses.clear();
+            ff = embot::hw::i2c::discover(s_privatedata.i2cdes[index].getI2Cbus(), addresses);
             ff = ff;
             #endif
             return resNOK;
@@ -738,7 +744,13 @@ namespace embot { namespace hw { namespace tlv493d {
 #endif       
         // wait a bit
         embot::hw::sys::delay(10*embot::core::time1millisec);
-        
+
+#if defined(embot_hw_tlv493d_DEBUG_readback_at_init)            
+        // read back
+        embot::core::Data datareadback = embot::core::Data(readback, sizeof(readback));
+        r = embot::hw::i2c::receive(s_privatedata.i2cdes[index].getI2Cbus(), s_privatedata.i2cdes[index].adr, datareadback, embot::core::time1second);
+        r = r;
+#endif        
         return resOK;        
     }
     


### PR DESCRIPTION
This PR validates the driver `embot::hw::i2ce` on boards `mtb4fap` and on the STM32G4 development board `stm32g4eval`.

As a result of that the driver `embot::hw::tlv493d` is able to read angle values from the `FAP` board attached to a  `mtb4fap` and  also to the `stm32g4eval`.


