### PR TITLE
Cross core printing from amc2 to amc

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc.cpp
@@ -1819,8 +1819,9 @@ extern "C"
 // --------------------------------------------------------------------------------------------------------------------
 
 #include "embot_hw_bsp_amc.h"
+#include "embot_hw_icc_printer.h"
 
-namespace embot { namespace hw { namespace bsp { namespace amc {
+namespace embot::hw::bsp::amc {
     
     OnSpecialize defOnSpec {};
     
@@ -1829,7 +1830,7 @@ namespace embot { namespace hw { namespace bsp { namespace amc {
         defOnSpec = onsp;
     }
     
-}}}}
+}
 
 
 
@@ -1904,7 +1905,12 @@ bool embot::hw::bsp::specialize() { return true; }
             {
                 // 1. init the hsems (just in case) and release hsem-0
                 __HAL_RCC_HSEM_CLK_ENABLE();
-                HAL_HSEM_Release(hsem0, procID0);           
+                HAL_HSEM_Release(hsem0, procID0);          
+
+#if defined(EMBOT_ENABLE_hw_icc_printer)
+                // and also activate the printer
+                embot::hw::icc::printer::theServer::getInstance().initialise({});
+#endif                
             } break;
             
             case amc::OnSpecialize::CM4MODE::donothing:

--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_bsp_amc_config.h
@@ -48,6 +48,7 @@
     #define EMBOT_ENABLE_hw_icc_sig
     #define EMBOT_ENABLE_hw_icc_mem
     #define EMBOT_ENABLE_hw_icc_ltr
+//    #define EMBOT_ENABLE_hw_icc_printer
         
 #else
     #error this is the bsp config of STM32HAL_BOARD_AMC ...

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvoptx
@@ -1465,17 +1465,77 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>42</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_mtx.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>43</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_icc_sig.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>44</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_icc_mem.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>45</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_icc_ltr.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>46</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_icc_printer.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>42</FileNumber>
+      <FileNumber>47</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1487,7 +1547,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>43</FileNumber>
+      <FileNumber>48</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1499,7 +1559,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>44</FileNumber>
+      <FileNumber>49</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1511,7 +1571,7 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>45</FileNumber>
+      <FileNumber>50</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1523,13 +1583,37 @@
     </File>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>46</FileNumber>
+      <FileNumber>51</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</PathWithFileName>
       <FilenameWithoutPath>ipal_hal_eth_stm32h7.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>9</GroupNumber>
+      <FileNumber>52</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_mtx_bsp_amc.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>9</GroupNumber>
+      <FileNumber>53</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_icc_bsp_amc.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -1543,7 +1627,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>47</FileNumber>
+      <FileNumber>54</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1555,7 +1639,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>48</FileNumber>
+      <FileNumber>55</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1567,7 +1651,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>49</FileNumber>
+      <FileNumber>56</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1579,7 +1663,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>50</FileNumber>
+      <FileNumber>57</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1591,7 +1675,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>51</FileNumber>
+      <FileNumber>58</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1603,7 +1687,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>52</FileNumber>
+      <FileNumber>59</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1615,7 +1699,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>53</FileNumber>
+      <FileNumber>60</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1627,7 +1711,7 @@
     </File>
     <File>
       <GroupNumber>10</GroupNumber>
-      <FileNumber>54</FileNumber>
+      <FileNumber>61</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1647,7 +1731,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>55</FileNumber>
+      <FileNumber>62</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1659,7 +1743,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>56</FileNumber>
+      <FileNumber>63</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1671,7 +1755,7 @@
     </File>
     <File>
       <GroupNumber>11</GroupNumber>
-      <FileNumber>57</FileNumber>
+      <FileNumber>64</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1691,7 +1775,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>58</FileNumber>
+      <FileNumber>65</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1703,7 +1787,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>59</FileNumber>
+      <FileNumber>66</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1715,7 +1799,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>60</FileNumber>
+      <FileNumber>67</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1727,7 +1811,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>61</FileNumber>
+      <FileNumber>68</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1739,7 +1823,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>62</FileNumber>
+      <FileNumber>69</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1751,7 +1835,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>63</FileNumber>
+      <FileNumber>70</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1763,7 +1847,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>64</FileNumber>
+      <FileNumber>71</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1775,7 +1859,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>65</FileNumber>
+      <FileNumber>72</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1787,7 +1871,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>66</FileNumber>
+      <FileNumber>73</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1799,7 +1883,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>67</FileNumber>
+      <FileNumber>74</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1811,7 +1895,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>68</FileNumber>
+      <FileNumber>75</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1823,7 +1907,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>69</FileNumber>
+      <FileNumber>76</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1835,7 +1919,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>70</FileNumber>
+      <FileNumber>77</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1847,7 +1931,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>71</FileNumber>
+      <FileNumber>78</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1859,7 +1943,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>72</FileNumber>
+      <FileNumber>79</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1871,7 +1955,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>73</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1883,7 +1967,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>74</FileNumber>
+      <FileNumber>81</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1895,7 +1979,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>75</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1907,7 +1991,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>76</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1919,7 +2003,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1931,7 +2015,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1943,7 +2027,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1955,7 +2039,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1975,7 +2059,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1987,7 +2071,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1999,7 +2083,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2011,7 +2095,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2031,7 +2115,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2043,7 +2127,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2055,7 +2139,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2067,7 +2151,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2079,7 +2163,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2091,7 +2175,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2103,7 +2187,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2123,7 +2207,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2143,7 +2227,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>100</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2155,7 +2239,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>101</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2175,7 +2259,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>102</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2187,7 +2271,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>103</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2199,7 +2283,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>104</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2211,7 +2295,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>105</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2223,7 +2307,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>106</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2235,7 +2319,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>107</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2247,7 +2331,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>101</FileNumber>
+      <FileNumber>108</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2259,7 +2343,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>102</FileNumber>
+      <FileNumber>109</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2271,7 +2355,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>103</FileNumber>
+      <FileNumber>110</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2283,7 +2367,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <FileNumber>111</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2295,7 +2379,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <FileNumber>112</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2307,7 +2391,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <FileNumber>113</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2319,7 +2403,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <FileNumber>114</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2331,7 +2415,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>108</FileNumber>
+      <FileNumber>115</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2343,7 +2427,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>109</FileNumber>
+      <FileNumber>116</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2363,7 +2447,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>110</FileNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2375,7 +2459,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>111</FileNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2387,7 +2471,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>112</FileNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2399,7 +2483,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>113</FileNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2411,7 +2495,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>114</FileNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2423,7 +2507,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>115</FileNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2435,7 +2519,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>116</FileNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2447,7 +2531,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2459,7 +2543,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2471,7 +2555,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2491,7 +2575,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <FileNumber>127</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2503,7 +2587,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <FileNumber>128</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2515,7 +2599,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <FileNumber>129</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2535,7 +2619,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <FileNumber>130</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2555,7 +2639,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <FileNumber>131</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2575,7 +2659,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>132</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2595,7 +2679,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2607,7 +2691,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2619,7 +2703,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <FileNumber>135</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2639,7 +2723,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <FileNumber>136</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2651,7 +2735,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <FileNumber>137</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2663,7 +2747,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2675,7 +2759,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <FileNumber>139</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2687,7 +2771,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2699,7 +2783,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2711,7 +2795,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <FileNumber>142</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2731,7 +2815,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <FileNumber>143</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2743,7 +2827,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <FileNumber>144</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2755,7 +2839,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <FileNumber>145</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2767,7 +2851,7 @@
     </File>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <FileNumber>146</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2787,7 +2871,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>26</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2807,7 +2891,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <FileNumber>148</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2819,7 +2903,7 @@
     </File>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <FileNumber>149</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2831,7 +2915,7 @@
     </File>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <FileNumber>150</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2843,7 +2927,7 @@
     </File>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <FileNumber>151</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2863,7 +2947,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>28</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <FileNumber>152</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2875,7 +2959,7 @@
     </File>
     <File>
       <GroupNumber>28</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <FileNumber>153</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2887,7 +2971,7 @@
     </File>
     <File>
       <GroupNumber>28</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <FileNumber>154</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2907,7 +2991,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>29</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <FileNumber>155</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2927,7 +3011,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>30</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <FileNumber>156</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2939,7 +3023,7 @@
     </File>
     <File>
       <GroupNumber>30</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <FileNumber>157</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2959,7 +3043,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <FileNumber>158</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2971,7 +3055,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <FileNumber>159</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2983,7 +3067,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <FileNumber>160</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2995,7 +3079,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <FileNumber>161</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3007,7 +3091,7 @@
     </File>
     <File>
       <GroupNumber>31</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <FileNumber>162</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3027,7 +3111,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>32</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <FileNumber>163</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3039,7 +3123,7 @@
     </File>
     <File>
       <GroupNumber>32</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <FileNumber>164</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3059,7 +3143,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>33</GroupNumber>
-      <FileNumber>158</FileNumber>
+      <FileNumber>165</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3071,7 +3155,7 @@
     </File>
     <File>
       <GroupNumber>33</GroupNumber>
-      <FileNumber>159</FileNumber>
+      <FileNumber>166</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3083,7 +3167,7 @@
     </File>
     <File>
       <GroupNumber>33</GroupNumber>
-      <FileNumber>160</FileNumber>
+      <FileNumber>167</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3095,7 +3179,7 @@
     </File>
     <File>
       <GroupNumber>33</GroupNumber>
-      <FileNumber>161</FileNumber>
+      <FileNumber>168</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3107,7 +3191,7 @@
     </File>
     <File>
       <GroupNumber>33</GroupNumber>
-      <FileNumber>162</FileNumber>
+      <FileNumber>169</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3127,7 +3211,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>163</FileNumber>
+      <FileNumber>170</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3139,7 +3223,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>164</FileNumber>
+      <FileNumber>171</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3151,7 +3235,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>165</FileNumber>
+      <FileNumber>172</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3163,7 +3247,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>166</FileNumber>
+      <FileNumber>173</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3175,7 +3259,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>167</FileNumber>
+      <FileNumber>174</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3187,7 +3271,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>168</FileNumber>
+      <FileNumber>175</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3199,7 +3283,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>169</FileNumber>
+      <FileNumber>176</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3211,7 +3295,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>170</FileNumber>
+      <FileNumber>177</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3223,7 +3307,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>171</FileNumber>
+      <FileNumber>178</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3235,7 +3319,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>172</FileNumber>
+      <FileNumber>179</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3247,7 +3331,7 @@
     </File>
     <File>
       <GroupNumber>34</GroupNumber>
-      <FileNumber>173</FileNumber>
+      <FileNumber>180</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3267,7 +3351,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>35</GroupNumber>
-      <FileNumber>174</FileNumber>
+      <FileNumber>181</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3279,7 +3363,7 @@
     </File>
     <File>
       <GroupNumber>35</GroupNumber>
-      <FileNumber>175</FileNumber>
+      <FileNumber>182</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvprojx
@@ -713,6 +713,31 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_MB049.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_mtx.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_sig.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_mem.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_ltr.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_printer.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -742,6 +767,16 @@
               <FileName>ipal_hal_eth_stm32h7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_mtx_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3281,6 +3316,31 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_MB049.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_mtx.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_sig.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_mem.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_ltr.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_printer.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3310,6 +3370,16 @@
               <FileName>ipal_hal_eth_stm32h7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_mtx_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -5594,6 +5664,31 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_MB049.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_mtx.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_sig.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_mem.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_ltr.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_printer.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -5623,6 +5718,16 @@
               <FileName>ipal_hal_eth_stm32h7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_mtx_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -8417,6 +8522,31 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_MB049.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_mtx.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_sig.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_mem.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_ltr.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_printer.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -8446,6 +8576,16 @@
               <FileName>ipal_hal_eth_stm32h7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_mtx_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -10016,6 +10156,31 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_MB049.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_mtx.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_sig.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_mem.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_ltr.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_printer.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -10045,6 +10210,16 @@
               <FileName>ipal_hal_eth_stm32h7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_mtx_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -11615,6 +11790,31 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_chip_MB049.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_mtx.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_mtx.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_sig.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_sig.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_mem.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_mem.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_ltr.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_printer.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -11644,6 +11844,16 @@
               <FileName>ipal_hal_eth_stm32h7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\bsp\ethdriver\ipal_hal_eth_stm32h7.c</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_mtx_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_mtx_bsp_amc.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_icc_bsp_amc.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\embot_hw_icc_bsp_amc.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
@@ -1137,7 +1137,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1369,7 +1369,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -1,5 +1,6 @@
 
 /*
+
  * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -1,6 +1,5 @@
 
 /*
-
  * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c.cpp
@@ -339,6 +339,7 @@ extern "C" {
 }
 
 #include "embot_hw_bsp_amc2c.h"
+#include "embot_hw_icc_printer.h"
 
 namespace embot::hw::bsp::amc2c {
     
@@ -354,6 +355,14 @@ namespace embot::hw::bsp::amc2c {
     
     // we have the input pins (PG5, PG6, PG7) which tells the hw version of the board
     // VER0_Pin, VER1_Pin, VER2_Pin
+    
+    void print(const std::string &str)
+    {
+#if defined(EMBOT_ENABLE_hw_icc_printer)        
+        embot::hw::icc::printer::theClient::getInstance().post(str);
+#endif        
+    }
+    
     
 }
 
@@ -416,6 +425,10 @@ bool embot::hw::bsp::specialize()
     leds_init_off();
 #endif
 
+#if defined(EMBOT_ENABLE_hw_icc_printer)    
+    embot::hw::icc::printer::theClient::getInstance().initialise({});
+#endif
+    
     #warning TODO: verificare che le priorita' delle IRQ del motor control possano essere impostate anche dopo la partenza del rtos
     return true;
 }

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c.h
@@ -26,6 +26,9 @@ namespace embot::hw::bsp::amc2c {
     embot::hw::BTN EXTFAULTbutton();
     embot::hw::LED EXTFAULTled();
     
+    // it prints to the CM7 core ... if EMBOT_ENABLE_hw_icc_printer is enabled both in here and amc
+    void print(const std::string &str);
+    
 }
 
 #endif  // include-guard

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c_config.h
@@ -35,6 +35,7 @@
     #define EMBOT_ENABLE_hw_icc_sig
     #define EMBOT_ENABLE_hw_icc_mem
     #define EMBOT_ENABLE_hw_icc_ltr
+//    #define EMBOT_ENABLE_hw_icc_printer
 
 #else
     #error this is the bsp config of STM32HAL_BOARD_AMC2C ...

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_icc_bsp_amc2c.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_icc_bsp_amc2c.cpp
@@ -1,0 +1,267 @@
+
+/*
+ * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_icc_bsp_amc2c.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include <cstring>
+#include <vector>
+#include <array>
+
+#include "embot_core_binary.h"
+#include "embot_core.h"
+
+#if defined(USE_STM32HAL)
+    #include "stm32hal.h"
+#else
+    #warning this implementation is only for stm32hal
+#endif
+
+
+using namespace std;
+using namespace embot::core::binary;
+
+// --------------------------------------------------------------------------------------------------------------------
+// - configuration of peripherals and chips. it is done board by board. it contains a check vs correct STM32HAL_BOARD_*
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_bsp_amc2c_config.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - support maps
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// - support map: begin of embot::hw::icc::sig
+
+#include "embot_hw_icc_sig_bsp.h"
+
+#if !defined(EMBOT_ENABLE_hw_icc_sig)
+
+namespace embot::hw::icc::sig::bsp {
+        
+    // -- SIG
+    
+    constexpr BSP thebsp {};
+    void BSP::init(embot::hw::icc::SIG h) const {}    
+    const BSP & getBSPsig() { return thebsp; }    
+    
+}
+
+#elif defined(EMBOT_ENABLE_hw_icc_sig)
+
+namespace embot::hw::icc::sig::bsp {
+                
+    // -- SIG
+
+    constexpr PROP sig01 = { embot::hw::MTX::five };
+    constexpr PROP sig02 = { embot::hw::MTX::six };
+    constexpr PROP sig03 = { embot::hw::MTX::seven };
+    constexpr PROP sig04 = { embot::hw::MTX::eight };
+    
+    
+    constexpr BSP thebsp {        
+        // maskofsupported
+        mask::pos2mask<uint32_t>(SIG::one) | mask::pos2mask<uint32_t>(SIG::two) | 
+        mask::pos2mask<uint32_t>(SIG::three) | mask::pos2mask<uint32_t>(SIG::four),        
+        // properties
+        {{
+            &sig01, &sig02, &sig03, &sig04    
+        }}        
+    };
+    
+
+    void BSP::init(embot::hw::icc::SIG h) const { }    
+    
+    const BSP & getBSP() { return thebsp; }  
+    
+}
+
+#endif // #elif defined(EMBOT_ENABLE_hw_icc_sig)
+
+
+// - support map: begin of embot::hw::icc::mem
+
+#include "embot_hw_icc_mem_bsp.h"
+
+#if !defined(EMBOT_ENABLE_hw_icc_mem)
+
+namespace embot::hw::icc::mem::bsp {
+    
+    // -- MEM
+    
+    constexpr BSP thebsp {};    
+    void BSP::init(embot::hw::icc::MEM h) const {}
+    const BSP & getBSP() { return thebsp; }  
+    
+}
+
+#elif defined(EMBOT_ENABLE_hw_icc_mem)
+
+namespace embot::hw::icc::mem::bsp {
+
+    // -- MEM
+    
+    constexpr uint32_t startmemory {0x38001000};
+    constexpr uint32_t memsize {256};
+    
+    static const PROP mm1 = {
+        reinterpret_cast<void*>(startmemory),
+        memsize,
+        MTX::nine
+    };
+    static const PROP mm2 = {
+        reinterpret_cast<void*>(startmemory+1*memsize),
+        memsize,
+        MTX::ten
+    };
+    static const PROP mm3 = {
+        reinterpret_cast<void*>(startmemory+2*memsize),
+        memsize,
+        MTX::eleven
+    };
+    static const PROP mm4 = {
+        reinterpret_cast<void*>(startmemory+3*memsize),
+        memsize,
+        MTX::twelve
+    };  
+    
+    constexpr BSP thebsp {        
+        // maskofsupported
+        mask::pos2mask<uint32_t>(MEM::one) | mask::pos2mask<uint32_t>(MEM::two) | 
+        mask::pos2mask<uint32_t>(MEM::three) | mask::pos2mask<uint32_t>(MEM::four),        
+        // properties
+        {{
+            &mm1, &mm2, &mm3, &mm4      
+        }}        
+    };
+    
+    void BSP::init(embot::hw::icc::MEM h) const { }    
+        
+    const BSP & getBSP() { return thebsp; }  
+ 
+} // namespace embot::hw::icc::mem::bsp {
+
+#endif // #elif defined(EMBOT_ENABLE_hw_icc_mem)    
+
+
+// - support map: begin of embot::hw::icc::ltr
+
+#include "embot_hw_icc_ltr_bsp.h"
+
+#if !defined(EMBOT_ENABLE_hw_icc_ltr)
+
+namespace embot::hw::icc::ltr::bsp {
+    
+    // -- LTR
+    
+    constexpr BSP thebsp {};    
+    void BSP::init(embot::hw::icc::LTR h) const {}
+    const BSP & getBSP() { return thebsp; }  
+    
+}
+
+#elif defined(EMBOT_ENABLE_hw_icc_ltr)
+
+namespace embot::hw::icc::ltr::bsp {
+
+    // LTR
+
+    constexpr PROP ltr01 = { embot::hw::icc::MEM::four, embot::hw::icc::SIG::four, embot::hw::icc::SIG::three };
+       
+    constexpr BSP thebsp {        
+        // maskofsupported
+        mask::pos2mask<uint32_t>(LTR::one),        
+        // properties
+        {{
+            &ltr01
+        }}        
+    };
+    
+
+    void BSP::init(embot::hw::icc::LTR h) const { }            
+
+    const BSP & getBSP() 
+    {
+        return thebsp;
+    }     
+
+} // namespace embot::hw::icc::ltr::bsp {
+
+#endif // #elif defined(EMBOT_ENABLE_hw_icc_ltr)    
+
+
+//namespace embot::hw::icc::sig::bsp {
+//        
+////    // -- SIG
+////    constexpr BSPsig thebsp_sig {};
+////    void BSPsig::init(embot::hw::icc::SIG h) const {}    
+////    const BSPsig & getBSPsig() { return thebsp_sig; }  
+//       
+////    // -- MEM
+////    constexpr BSPmem thebsp_mem {};    
+////    void BSPmem::init(embot::hw::icc::MEM h) const {}
+////    const BSPmem & getBSPmem() { return thebsp_mem; }  
+
+////    // LTR      
+////    constexpr BSPltr thebsp_ltr {};
+////    void BSPltr::init(embot::hw::icc::LTR h) const {}
+////    const BSPltr & getBSPltr() { return thebsp_ltr; }    
+
+//}
+
+//#elif defined(EMBOT_ENABLE_hw_icc)
+
+
+//    
+
+//    
+
+
+//    // LTR
+
+//    constexpr PROPltr ltr01 = { embot::hw::icc::MEM::four, embot::hw::icc::SIG::four, embot::hw::icc::SIG::three };
+//       
+//    constexpr BSPltr thebsp_ltr {        
+//        // maskofsupported
+//        mask::pos2mask<uint32_t>(LTR::one),        
+//        // properties
+//        {{
+//            &ltr01
+//        }}        
+//    };
+//    
+
+//    void BSPltr::init(embot::hw::icc::LTR h) const
+//    {
+//    }            
+
+//    const BSPltr & getBSPltr() 
+//    {
+//        return thebsp_ltr;
+//    }      
+
+//} // namespace embot::hw::icc::bsp {
+
+
+//#endif // #elif defined(EMBOT_ENABLE_hw_icc)
+
+
+//// - support map: end of embot::hw::icc
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_icc_bsp_amc2c.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_icc_bsp_amc2c.h
@@ -1,0 +1,26 @@
+
+/*
+ * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_HW_ICC_BSP_AMC2C_H_
+#define __EMBOT_HW_ICC_BSP_AMC2C_H_
+
+#include "embot_hw_bsp.h"
+#include "embot_hw_icc.h"
+
+namespace embot::hw::icc::bsp {
+
+}
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+
+


### PR DESCRIPTION
This PR enables the cross core printing from the CM4 core to the CM7 using the `embot::hw::icc::printer` objects

If macro `EMBOT_ENABLE_hw_icc_printer` is defined both in the `amc2c `and the `amc`, then the `amc2c` application can use `embot::hw::bsp::amc2c::print()` to direct the printing over the debug session of the `amc`.

As this is a debugging feature, the macro  `EMBOT_ENABLE_hw_icc_printer` is undefined and must be defined explicitely.
.