### PR TITLE
The POS service offered by `EOthePOS` can share the CAN bus used by another ETH board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,21 +81,21 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          59
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          60
 
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
+#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          9
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          33
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheCANdiscovery2.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheCANdiscovery2.c
@@ -368,6 +368,19 @@ extern eOresult_t eo_candiscovery2_OneBoardIsFound(EOtheCANdiscovery2 *p, eObrd_
         return(eores_NOK_nullpointer);
     }
     
+    // we need to be sure that we are expecting this message
+    if(eobool_false == s_eo_thecandiscovery2.searchstatus.searching)
+    {   // if we are not searching, clearly we are not expecting
+        return eores_OK;
+    }
+    
+    if(eobool_false == eo_common_hlfword_bitcheck(s_eo_thecandiscovery2.canmapofoverlappedtargets[loc.port], loc.addr))
+    {   // the board which sent the reply is not amongst those we are searching
+        return eores_OK;
+    }
+    
+    // ok: a board we are searching has replied
+    
     // use the information inside loc to mark that a can board has replied. 
     eo_common_hlfword_bitset(&s_eo_thecandiscovery2.detection.replies[loc.port], loc.addr);
     // put inside detected what the board has told

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOthePOS.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOthePOS.c
@@ -842,6 +842,22 @@ extern eOresult_t eo_pos_Config(EOthePOS *p, eOas_pos_config_t* config)
     return(eores_OK);     
 }
 
+static eObool_t eo_pos_CANframeIsExpected(EOthePOS *p, eOcanframe_t *frame, eOcanport_t port)
+{
+    eObool_t r = eobool_true;
+    
+    // in here we accept only messages of class = periodicAS and typ = PER_AS_MSG__POS
+    // but we dont chack vs that because eo_pos_AcceptCANframe() is called only inside eocanprotASperiodic_parser_PER_AS_MSG__POS()
+    // so the check would be redundant
+    
+    // we check however that the message comes from a board specified inside the service configuration. 
+    // we use not_heardof_target      
+    
+    r = eo_common_hlfword_bitcheck(p->not_heardof_target[port], EOCANPROT_FRAME_GET_SOURCE(frame));
+    
+    return r;    
+}
+
 extern eOresult_t eo_pos_AcceptCANframe(EOthePOS *p, eOcanframe_t *frame, eOcanport_t port)
 {
     if(NULL == p)
@@ -865,6 +881,13 @@ extern eOresult_t eo_pos_AcceptCANframe(EOthePOS *p, eOcanframe_t *frame, eOcanp
         return(eores_OK);
     }  
     
+    // i verify that the can frame is expected
+    if(eobool_false == eo_pos_CANframeIsExpected(p, frame, port))
+    {
+        return(eores_OK);
+    }
+    
+    // now i know that we have a frame of type PER_AS_MSG__POS coming from a registered can board
     
     // i get the content of the frame and i fill the status of the pos
    

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,20 +75,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          41
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          42
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
+#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          21 
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          12 
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -87,22 +87,22 @@ extern "C" {
 //  <o> minor           <0-255> 
 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          59
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          60
 
 
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2022
+#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          34
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          10
 
 //  </h>build date
 


### PR DESCRIPTION
This PR adds the required protections so that the POS service can be run by multiple ETH boards which share the same bus as long as they use CAN boards w/ different ID.

To clarify:

If board `ETH-1` configures a CAN board `can-ID-1` to transmit POS values inside a CAN frame of class streaming analog, these messages are received by any ETH board attached to the same CAN bus. Suppose for instance that the board `ETH-2` shares the same bus.

Both `ETH-1` and `ETH-2` will receive the same messages. `ETH-1` expects and correctly processes them, but `ETH-2`does not expect them and must discard them.

This PR adds a filter to the CAN RX processing functions inside `EOtheCANdiscovery2` and `EOthePOS` so that they process only the messages coming from the CAN IDs used by the service.


This PR is required because in the new hand V3 we use two mc4plus boards which share the same CAN bus and both of them run the POS service using two different `mtb4c` boards.
