### PR TITLE
AMC – Position direct support for `wrist-mk2`

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
@@ -47,7 +47,7 @@ namespace embot { namespace app { namespace eth {
 #else            
             {103, 0},  
 #endif            
-            {2022, Month::Apr, Day::fourteen, 15, 16}
+            {2023, Month::Mar, Day::two, 14, 50}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
@@ -40,9 +40,9 @@ namespace embot { namespace app { namespace eth {
             Process::eApplication,
 #if defined(WRIST_MK2)
     #if defined(WRIST_MK2_RIGHT)
-            {4, 4},
+            {4, 5},
     #else
-            {3, 0},
+            {3, 5},
     #endif            
 #else            
             {103, 0},  

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
@@ -40,14 +40,14 @@ namespace embot { namespace app { namespace eth {
             Process::eApplication,
 #if defined(WRIST_MK2)
     #if defined(WRIST_MK2_RIGHT)
-            {4, 5},
+            {101, 0},
     #else
-            {3, 5},
+            {102, 0},
     #endif            
 #else            
             {103, 0},  
 #endif            
-            {2023, Month::Mar, Day::two, 14, 50}
+            {2023, Month::Mar, Day::two, 15, 20}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
@@ -2055,10 +2055,10 @@ void MController_config_joint_vel_ref_timeout(int j, int32_t timeout_ms)
 
 BOOL MController_set_joint_pos_ref(int j, CTRL_UNITS pos_ref, CTRL_UNITS vel_ref)
 {
-#ifndef WRIST_MK2
+#if !defined(WRIST_MK2)
     return Joint_set_pos_ref(smc->joint+j, pos_ref, vel_ref);
 #else
-	return JointSet_set_pos_ref(&(smc->jointSet[0]), j, pos_ref, vel_ref);
+    return JointSet_set_pos_ref(&(smc->jointSet[0]), j, pos_ref, vel_ref);
 #endif
 }
 
@@ -2069,7 +2069,11 @@ BOOL MController_set_joint_vel_ref(int j, CTRL_UNITS vel_ref, CTRL_UNITS acc_ref
 
 BOOL MController_set_joint_pos_raw(int j, CTRL_UNITS pos_ref)
 {
+#if !defined(WRIST_MK2)
     return Joint_set_pos_raw(smc->joint+j, pos_ref);
+#else
+    return JointSet_set_pos_ref(&(smc->jointSet[0]), j, pos_ref, 0.0f);
+#endif
 }
 
 BOOL MController_set_joint_vel_raw(int j, CTRL_UNITS vel_ref)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -617,6 +617,7 @@ BOOL JointSet_set_control_mode(JointSet* o, eOmc_controlmode_command_t control_m
     case eomc_controlmode_cmd_velocity_pos:
     case eomc_controlmode_cmd_position:
     case eomc_controlmode_cmd_velocity:
+    case eomc_controlmode_cmd_direct:
     {        
         //if (o->external_fault) return FALSE;
                 
@@ -638,8 +639,8 @@ BOOL JointSet_set_control_mode(JointSet* o, eOmc_controlmode_command_t control_m
     case eomc_controlmode_cmd_openloop:
     case eomc_controlmode_cmd_current:    
     case eomc_controlmode_cmd_torque:
-    case eomc_controlmode_cmd_direct:
 #ifndef WRIST_MK2
+    case eomc_controlmode_cmd_direct:
     case eomc_controlmode_cmd_mixed:
     case eomc_controlmode_cmd_velocity_pos:
     case eomc_controlmode_cmd_position:
@@ -1881,15 +1882,21 @@ BOOL JointSet_set_pos_ref(JointSet* o, int j, CTRL_UNITS pos_ref, CTRL_UNITS vel
 {
     if (o->is_parking) return FALSE;
     
-    if ((o->control_mode != eomc_controlmode_position) && (o->control_mode != eomc_controlmode_mixed) && (o->control_mode != eomc_ctrlmval_velocity_pos))
+    if ((o->control_mode != eomc_controlmode_direct) && (o->control_mode != eomc_controlmode_position) && (o->control_mode != eomc_controlmode_mixed) && (o->control_mode != eomc_ctrlmval_velocity_pos))
     {
         return FALSE;
+    }
+    
+    if(eomc_controlmode_direct == o->control_mode)
+    {
+        Trajectory_set_pos_raw(&(o->ypr_trajectory[j]), pos_ref);
+        return TRUE;
     }
     
     if (vel_ref == 0.0f) return TRUE;
     
     Trajectory_set_pos_end(&(o->ypr_trajectory[j]), pos_ref, vel_ref);
-    
+
     return TRUE;
 }
 


### PR DESCRIPTION
**What's new:**
- enabled position direct control mode for `wrist-mk2` 


**Notes:**
- tested on `wrist-setup`


cc @ale-git @pattacini @marcoaccame 