### PR TITLE
Upgrade version  from 1.1.0 to 1.2.0 for BAT board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -10,7 +10,7 @@
 #include "BAT_B.h"
 
 char Firmware_vers = 1;
-char Revision_vers = 1;
+char Revision_vers = 2;
 char Build_number  = 0;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis


### PR DESCRIPTION
Update BAT board version after introducing new message 
for info about battery pack. Battery pack charge and battery pack current voltage