### PR TITLE
Fix of PR #349 for problem related to POS service

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOthePOS.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOthePOS.c
@@ -144,6 +144,11 @@
     {
         return eores_NOK_generic;
     }
+		
+    extern eObool_t eo_pos_isAlive(EOthePOS *p)
+    {
+            return eobool_false;
+    }
 
 
 #elif !defined(EOTHESERVICES_disable_thePOS)


### PR DESCRIPTION
This PR introduces a dummy function for the method `eo_pos_isAlive` when the POS service is disabled in a board.
This has been done in order to fix compilation problem for projects that do not used POS service introduced with the PR #349 where a file shared among projects has been modified.
 