### PR TITLE
Improved calib type 6 w/ FAP.

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -86,7 +86,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          64
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          65
 
 //  </h>version
 
@@ -96,7 +96,7 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -683,6 +683,17 @@ BOOL AbsEncoder_is_ok(AbsEncoder* o)
 
 BOOL AbsEncoder_is_calibrated(AbsEncoder* o)
 {
+
+    eOerrmanDescriptor_t errdes = {0};
+    char message[150];
+    snprintf(message, sizeof(message), "enc_off=o->offset=%d enc_zero=%d",o->offset, o->zero );
+    errdes.code             = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag02);
+    errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+    errdes.sourceaddress    = 0;
+    errdes.par16            = 0;
+    errdes.par64            = 0;
+    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_debug, message, NULL, &errdes);
+    
     return !o->state.bits.not_calibrated;
 }
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -112,7 +112,7 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
                 
                 jCalib6Data_ptr->is_active = FALSE;
                 char info[80];
-                sprintf(info,"calib 6:outLim: cp%d mx%.1f mn%.1f",curr_pos, j_ptr->pos_max, j_ptr->pos_min);
+                sprintf(info,"calib 6:outLim: cp:%d mx:%.1f mn:%.1f",curr_pos, j_ptr->pos_max, j_ptr->pos_min);
                 JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
 
                 return(eores_NOK_generic);
@@ -185,20 +185,15 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
                 m_ptr->pos_fbk_old = 0;
                 m_ptr->not_init = TRUE;
                 
-//                /////Debug code
-//                char message[150];
-//                snprintf(message, sizeof(message), "c6M:pos reached: cp%d co%d", m_ptr->pos_fbk, m_ptr->pos_calib_offset);
-//                JointSet_send_debug_message(message, m_ptr->ID);
+                /////Debug code
+                char message[150];
+                snprintf(message, sizeof(message), "c6M:pos reached: cp=%d co=%d", m_ptr->pos_fbk, m_ptr->pos_calib_offset);
+                JointSet_send_debug_message(message, m_ptr->ID, 0, 0);
                 
                 m_ptr->not_calibrated = FALSE;
                 
                 
-                /////Debug code
-//                char info[80];
-//                snprintf(info, 80,"Calib offset is %d", offset);
-//                JointSet_send_debug_message(info, j_ptr->ID);
-                /////ended
-                
+               
                 for (int k=0; k<*(o->pN); ++k)
                 {
                     int m = o->motors_of_set[k];
@@ -210,11 +205,11 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
                 //restore rotor limits
                 m_ptr->pos_min = j_ptr->running_calibration.data.type6.rotorposmin;
                 m_ptr->pos_max = j_ptr->running_calibration.data.type6.rotorposmax;
-//                /////Debug code 
-//                char info[80];
-//                sprintf(info,"calib 6: restore rlim of m %d", m_ptr->ID);
-//                JointSet_send_debug_message(info, j_ptr->ID);
-//                ////ended
+                /////Debug code 
+                char info[80];
+                sprintf(info,"m_min=%d m_max=%d", m_ptr->pos_min, m_ptr->pos_max );
+                JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
+                ////ended
             }
                 
         }
@@ -223,6 +218,9 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
         case calibtype6_st_finished:
         {
             *calibrationCompleted = TRUE;
+            char info[80];
+            sprintf(info,"calib Completed" );
+            JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
         }break;
         
         default:
@@ -301,6 +299,7 @@ BOOL JointSet_do_wait_calibration_mixed(JointSet* o)
     
     BOOL calibrationCompleted = TRUE;
     eOresult_t res = eores_OK;
+    volatile uint8_t num_of_j = *(o->pN);
     
     for (int k=0; ( (k<*(o->pN)) && (eores_OK == res) ); ++k)
     {
@@ -356,6 +355,10 @@ BOOL JointSet_do_wait_calibration_mixed(JointSet* o)
             Joint* j_ptr = o->joint + o->joints_of_set[k];
             Joint_reset_calibration_data(j_ptr);
         }
+        //Debug code
+        char message[150];
+        snprintf(message, sizeof(message), "JointSet_do_wait_calibration_mixed: calib completed.");
+        JointSet_send_debug_message(message, 0, 0, 0);
     
     }
     return(calibrationCompleted);

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -112,7 +112,7 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
                 
                 jCalib6Data_ptr->is_active = FALSE;
                 char info[80];
-                sprintf(info,"calib 6:outLim: cp:%d mx:%.1f mn:%.1f",curr_pos, j_ptr->pos_max, j_ptr->pos_min);
+                snprintf(info, sizeof(info), "calib 6:outLim: cp:%d mx:%.1f mn:%.1f", curr_pos, j_ptr->pos_max, j_ptr->pos_min);
                 JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
 
                 return(eores_NOK_generic);
@@ -148,7 +148,7 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
             if(!ret)
             {
                 char info[50];
-                snprintf(info, 50,"error in Joint_set_pos_ref_in_calibType6");
+                snprintf(info, sizeof(info),"error in Joint_set_pos_ref_in_calibType6");
                 JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
                 //restore rotor limits
                 m_ptr->pos_min = j_ptr->running_calibration.data.type6.rotorposmin;
@@ -207,7 +207,7 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
                 m_ptr->pos_max = j_ptr->running_calibration.data.type6.rotorposmax;
                 /////Debug code 
                 char info[80];
-                sprintf(info,"m_min=%d m_max=%d", m_ptr->pos_min, m_ptr->pos_max );
+                snprintf(info, sizeof(info), "m_min=%d m_max=%d", m_ptr->pos_min, m_ptr->pos_max );
                 JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
                 ////ended
             }
@@ -219,7 +219,7 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
         {
             *calibrationCompleted = TRUE;
             char info[80];
-            sprintf(info,"calib Completed" );
+            snprintf(info, sizeof(info), "calib Completed" );
             JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
         }break;
         

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1491,8 +1491,6 @@ static void JointSet_do_wait_calibration(JointSet* o)
     
     JointSet_set_control_mode(o, eomc_controlmode_cmd_position);
 }
-bool isMais(void)
-{return false;}
 
 void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
 {
@@ -1567,7 +1565,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             {
                 ////debug code
                 char info[50];
-                snprintf(info, 50, "error type6.current=%d",calibrator->params.type6.current);
+                snprintf(info, sizeof(info), "error type6.current=%d",calibrator->params.type6.current);
                 JointSet_send_debug_message(info, e, 0, 0);
                 ////debug code ended
                 return;
@@ -1575,7 +1573,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             
             ////debug code
             char info[50];
-            snprintf(info, 50, "vmax=%d,vim=%d",calibrator->params.type6.vmax, calibrator->params.type6.vmin);
+            snprintf(info, sizeof(info), "vmax=%d,vim=%d",calibrator->params.type6.vmax, calibrator->params.type6.vmin);
             JointSet_send_debug_message(info, e, 0, 0);
             ////debug code ended
                 
@@ -1606,7 +1604,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 {    
                     ////debug code
                     char info[70];
-                    snprintf(info, 70, "calib6: error updating Mais conversion factor j%d", e);
+                    snprintf(info, sizeof(info), "calib6: error updating Mais conversion factor j%d", e);
                     JointSet_send_debug_message(info, e, 0, 0);
                     ////debug code ended
                     return;


### PR DESCRIPTION
Tested and working on both desk setup and ergocab robot.

In this PR the following tasks have been done:
- Improve current working calibration type 6 by allowing to use FAP sensors instead of MICE;
- Tested the calibration procedure on the left arm bench setup.
- Tested the calibration procedure on the left arm of ergocub robot (test on right arm is going to be done)
- Updated firmware code by customizing calibration type 6 enabling POS service use