### PR TITLE
BAT board: align the software overcurrent thresholds to the hardware thresholds

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -46,7 +46,7 @@ uint8_t toggle_100ms = 0;
 
 uint16_t I_V12board_MAX      = 10000;    // threshold in mA
 uint16_t I_V12motor_MAX      = 10000;    // threshold in mA
-uint16_t I_HSM_MAX           = 40000;    // threshold in mA
+uint16_t I_HSM_MAX           = 36000;    // threshold in mA
 uint16_t timer_fault_board   = 0;
 uint16_t timer_fault_motors  = 0;
 uint16_t timer_fault_HSM     = 0;

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -44,9 +44,9 @@ uint32_t blink_ds=100;
 uint8_t toggle_1s = 0;
 uint8_t toggle_100ms = 0;
 
-uint16_t I_V12board_MAX      = 9000;     // threshold in mA
-uint16_t I_V12motor_MAX      = 6500;     // threshold in mA
-uint16_t I_HSM_MAX           = 20000;
+uint16_t I_V12board_MAX      = 10000;    // threshold in mA
+uint16_t I_V12motor_MAX      = 10000;    // threshold in mA
+uint16_t I_HSM_MAX           = 40000;    // threshold in mA
 uint16_t timer_fault_board   = 0;
 uint16_t timer_fault_motors  = 0;
 uint16_t timer_fault_HSM     = 0;


### PR DESCRIPTION
This PR is to align the software overcurrent thresholds of the BAT board to the corresponding new hardware revision: iitcode 10050 rev. D.
Note: all the previous revisions are obsolete.

The hardware overcurrent limits are:
- 36A for the HSM section
- 10A for the 12V voltage regulator CPU section
- 10A for the 12V voltage regulator Motor section