### PR TITLE
BAT firmware revision version updated to 1.1.0

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -10,7 +10,7 @@
 #include "BAT_B.h"
 
 char Firmware_vers = 1;
-char Revision_vers = 0;
+char Revision_vers = 1;
 char Build_number  = 0;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis


### PR DESCRIPTION
I forgot to update the revision version in https://github.com/robotology/icub-firmware/pull/353.
This PR is only to change it.