### PR TITLE
AMDBLDC: add thermal model running at 10ms and reusable functions from codegen (icub-fw-models@2e2670b)

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
@@ -1137,7 +1137,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1369,7 +1369,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1953,6 +1953,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>83</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</PathWithFileName>
+      <FilenameWithoutPath>SupervisorFSM_RX_data.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1963,7 +1975,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1983,7 +1995,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2003,7 +2015,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2015,7 +2027,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2027,7 +2039,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2047,7 +2059,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2067,7 +2079,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2087,13 +2099,33 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>26</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\amcbldc\application\src\model-based-design\amc-bldc\AMC_BLDC.cpp</PathWithFileName>
       <FilenameWithoutPath>AMC_BLDC.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>mbd::thermal-model</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>27</GroupNumber>
+      <FileNumber>92</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\amcbldc\application\src\model-based-design\thermal-model\thermal_model.cpp</PathWithFileName>
+      <FilenameWithoutPath>thermal_model.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvprojx
@@ -1009,6 +1009,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX.cpp</FilePath>
             </File>
+            <File>
+              <FileName>SupervisorFSM_RX_data.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1078,6 +1083,16 @@
               <FileName>AMC_BLDC.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\amcbldc\application\src\model-based-design\amc-bldc\AMC_BLDC.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::thermal-model</GroupName>
+          <Files>
+            <File>
+              <FileName>thermal_model.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\amcbldc\application\src\model-based-design\thermal-model\thermal_model.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -1417,7 +1432,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMC2C STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\hw;..\..\..\..\embot\os;..\..\..\..\embot\app;..\..\..\..\embot\app;..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\embot\prot\can;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\bsp;..\..\..\..\embot\app\eth;..\..\..\..\embot\app\bldc;..\src\app-board-amc2c;..\..\..\amcbldc\application\src\model-based-design\sharedutils;..\..\..\amcbldc\application\src\model-based-design\can-decoder;..\..\..\amcbldc\application\src\model-based-design\can-encoder;..\..\..\amcbldc\application\src\model-based-design\supervisor-rx;..\..\..\amcbldc\application\src\model-based-design\supervisor-tx;..\..\..\amcbldc\application\src\model-based-design\control-outer;..\..\..\amcbldc\application\src\model-based-design\control-foc;..\..\..\amcbldc\application\src\model-based-design\estimator;..\..\..\amcbldc\application\src\model-based-design\amc-bldc;..\..\..\amcbldc\application\src\model-based-design\filter-current;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include;..\..\bsp\motorhal</IncludePath>
+              <IncludePath>..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\hw;..\..\..\..\embot\os;..\..\..\..\embot\app;..\..\..\..\embot\app;..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\embot\prot\can;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\bsp;..\..\..\..\embot\app\eth;..\..\..\..\embot\app\bldc;..\src\app-board-amc2c;..\..\..\amcbldc\application\src\model-based-design\sharedutils;..\..\..\amcbldc\application\src\model-based-design\can-decoder;..\..\..\amcbldc\application\src\model-based-design\can-encoder;..\..\..\amcbldc\application\src\model-based-design\supervisor-rx;..\..\..\amcbldc\application\src\model-based-design\supervisor-tx;..\..\..\amcbldc\application\src\model-based-design\control-outer;..\..\..\amcbldc\application\src\model-based-design\control-foc;..\..\..\amcbldc\application\src\model-based-design\estimator;..\..\..\amcbldc\application\src\model-based-design\amc-bldc;..\..\..\amcbldc\application\src\model-based-design\filter-current;..\..\..\amcbldc\application\src\model-based-design\thermal-model;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include;..\..\bsp\motorhal</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -2188,6 +2203,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX.cpp</FilePath>
             </File>
+            <File>
+              <FileName>SupervisorFSM_RX_data.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2257,6 +2277,16 @@
               <FileName>AMC_BLDC.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\amcbldc\application\src\model-based-design\amc-bldc\AMC_BLDC.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::thermal-model</GroupName>
+          <Files>
+            <File>
+              <FileName>thermal_model.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\amcbldc\application\src\model-based-design\thermal-model\thermal_model.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -3316,6 +3346,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX.cpp</FilePath>
             </File>
+            <File>
+              <FileName>SupervisorFSM_RX_data.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\amcbldc\application\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -3385,6 +3420,16 @@
               <FileName>AMC_BLDC.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\amcbldc\application\src\model-based-design\amc-bldc\AMC_BLDC.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::thermal-model</GroupName>
+          <Files>
+            <File>
+              <FileName>thermal_model.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\amcbldc\application\src\model-based-design\thermal-model\thermal_model.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.cpp
@@ -458,7 +458,21 @@ bool embot::app::board::amc2c::theMBD::Impl::tick(const std::vector<embot::prot:
     // Model Step Function (1 ms)
     // -----------------------------------------------------------------------------
     
-    AMC_BLDC_step_Time();
+    AMC_BLDC_step_Time_1ms();
+    
+
+    // -----------------------------------------------------------------------------
+    // Thermal Model Step Function (10 ms)
+    // -----------------------------------------------------------------------------
+    
+    static uint8_t thermal_model_counter = 0;
+
+    if(thermal_model_counter % 10 == 0)
+    {
+        AMC_BLDC_step_Time_10ms();
+        thermal_model_counter = 0;
+    }
+    thermal_model_counter++;
     
     
     // get any out can frame

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/proj/amcbldc-application2.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/proj/amcbldc-application2.uvoptx
@@ -334,7 +334,7 @@
         <bEvRecOn>1</bEvRecOn>
         <bSchkAxf>0</bSchkAxf>
         <bTchkAxf>0</bTchkAxf>
-        <nTsel>1</nTsel>
+        <nTsel>0</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -345,7 +345,7 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile></tIfile>
-        <pMon>BIN\ULP2CM3.DLL</pMon>
+        <pMon>BIN\UL2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
         <SetRegEntry>
@@ -381,7 +381,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>UL2CM3</Key>
-          <Name>UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512 -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM))</Name>
+          <Name>-UAny -O206 -S8 -C0 -P00 -N00("") -D00(00000000) -L00(0) -TO65555 -TC168000000 -TT10000000 -TP21 -TDS808F -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC1000 -FN1 -FF0STM32G47x-8x_512.FLM -FS08000000 -FL080000 -FP0($$Device:STM32G474QETx$CMSIS\Flash\STM32G47x-8x_512.FLM)</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
       <Breakpoint/>
@@ -453,7 +453,7 @@
         <EnableFlashSeq>1</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
-        <DbgClock>50000000</DbgClock>
+        <DbgClock>10000000</DbgClock>
       </DebugDescription>
     </TargetOption>
   </Target>
@@ -480,7 +480,7 @@
 
   <Group>
     <GroupName>embot::app::board::amcbldc</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -592,7 +592,7 @@
 
   <Group>
     <GroupName>embot::app::application</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1508,7 +1508,7 @@
 
   <Group>
     <GroupName>mbd::supervisor-rx</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1524,6 +1524,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>76</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</PathWithFileName>
+      <FilenameWithoutPath>SupervisorFSM_RX_data.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -1534,7 +1546,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>76</FileNumber>
+      <FileNumber>77</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1554,7 +1566,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <FileNumber>78</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1574,7 +1586,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>79</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1586,7 +1598,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1598,7 +1610,7 @@
     </File>
     <File>
       <GroupNumber>24</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>81</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1618,7 +1630,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>25</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1638,7 +1650,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>26</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1658,13 +1670,33 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>27</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\src\model-based-design\amc-bldc\AMC_BLDC.cpp</PathWithFileName>
       <FilenameWithoutPath>AMC_BLDC.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>mbd::thermal-model</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>28</GroupNumber>
+      <FileNumber>85</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\model-based-design\thermal-model\thermal_model.cpp</PathWithFileName>
+      <FilenameWithoutPath>thermal_model.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/proj/amcbldc-application2.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/proj/amcbldc-application2.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.2.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -186,6 +186,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1066,6 +1067,11 @@
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\supervisor-rx\SupervisorFSM_RX.cpp</FilePath>
             </File>
+            <File>
+              <FileName>SupervisorFSM_RX_data.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1135,6 +1141,16 @@
               <FileName>AMC_BLDC.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\amc-bldc\AMC_BLDC.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::thermal-model</GroupName>
+          <Files>
+            <File>
+              <FileName>thermal_model.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\thermal-model\thermal_model.cpp</FilePath>
             </File>
           </Files>
         </Group>
@@ -1216,14 +1232,14 @@
       <TargetName>amcbldc-app-motorhal2</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6160000::V6.16::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32G474QETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32G4xx_DFP.1.2.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32G4xx_DFP.1.5.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IROM(0x08000000,0x00080000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -1392,6 +1408,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -1545,7 +1562,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal -DEMBOT_AMCBLDC_APP05</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMCBLDC STM32HAL_DRIVER_V122</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\bsp;..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\embot\app;..\..\..\..\embot\i2h;..\..\..\..\embot\hw;..\..\..\..\embot\os;..\..\..\..\embot;..\..\..\..\embot\app\dsp;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include;..\..\..\..\libs\highlevel\abslayer\hal2\api;..\src\motorhal2;..\src\model-based-design\sharedutils;..\src\model-based-design\can-decoder;..\src\model-based-design\can-raw2struct;..\src\model-based-design\supervisor-rx;..\src\model-based-design\supervisor-tx;..\src\model-based-design\can-encoder;..\src\model-based-design\control-outer;..\src\model-based-design\control-foc;..\src\model-based-design\estimator;..\src\model-based-design\amc-bldc;..\src\model-based-design\filter-current;..\..\..\..\embot\app\bldc;..\src\app-board-amcbldc</IncludePath>
+              <IncludePath>..\..\bsp;..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\embot\app;..\..\..\..\embot\i2h;..\..\..\..\embot\hw;..\..\..\..\embot\os;..\..\..\..\embot;..\..\..\..\embot\app\dsp;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include;..\..\..\..\libs\highlevel\abslayer\hal2\api;..\src\motorhal2;..\src\model-based-design\sharedutils;..\src\model-based-design\can-decoder;..\src\model-based-design\can-raw2struct;..\src\model-based-design\supervisor-rx;..\src\model-based-design\supervisor-tx;..\src\model-based-design\can-encoder;..\src\model-based-design\control-outer;..\src\model-based-design\control-foc;..\src\model-based-design\estimator;..\src\model-based-design\amc-bldc;..\src\model-based-design\filter-current;..\..\..\..\embot\app\bldc;..\src\app-board-amcbldc;..\src\model-based-design\thermal-model</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -2323,6 +2340,11 @@
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\supervisor-rx\SupervisorFSM_RX.cpp</FilePath>
             </File>
+            <File>
+              <FileName>SupervisorFSM_RX_data.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\supervisor-rx\SupervisorFSM_RX_data.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2461,6 +2483,16 @@
               <FileName>AMC_BLDC.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\model-based-design\amc-bldc\AMC_BLDC.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::thermal-model</GroupName>
+          <Files>
+            <File>
+              <FileName>thermal_model.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\model-based-design\thermal-model\thermal_model.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
@@ -30,7 +30,7 @@ namespace embot::app::board::amcbldc::info {
     
     constexpr embot::prot::can::applicationInfo applInfo 
     {   
-        embot::prot::can::versionOfAPPLICATION {2, 0, 2},    
+        embot::prot::can::versionOfAPPLICATION {2, 0, 3},    
         embot::prot::can::versionOfCANPROTOCOL {2, 0}   
     };
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_theMBD.cpp
@@ -451,8 +451,22 @@ bool embot::app::board::amcbldc::theMBD::Impl::tick(const std::vector<embot::pro
     // Model Step Function (1 ms)
     // -----------------------------------------------------------------------------
     
-    AMC_BLDC_step_Time();
+    AMC_BLDC_step_Time_1ms();
     
+
+    // -----------------------------------------------------------------------------
+    // Thermal Model Step Function (10 ms)
+    // -----------------------------------------------------------------------------
+    
+		static uint8_t thermal_model_counter = 0;
+		
+		if(thermal_model_counter % 10 == 0)
+		{
+			AMC_BLDC_step_Time_10ms();
+		  thermal_model_counter = 0;
+		}
+		thermal_model_counter++;
+		
     
     // get any out can frame
     

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_theMBD.cpp
@@ -458,15 +458,14 @@ bool embot::app::board::amcbldc::theMBD::Impl::tick(const std::vector<embot::pro
     // Thermal Model Step Function (10 ms)
     // -----------------------------------------------------------------------------
     
-		static uint8_t thermal_model_counter = 0;
-		
-		if(thermal_model_counter % 10 == 0)
-		{
-			AMC_BLDC_step_Time_10ms();
-		  thermal_model_counter = 0;
-		}
-		thermal_model_counter++;
-		
+    static uint8_t thermal_model_counter = 0;
+
+    if(thermal_model_counter % 10 == 0)
+    {
+        AMC_BLDC_step_Time_10ms();
+        thermal_model_counter = 0;
+    }
+    thermal_model_counter++;
     
     // get any out can frame
     

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 6.1
+// Model version                  : 6.17
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:14 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:19 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,18 +20,15 @@
 #include "rtw_mutex.h"
 #include "rtwtypes.h"
 #include "AMC_BLDC_types.h"
-#define estimation_velocity_MDLREF_HIDE_CHILD_
+#include "thermal_model.h"
 #include "estimation_velocity.h"
-#define filter_current_MDLREF_HIDE_CHILD_
 #include "filter_current.h"
-#define control_foc_MDLREF_HIDE_CHILD_
 #include "control_foc.h"
+#include "control_outer.h"
 #define can_decoder_MDLREF_HIDE_CHILD_
 #include "can_decoder.h"
 #define can_encoder_MDLREF_HIDE_CHILD_
 #include "can_encoder.h"
-#define control_outer_MDLREF_HIDE_CHILD_
-#include "control_outer.h"
 #define SupervisorFSM_RX_MDLREF_HIDE_CHILD_
 #include "SupervisorFSM_RX.h"
 #define SupervisorFSM_TX_MDLREF_HIDE_CHILD_
@@ -55,11 +52,16 @@ ConfigurationParameters InitConfParams = {
     0.0F,
     0.0F,
     44.0F,
-    24.0F
+    24.0F,
+    25.9F,
+    271.0F,
+    16.0F,
+    797.5F
   },
 
   {
-    EstimationVelocityModes_MovingAverage
+    EstimationVelocityModes_MovingAverage,
+    0.9995F
   },
 
   {
@@ -122,8 +124,10 @@ ConfigurationParameters InitConfParams = {
     2.0F,
     5.0F,
     10.0F,
-    32000U
-  }
+    32000U,
+    70.0F
+  },
+  25.0F
 } ;                                    // Variable: InitConfParams
                                           //  Referenced by: '<S7>/SupervisorFSM_RX'
 
@@ -172,62 +176,71 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_p =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_hj;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_RD =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Ls;
   rtw_mutex_unlock();
-  AMC_BLDC_B.BusConversion_InsertedFor_FOC_a.flags =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_l[AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_p];
+  AMC_BLDC_B.BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1.flags =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Bu[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_RD];
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_m3 =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_mp;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_RD =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Ls;
   rtw_mutex_unlock();
-  AMC_BLDC_B.BusConversion_InsertedFor_FOC_a.configurationparameters =
-    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedF[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_m3];
+  AMC_BLDC_B.BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1.configurationparameters
+    =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Bu[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_RD];
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_ko =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_b2;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_RD =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Ls;
   rtw_mutex_unlock();
-  AMC_BLDC_B.BusConversion_InsertedFor_FOC_a.estimateddata =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_k[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_ko];
+  AMC_BLDC_B.BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1.estimateddata
+    =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Bu[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_RD];
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_mb =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_jj;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_RD =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Ls;
   rtw_mutex_unlock();
-  AMC_BLDC_B.BusConversion_InsertedFor_FOC_a.targets =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_m[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_mb];
+  AMC_BLDC_B.BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1.targets =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Bu[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_RD];
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_p5;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_RD =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Ls;
   rtw_mutex_unlock();
-  AMC_BLDC_B.BusConversion_InsertedFor_FOC_a.controlouteroutputs =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw];
+  AMC_BLDC_B.BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1.controlouteroutputs
+    =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Bu[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_RD];
 
   // ModelReference: '<Root>/FOC' incorporates:
   //   Inport generated from: '<Root>/In Bus Element5'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc(&AMC_BLDC_U.SensorsData_p,
-              &AMC_BLDC_B.BusConversion_InsertedFor_FOC_a,
-              &AMC_BLDC_Y.ControlOutputs_p);
+              &AMC_BLDC_B.BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1,
+              &AMC_BLDC_Y.ControlOutputs_p, &(AMC_BLDC_DW.FOC_InstanceData.rtb),
+              &(AMC_BLDC_DW.FOC_InstanceData.rtdw),
+              &(AMC_BLDC_DW.FOC_InstanceData.rtzce));
 
   // RateTransition generated from: '<Root>/Adapter1' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element'
 
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_js + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_LstB +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_a) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RDBu)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -237,19 +250,23 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   rtw_mutex_unlock();
   switch (wrBufIdx) {
    case 0:
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_d = AMC_BLDC_Y.ControlOutputs_p;
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf0 =
+      AMC_BLDC_Y.ControlOutputs_p;
     break;
 
    case 1:
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_j2 = AMC_BLDC_Y.ControlOutputs_p;
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf1 =
+      AMC_BLDC_Y.ControlOutputs_p;
     break;
 
    case 2:
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_o = AMC_BLDC_Y.ControlOutputs_p;
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf2 =
+      AMC_BLDC_Y.ControlOutputs_p;
     break;
   }
 
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_js = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_LstB =
+    wrBufIdx;
 
   // End of RateTransition generated from: '<Root>/Adapter1'
 
@@ -257,12 +274,16 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   //   Inport generated from: '<Root>/In Bus Element5'
 
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_LstB +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Insert_pa) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RDBu)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -272,121 +293,122 @@ void AMC_BLDC_step_FOC(void)       // Sample time: [3.65714285714286E-5s, 0.0s]
   rtw_mutex_unlock();
   switch (wrBufIdx) {
    case 0:
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_e = AMC_BLDC_U.SensorsData_p;
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_e =
+      AMC_BLDC_U.SensorsData_p;
     break;
 
    case 1:
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_c = AMC_BLDC_U.SensorsData_p;
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_c =
+      AMC_BLDC_U.SensorsData_p;
     break;
 
    case 2:
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_j = AMC_BLDC_U.SensorsData_p;
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_j =
+      AMC_BLDC_U.SensorsData_p;
     break;
   }
 
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_LstB =
+    wrBufIdx;
 
   // End of RateTransition generated from: '<Root>/Adapter3'
 }
 
 // Model step function for TID2
-void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
+void AMC_BLDC_step_Time_1ms(void)      // Sample time: [0.001s, 0.0s]
 {
   // local block i/o variables
   Targets rtb_SupervisorFSM_RX_o2;
   ControlOuterOutputs rtb_OuterControl;
   BUS_STATUS_TX rtb_SupervisorFSM_TX_o2;
-  ControlOutputs rtb_BusConversion_InsertedFor_F;
-  MotorCurrent rtb_Filter_Current;
   int8_T wrBufIdx;
 
-  // RateTransition generated from: '<Root>/Adapter1'
-  rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_a =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Insert_js;
-  rtw_mutex_unlock();
-  switch (AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_a) {
-   case 0:
-    // RateTransition generated from: '<Root>/Adapter1'
-    AMC_BLDC_B.RTBInsertedForAdapter_Inserte_a =
-      AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_d;
-    break;
-
-   case 1:
-    // RateTransition generated from: '<Root>/Adapter1'
-    AMC_BLDC_B.RTBInsertedForAdapter_Inserte_a =
-      AMC_BLDC_DW.RTBInsertedForAdapter_Insert_j2;
-    break;
-
-   case 2:
-    // RateTransition generated from: '<Root>/Adapter1'
-    AMC_BLDC_B.RTBInsertedForAdapter_Inserte_a =
-      AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_o;
-    break;
-  }
-
-  // End of RateTransition generated from: '<Root>/Adapter1'
-
-  // BusCreator generated from: '<S5>/Filter_Current'
-  rtb_Filter_Current.current = 0.0F;
-
-  // BusCreator generated from: '<S5>/Filter_Current'
-  rtb_BusConversion_InsertedFor_F.Vq = 0.0F;
-  rtb_BusConversion_InsertedFor_F.Vabc[0] = 0.0F;
-  rtb_BusConversion_InsertedFor_F.Vabc[1] = 0.0F;
-  rtb_BusConversion_InsertedFor_F.Vabc[2] = 0.0F;
-  rtb_BusConversion_InsertedFor_F.Iq_fbk =
-    AMC_BLDC_B.RTBInsertedForAdapter_Inserte_a.Iq_fbk;
-  rtb_BusConversion_InsertedFor_F.Id_fbk = rtb_Filter_Current;
+  // UnitDelay generated from: '<Root>/Adapter4'
+  AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0 =
+    AMC_BLDC_DW.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0;
 
   // RateTransition generated from: '<Root>/Adapter3'
   rtw_mutex_lock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_pa =
-    AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_g;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RDBu =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_LstB;
   rtw_mutex_unlock();
-  switch (AMC_BLDC_DW.RTBInsertedForAdapter_Insert_pa) {
+  switch
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RDBu) {
    case 0:
     // RateTransition generated from: '<Root>/Adapter3'
-    AMC_BLDC_B.RTBInsertedForAdapter_InsertedF =
-      AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_e;
+    AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_e;
     break;
 
    case 1:
     // RateTransition generated from: '<Root>/Adapter3'
-    AMC_BLDC_B.RTBInsertedForAdapter_InsertedF =
-      AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_c;
+    AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_c;
     break;
 
    case 2:
     // RateTransition generated from: '<Root>/Adapter3'
-    AMC_BLDC_B.RTBInsertedForAdapter_InsertedF =
-      AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_j;
+    AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_j;
     break;
   }
 
   // End of RateTransition generated from: '<Root>/Adapter3'
 
-  // UnitDelay generated from: '<Root>/Adapter4'
-  AMC_BLDC_B.ZOHBlockInsertedForAdapter_Inse =
-    AMC_BLDC_DW.ZOHBlockInsertedForAdapter_Inse;
-
   // ModelReference: '<S5>/Estimation_Velocity'
-  estimation_velocity(&AMC_BLDC_B.RTBInsertedForAdapter_InsertedF,
-                      &AMC_BLDC_B.ZOHBlockInsertedForAdapter_Inse,
-                      &AMC_BLDC_Y.EstimatedData_p.jointvelocities);
+  estimation_velocity
+    (&AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0,
+     &AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0,
+     &AMC_BLDC_Y.EstimatedData_p.jointvelocities,
+     &(AMC_BLDC_DW.Estimation_Velocity_InstanceData.rtdw));
+
+  // RateTransition generated from: '<Root>/Adapter1'
+  rtw_mutex_lock();
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RDBu =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_LstB;
+  rtw_mutex_unlock();
+  switch
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RDBu) {
+   case 0:
+    // RateTransition generated from: '<Root>/Adapter1'
+    AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf0;
+    break;
+
+   case 1:
+    // RateTransition generated from: '<Root>/Adapter1'
+    AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf1;
+    break;
+
+   case 2:
+    // RateTransition generated from: '<Root>/Adapter1'
+    AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf2;
+    break;
+  }
+
+  // End of RateTransition generated from: '<Root>/Adapter1'
 
   // ModelReference: '<S5>/Filter_Current'
-  filter_current(&rtb_BusConversion_InsertedFor_F, &rtb_Filter_Current);
+  filter_current
+    (&AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0,
+     &AMC_BLDC_Y.EstimatedData_p.Iq_filtered,
+     &(AMC_BLDC_DW.Filter_Current_InstanceData.rtdw));
 
-  // BusCreator: '<S9>/Bus Creator' incorporates:
-  //   Outport generated from: '<Root>/Out Bus Element2'
-
-  AMC_BLDC_Y.EstimatedData_p.Iq_filtered = rtb_Filter_Current;
+  // RateTransition generated from: '<S5>/Adapter1'
+  rtw_mutex_lock();
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RD_a =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Ls_j;
+  rtw_mutex_unlock();
+  AMC_BLDC_Y.EstimatedData_p.motor_temperature =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RD_a];
 
   // ModelReference: '<S6>/CAN_Decoder' incorporates:
   //   Inport generated from: '<Root>/In Bus Element2'
 
-  can_decoder(&AMC_BLDC_U.PacketsRx, &AMC_BLDC_B.ZOHBlockInsertedForAdapter_Inse,
+  can_decoder(&AMC_BLDC_U.PacketsRx,
+              &AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0,
               &AMC_BLDC_B.CAN_Decoder_o1, &AMC_BLDC_B.CAN_Decoder_o2,
               &AMC_BLDC_B.CAN_Decoder_o3);
 
@@ -396,29 +418,31 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
   //   Outport generated from: '<Root>/Out Bus Element2'
   //   Outport generated from: '<Root>/Out Bus Element4'
 
-  SupervisorFSM_RX(&AMC_BLDC_B.RTBInsertedForAdapter_InsertedF,
-                   &AMC_BLDC_U.ExternalFlags_p,
-                   &AMC_BLDC_B.RTBInsertedForAdapter_Inserte_a,
-                   &AMC_BLDC_B.CAN_Decoder_o1, &AMC_BLDC_Y.EstimatedData_p,
-                   &AMC_BLDC_B.CAN_Decoder_o2, &AMC_BLDC_B.CAN_Decoder_o3,
-                   &AMC_BLDC_Y.Flags_p, &rtb_SupervisorFSM_RX_o2,
-                   &AMC_BLDC_Y.ConfigurationParameters_p);
+  SupervisorFSM_RX
+    (&AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0,
+     &AMC_BLDC_U.ExternalFlags_p,
+     &AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0,
+     &AMC_BLDC_B.CAN_Decoder_o1, &AMC_BLDC_Y.EstimatedData_p,
+     &AMC_BLDC_B.CAN_Decoder_o2, &AMC_BLDC_B.CAN_Decoder_o3, &AMC_BLDC_Y.Flags_p,
+     &rtb_SupervisorFSM_RX_o2, &AMC_BLDC_Y.ConfigurationParameters_p);
 
   // ModelReference: '<S7>/SupervisorFSM_TX' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element3'
   //   Outport generated from: '<Root>/Out Bus Element2'
   //   Outport generated from: '<Root>/Out Bus Element4'
 
-  SupervisorFSM_TX(&AMC_BLDC_B.RTBInsertedForAdapter_InsertedF,
-                   &AMC_BLDC_Y.EstimatedData_p, &AMC_BLDC_Y.Flags_p,
-                   &AMC_BLDC_B.RTBInsertedForAdapter_Inserte_a,
-                   &AMC_BLDC_B.MessagesTx, &rtb_SupervisorFSM_TX_o2);
+  SupervisorFSM_TX
+    (&AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0,
+     &AMC_BLDC_Y.EstimatedData_p, &AMC_BLDC_Y.Flags_p,
+     &AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0,
+     &AMC_BLDC_B.MessagesTx, &rtb_SupervisorFSM_TX_o2);
 
   // ModelReference: '<S6>/CAN_Encoder' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element1'
 
   can_encoder(&AMC_BLDC_B.MessagesTx, &rtb_SupervisorFSM_TX_o2,
-              &AMC_BLDC_B.ZOHBlockInsertedForAdapter_Inse, &AMC_BLDC_Y.PacketsTx);
+              &AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0,
+              &AMC_BLDC_Y.PacketsTx);
 
   // ModelReference: '<Root>/OuterControl' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element3'
@@ -427,17 +451,24 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
 
   control_outer(&AMC_BLDC_Y.Flags_p, &AMC_BLDC_Y.ConfigurationParameters_p,
                 &rtb_SupervisorFSM_RX_o2,
-                &AMC_BLDC_B.RTBInsertedForAdapter_InsertedF,
-                &AMC_BLDC_Y.EstimatedData_p, &rtb_OuterControl);
+                &AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0,
+                &AMC_BLDC_Y.EstimatedData_p, &rtb_OuterControl,
+                &(AMC_BLDC_DW.OuterControl_InstanceData.rtb),
+                &(AMC_BLDC_DW.OuterControl_InstanceData.rtdw),
+                &(AMC_BLDC_DW.OuterControl_InstanceData.rtzce));
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_p5 + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Ls +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Insert_bw) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_RD)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -445,19 +476,25 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
   }
 
   rtw_mutex_unlock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_i[wrBufIdx] = rtb_OuterControl;
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_p5 = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Bu[wrBufIdx]
+    = rtb_OuterControl;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Ls =
+    wrBufIdx;
 
   // RateTransition generated from: '<Root>/Adapter2' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element4'
 
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_hj + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Ls +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_p) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_RD)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -465,19 +502,25 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
   }
 
   rtw_mutex_unlock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_l[wrBufIdx] = AMC_BLDC_Y.Flags_p;
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_hj = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Bu[wrBufIdx]
+    = AMC_BLDC_Y.Flags_p;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Ls =
+    wrBufIdx;
 
   // RateTransition generated from: '<Root>/Adapter2' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element3'
 
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_mp + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Ls +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Insert_m3) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_RD)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -485,18 +528,23 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
   }
 
   rtw_mutex_unlock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedF[wrBufIdx] =
-    AMC_BLDC_Y.ConfigurationParameters_p;
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_mp = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Bu[wrBufIdx]
+    = AMC_BLDC_Y.ConfigurationParameters_p;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Ls =
+    wrBufIdx;
 
   // RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_jj + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Ls +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Insert_mb) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_RD)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -504,20 +552,25 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
   }
 
   rtw_mutex_unlock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_m[wrBufIdx] =
-    rtb_SupervisorFSM_RX_o2;
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_jj = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Bu[wrBufIdx]
+    = rtb_SupervisorFSM_RX_o2;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Ls =
+    wrBufIdx;
 
   // RateTransition generated from: '<Root>/Adapter2' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element2'
 
   rtw_mutex_lock();
-  wrBufIdx = static_cast<int8_T>(AMC_BLDC_DW.RTBInsertedForAdapter_Insert_b2 + 1);
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Ls +
+     1);
   if (wrBufIdx == 3) {
     wrBufIdx = 0;
   }
 
-  if (wrBufIdx == AMC_BLDC_DW.RTBInsertedForAdapter_Insert_ko) {
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_RD)
+  {
     wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
     if (wrBufIdx == 3) {
       wrBufIdx = 0;
@@ -525,28 +578,215 @@ void AMC_BLDC_step_Time(void)          // Sample time: [0.001s, 0.0s]
   }
 
   rtw_mutex_unlock();
-  AMC_BLDC_DW.RTBInsertedForAdapter_Inserte_k[wrBufIdx] =
-    AMC_BLDC_Y.EstimatedData_p;
-  AMC_BLDC_DW.RTBInsertedForAdapter_Insert_b2 = wrBufIdx;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Bu[wrBufIdx]
+    = AMC_BLDC_Y.EstimatedData_p;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Ls =
+    wrBufIdx;
+
+  // RateTransition generated from: '<S5>/Adapter3'
+  rtw_mutex_lock();
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Ls_g +
+     1);
+  if (wrBufIdx == 3) {
+    wrBufIdx = 0;
+  }
+
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RD_p)
+  {
+    wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
+    if (wrBufIdx == 3) {
+      wrBufIdx = 0;
+    }
+  }
+
+  rtw_mutex_unlock();
+  switch (wrBufIdx) {
+   case 0:
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf0 =
+      AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0;
+    break;
+
+   case 1:
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf1 =
+      AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0;
+    break;
+
+   case 2:
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf2 =
+      AMC_BLDC_B.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0;
+    break;
+  }
+
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Ls_g =
+    wrBufIdx;
+
+  // End of RateTransition generated from: '<S5>/Adapter3'
+
+  // RateTransition generated from: '<S5>/Adapter'
+  rtw_mutex_lock();
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_LstBu +
+     1);
+  if (wrBufIdx == 3) {
+    wrBufIdx = 0;
+  }
+
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_RDBuf)
+  {
+    wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
+    if (wrBufIdx == 3) {
+      wrBufIdx = 0;
+    }
+  }
+
+  rtw_mutex_unlock();
+  switch (wrBufIdx) {
+   case 0:
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf0 =
+      AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0;
+    break;
+
+   case 1:
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf1 =
+      AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0;
+    break;
+
+   case 2:
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf2 =
+      AMC_BLDC_B.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0;
+    break;
+  }
+
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_LstBu =
+    wrBufIdx;
+
+  // End of RateTransition generated from: '<S5>/Adapter'
 
   // Update for UnitDelay generated from: '<Root>/Adapter4' incorporates:
   //   Outport generated from: '<Root>/Out Bus Element3'
 
-  AMC_BLDC_DW.ZOHBlockInsertedForAdapter_Inse =
+  AMC_BLDC_DW.ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0 =
     AMC_BLDC_Y.ConfigurationParameters_p;
+}
+
+// Model step function for TID3
+void AMC_BLDC_step_Time_10ms(void)     // Sample time: [0.01s, 0.0s]
+{
+  // local block i/o variables
+  MotorTemperature rtb_Estimation_Temperature;
+  ConfigurationParameters
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0;
+  ControlOutputs rtb_RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0;
+  int8_T wrBufIdx;
+
+  // RateTransition generated from: '<S5>/Adapter'
+  rtw_mutex_lock();
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_RDBuf =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_LstBu;
+  rtw_mutex_unlock();
+  switch
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_RDBuf) {
+   case 0:
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf0;
+    break;
+
+   case 1:
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf1;
+    break;
+
+   case 2:
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf2;
+    break;
+  }
+
+  // End of RateTransition generated from: '<S5>/Adapter'
+
+  // RateTransition generated from: '<S5>/Adapter3'
+  rtw_mutex_lock();
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RD_p =
+    AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Ls_g;
+  rtw_mutex_unlock();
+  switch
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RD_p) {
+   case 0:
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf0;
+    break;
+
+   case 1:
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf1;
+    break;
+
+   case 2:
+    rtb_RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0 =
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf2;
+    break;
+  }
+
+  // End of RateTransition generated from: '<S5>/Adapter3'
+
+  // ModelReference: '<S5>/Estimation_Temperature'
+  thermal_model(&rtb_RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0,
+                &rtb_RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0,
+                &rtb_Estimation_Temperature,
+                &(AMC_BLDC_DW.Estimation_Temperature_InstanceData.rtdw));
+
+  // RateTransition generated from: '<S5>/Adapter1'
+  rtw_mutex_lock();
+  wrBufIdx = static_cast<int8_T>
+    (AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Ls_j +
+     1);
+  if (wrBufIdx == 3) {
+    wrBufIdx = 0;
+  }
+
+  if (wrBufIdx ==
+      AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RD_a)
+  {
+    wrBufIdx = static_cast<int8_T>(wrBufIdx + 1);
+    if (wrBufIdx == 3) {
+      wrBufIdx = 0;
+    }
+  }
+
+  rtw_mutex_unlock();
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf[wrBufIdx]
+    = rtb_Estimation_Temperature;
+  AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Ls_j =
+    wrBufIdx;
+
+  // End of RateTransition generated from: '<S5>/Adapter1'
 }
 
 // Model initialize function
 void AMC_BLDC_initialize(void)
 {
+  // Model Initialize function for ModelReference Block: '<S5>/Estimation_Temperature' 
+  thermal_model_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M),
+    &(AMC_BLDC_DW.Estimation_Temperature_InstanceData.rtm),
+    &(AMC_BLDC_DW.Estimation_Temperature_InstanceData.rtdw));
+
   // Model Initialize function for ModelReference Block: '<S5>/Estimation_Velocity' 
-  estimation_velocity_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
+  estimation_velocity_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M),
+    &(AMC_BLDC_DW.Estimation_Velocity_InstanceData.rtm),
+    &(AMC_BLDC_DW.Estimation_Velocity_InstanceData.rtdw));
 
   // Model Initialize function for ModelReference Block: '<S5>/Filter_Current'
-  filter_current_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
+  filter_current_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M),
+    &(AMC_BLDC_DW.Filter_Current_InstanceData.rtm),
+    &(AMC_BLDC_DW.Filter_Current_InstanceData.rtdw));
 
   // Model Initialize function for ModelReference Block: '<Root>/FOC'
-  control_foc_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
+  control_foc_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M),
+    &(AMC_BLDC_DW.FOC_InstanceData.rtm), &(AMC_BLDC_DW.FOC_InstanceData.rtb),
+    &(AMC_BLDC_DW.FOC_InstanceData.rtdw), &(AMC_BLDC_DW.FOC_InstanceData.rtzce));
 
   // Model Initialize function for ModelReference Block: '<S6>/CAN_Decoder'
   can_decoder_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
@@ -555,7 +795,11 @@ void AMC_BLDC_initialize(void)
   can_encoder_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
 
   // Model Initialize function for ModelReference Block: '<Root>/OuterControl'
-  control_outer_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
+  control_outer_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M),
+    &(AMC_BLDC_DW.OuterControl_InstanceData.rtm),
+    &(AMC_BLDC_DW.OuterControl_InstanceData.rtb),
+    &(AMC_BLDC_DW.OuterControl_InstanceData.rtdw),
+    &(AMC_BLDC_DW.OuterControl_InstanceData.rtzce));
 
   // Model Initialize function for ModelReference Block: '<S7>/SupervisorFSM_RX' 
   SupervisorFSM_RX_initialize(rtmGetErrorStatusPointer(AMC_BLDC_M));
@@ -584,28 +828,34 @@ void AMC_BLDC_initialize(void)
   // Start for RateTransition generated from: '<Root>/Adapter3'
   rtw_mutex_init();
 
+  // Start for RateTransition generated from: '<S5>/Adapter1'
+  rtw_mutex_init();
+
+  // Start for RateTransition generated from: '<S5>/Adapter3'
+  rtw_mutex_init();
+
+  // Start for RateTransition generated from: '<S5>/Adapter'
+  rtw_mutex_init();
+
+  // SystemInitialize for ModelReference: '<S5>/Estimation_Temperature'
+  thermal_model_Init(&(AMC_BLDC_DW.Estimation_Temperature_InstanceData.rtdw));
+
   // SystemInitialize for ModelReference: '<S5>/Estimation_Velocity'
-  estimation_velocity_Init();
+  estimation_velocity_Init(&(AMC_BLDC_DW.Estimation_Velocity_InstanceData.rtdw));
 
   // SystemInitialize for ModelReference: '<S5>/Filter_Current'
-  filter_current_Init();
+  filter_current_Init(&(AMC_BLDC_DW.Filter_Current_InstanceData.rtdw));
 
-  // SystemInitialize for ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
-  //   Outport generated from: '<Root>/Out Bus Element'
-
-  control_foc_Init();
+  // SystemInitialize for ModelReference: '<Root>/FOC'
+  control_foc_Init(&(AMC_BLDC_DW.FOC_InstanceData.rtdw));
 
   // SystemInitialize for ModelReference: '<S6>/CAN_Decoder' incorporates:
   //   Inport generated from: '<Root>/In Bus Element2'
 
   can_decoder_Init();
 
-  // SystemInitialize for ModelReference: '<Root>/OuterControl' incorporates:
-  //   Outport generated from: '<Root>/Out Bus Element3'
-  //   Outport generated from: '<Root>/Out Bus Element4'
-
-  control_outer_Init();
+  // SystemInitialize for ModelReference: '<Root>/OuterControl'
+  control_outer_Init(&(AMC_BLDC_DW.OuterControl_InstanceData.rtdw));
 
   // SystemInitialize for ModelReference: '<S7>/SupervisorFSM_RX' incorporates:
   //   Inport generated from: '<Root>/In Bus Element'
@@ -621,12 +871,8 @@ void AMC_BLDC_initialize(void)
 
   SupervisorFSM_TX_Init(&AMC_BLDC_B.MessagesTx);
 
-  // Enable for ModelReference: '<Root>/OuterControl' incorporates:
-  //   Outport generated from: '<Root>/Out Bus Element3'
-  //   Outport generated from: '<Root>/Out Bus Element2'
-  //   Outport generated from: '<Root>/Out Bus Element4'
-
-  control_outer_Enable();
+  // Enable for ModelReference: '<Root>/OuterControl'
+  control_outer_Enable(&(AMC_BLDC_DW.OuterControl_InstanceData.rtdw));
 }
 
 // Model terminate function
@@ -647,6 +893,9 @@ void AMC_BLDC_terminate(void)
   // Terminate for RateTransition generated from: '<Root>/Adapter2'
   rtw_mutex_destroy();
 
+  // Terminate for ModelReference: '<Root>/FOC'
+  control_foc_Term(&(AMC_BLDC_DW.FOC_InstanceData.rtdw));
+
   // Terminate for RateTransition generated from: '<Root>/Adapter1'
   rtw_mutex_destroy();
 
@@ -654,7 +903,16 @@ void AMC_BLDC_terminate(void)
   rtw_mutex_destroy();
 
   // Terminate for ModelReference: '<S5>/Filter_Current'
-  filter_current_Term();
+  filter_current_Term(&(AMC_BLDC_DW.Filter_Current_InstanceData.rtdw));
+
+  // Terminate for RateTransition generated from: '<S5>/Adapter1'
+  rtw_mutex_destroy();
+
+  // Terminate for RateTransition generated from: '<S5>/Adapter3'
+  rtw_mutex_destroy();
+
+  // Terminate for RateTransition generated from: '<S5>/Adapter'
+  rtw_mutex_destroy();
 }
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 6.1
+// Model version                  : 6.17
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:14 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:19 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,11 @@
 #define RTW_HEADER_AMC_BLDC_h_
 #include "rtwtypes.h"
 #include "AMC_BLDC_types.h"
+#include "control_foc.h"
+#include "estimation_velocity.h"
+#include "filter_current.h"
+#include "control_outer.h"
+#include "thermal_model.h"
 #include <stddef.h>
 #include "zero_crossing_types.h"
 
@@ -46,51 +51,79 @@
 
 // Block signals (default storage)
 struct B_AMC_BLDC_T {
-  FOCSlowInputs BusConversion_InsertedFor_FOC_a;
+  FOCSlowInputs BusConversion_InsertedFor_FOC_at_inport_1_BusCreator1;
   BUS_MESSAGES_RX_MULTIPLE CAN_Decoder_o1;// '<S6>/CAN_Decoder'
-  ConfigurationParameters ZOHBlockInsertedForAdapter_Inse;// '<Root>/Adapter4'
+  ConfigurationParameters
+    ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0;// '<Root>/Adapter4' 
   BUS_MESSAGES_TX MessagesTx;          // '<S7>/SupervisorFSM_TX'
-  SensorsData RTBInsertedForAdapter_InsertedF;// '<Root>/Adapter3'
-  ControlOutputs RTBInsertedForAdapter_Inserte_a;// '<Root>/Adapter1'
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0;// '<Root>/Adapter1' 
+  SensorsData RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0;// '<Root>/Adapter3' 
   BUS_STATUS_RX_MULTIPLE CAN_Decoder_o2;// '<S6>/CAN_Decoder'
   BUS_CAN_RX_ERRORS_MULTIPLE CAN_Decoder_o3;// '<S6>/CAN_Decoder'
 };
 
 // Block states (default storage) for system '<Root>'
 struct DW_AMC_BLDC_T {
-  ConfigurationParameters ZOHBlockInsertedForAdapter_Inse;// synthesized block
-  ConfigurationParameters RTBInsertedForAdapter_InsertedF[3];// synthesized block 
-  SensorsData RTBInsertedForAdapter_Inserte_e;// synthesized block
-  SensorsData RTBInsertedForAdapter_Inserte_c;// synthesized block
-  SensorsData RTBInsertedForAdapter_Inserte_j;// synthesized block
-  Targets RTBInsertedForAdapter_Inserte_m[3];// synthesized block
-  ControlOutputs RTBInsertedForAdapter_Inserte_d;// synthesized block
-  ControlOutputs RTBInsertedForAdapter_Insert_j2;// synthesized block
-  ControlOutputs RTBInsertedForAdapter_Inserte_o;// synthesized block
-  ControlOuterOutputs RTBInsertedForAdapter_Inserte_i[3];// synthesized block
-  EstimatedData RTBInsertedForAdapter_Inserte_k[3];// synthesized block
-  Flags RTBInsertedForAdapter_Inserte_l[3];// synthesized block
-  void* RTBInsertedForAdapter_Insert_mf;// synthesized block
-  void* RTBInsertedForAdapter_Inserte_b;// synthesized block
-  void* RTBInsertedForAdapter_Inserte_f;// synthesized block
-  void* RTBInsertedForAdapter_Insert_ey;// synthesized block
-  void* RTBInsertedForAdapter_Insert_ci;// synthesized block
-  void* RTBInsertedForAdapter_Inserte_h;// synthesized block
-  void* RTBInsertedForAdapter_Insert_bz;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_hj;// synthesized block
-  int8_T RTBInsertedForAdapter_Inserte_p;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_mp;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_m3;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_b2;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_ko;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_jj;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_mb;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_p5;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_bw;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_js;// synthesized block
-  int8_T RTBInsertedForAdapter_Inserte_a;// synthesized block
-  int8_T RTBInsertedForAdapter_Inserte_g;// synthesized block
-  int8_T RTBInsertedForAdapter_Insert_pa;// synthesized block
+  ConfigurationParameters
+    ZOHBlockInsertedForAdapter_InsertedFor_Adapter4_at_outport_0;// synthesized block 
+  ConfigurationParameters
+    RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Bu[3];// synthesized block 
+  ConfigurationParameters
+    RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf0;// synthesized block 
+  ConfigurationParameters
+    RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf1;// synthesized block 
+  ConfigurationParameters
+    RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Buf2;// synthesized block 
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf0;// synthesized block 
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf1;// synthesized block 
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf2;// synthesized block 
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf0;// synthesized block 
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf1;// synthesized block 
+  ControlOutputs RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_Buf2;// synthesized block 
+  SensorsData RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_e;// synthesized block 
+  SensorsData RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_c;// synthesized block 
+  SensorsData RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Bu_j;// synthesized block 
+  Targets RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Bu[3];// synthesized block 
+  EstimatedData RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Bu[3];// synthesized block 
+  ControlOuterOutputs
+    RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Bu[3];// synthesized block 
+  Flags RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Bu[3];// synthesized block 
+  MotorTemperature RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Buf[3];// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_SE;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_SE;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_SE;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_SE;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_SE;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_SEMA;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_SEMA;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_SE_l;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_SE_b;// synthesized block 
+  void* RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_SEMAP;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_Ls;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_1_RD;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_Ls;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_2_RD;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_Ls;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_3_RD;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_Ls;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_4_RD;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Ls;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_RD;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_LstB;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RDBu;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_LstB;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RDBu;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_Ls_j;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter1_at_outport_0_RD_a;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_Ls_g;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter3_at_outport_0_RD_p;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_LstBu;// synthesized block 
+  int8_T RTBInsertedForAdapter_InsertedFor_Adapter_at_outport_0_RDBuf;// synthesized block 
+  MdlrefDW_control_foc_T FOC_InstanceData;// '<Root>/FOC'
+  MdlrefDW_estimation_velocity_T Estimation_Velocity_InstanceData;// '<S5>/Estimation_Velocity' 
+  MdlrefDW_filter_current_T Filter_Current_InstanceData;// '<S5>/Filter_Current' 
+  MdlrefDW_control_outer_T OuterControl_InstanceData;// '<Root>/OuterControl'
+  MdlrefDW_thermal_model_T Estimation_Temperature_InstanceData;// '<S5>/Estimation_Temperature' 
 };
 
 // External inputs (root inport signals with default storage)
@@ -120,7 +153,7 @@ struct tag_RTM_AMC_BLDC_T {
 
   struct {
     struct {
-      uint32_T TID[3];
+      uint32_T TID[4];
     } TaskCounters;
   } Timing;
 };
@@ -200,7 +233,8 @@ extern "C"
   extern void AMC_BLDC_initialize(void);
   extern void AMC_BLDC_step0(void);
   extern void AMC_BLDC_step_FOC(void);
-  extern void AMC_BLDC_step_Time(void);
+  extern void AMC_BLDC_step_Time_1ms(void);
+  extern void AMC_BLDC_step_Time_10ms(void);
   extern void AMC_BLDC_terminate(void);
 
 #ifdef __cplusplus
@@ -248,7 +282,9 @@ extern "C"
 //  '<S6>'   : 'AMC_BLDC/Messaging'
 //  '<S7>'   : 'AMC_BLDC/Supervision'
 //  '<S8>'   : 'AMC_BLDC/Estimation/Adapter'
-//  '<S9>'   : 'AMC_BLDC/Estimation/Mux'
+//  '<S9>'   : 'AMC_BLDC/Estimation/Adapter1'
+//  '<S10>'  : 'AMC_BLDC/Estimation/Adapter3'
+//  '<S11>'  : 'AMC_BLDC/Estimation/Mux'
 
 #endif                                 // RTW_HEADER_AMC_BLDC_h_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 6.1
+// Model version                  : 6.17
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:14 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:19 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 6.1
+// Model version                  : 6.17
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:14 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:19 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -100,6 +100,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T enable_thermal_protection;
 };
 
 #endif
@@ -125,6 +126,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -146,6 +151,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -217,6 +225,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -233,6 +244,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif
@@ -259,14 +271,30 @@ struct MotorCurrent
 
 #endif
 
+#ifndef DEFINED_TYPEDEF_FOR_MotorTemperature_
+#define DEFINED_TYPEDEF_FOR_MotorTemperature_
+
+struct MotorTemperature
+{
+  // motor temperature
+  real32_T temperature;
+};
+
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
 #define DEFINED_TYPEDEF_FOR_EstimatedData_
 
 struct EstimatedData
 {
-  // velocities
+  // velocity
   JointVelocities jointvelocities;
+
+  // filtered motor current
   MotorCurrent Iq_filtered;
+
+  // motor temperature
+  MotorTemperature motor_temperature;
 };
 
 #endif
@@ -340,6 +368,12 @@ struct ControlOutputs
 
   // direct current
   MotorCurrent Id_fbk;
+
+  // RMS of Iq
+  MotorCurrent Iq_rms;
+
+  // RMS of Id
+  MotorCurrent Id_rms;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:19 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:04 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -25,13 +25,13 @@
 #include "rtw_defines.h"
 
 // Named constants for Chart: '<S2>/Decoding Logic'
-const int32_T ca_event_ev_error_pck_malformed = 1;
-const int32_T can_d_event_ev_error_pck_not4us = 2;
 const int32_T can_decoder_CALL_EVENT = -1;
 const uint8_T can_decoder_IN_Event_Error = 1U;
 const uint8_T can_decoder_IN_Home = 1U;
 const uint8_T can_decoder_IN_Home_k = 2U;
-const int32_T event_ev_error_mode_unrecognize = 0;
+const int32_T can_decoder_event_ev_error_mode_unrecognized = 0;
+const int32_T can_decoder_event_ev_error_pck_malformed = 1;
+const int32_T can_decoder_event_ev_error_pck_not4us = 2;
 MdlrefDW_can_decoder_T can_decoder_MdlrefDW;
 
 // Block signals (default storage)
@@ -41,17 +41,17 @@ B_can_decoder_c_T can_decoder_B;
 DW_can_decoder_f_T can_decoder_DW;
 
 // Forward declaration for local functions
-static int32_T can_de_safe_cast_to_MCStreaming(int32_T input);
+static int32_T can_decoder_safe_cast_to_MCStreaming(int32_T input);
 static void can_decoder_ERROR_HANDLING(boolean_T rtu_pck_available,
   B_DecodingLogic_can_decoder_T *localB, DW_DecodingLogic_can_decoder_T *localDW);
 static int16_T can_decoder_merge_2bytes_signed(uint16_T bl, uint16_T bh);
-static boolean_T can_d_is_controlmode_recognized(int32_T mode);
-static int32_T can_safe_cast_to_MCControlModes(int32_T input);
-static uint16_T can_decod_merge_2bytes_unsigned(uint16_T bl, uint16_T bh);
+static boolean_T can_decoder_is_controlmode_recognized(int32_T mode);
+static int32_T can_decoder_safe_cast_to_MCControlModes(int32_T input);
+static uint16_T can_decoder_merge_2bytes_unsigned(uint16_T bl, uint16_T bh);
 
 // Forward declaration for local functions
-static CANClassTypes c_convert_to_enum_CANClassTypes(int32_T input);
-static int32_T can_de_safe_cast_to_MCStreaming(int32_T input)
+static CANClassTypes can_decoder_convert_to_enum_CANClassTypes(int32_T input);
+static int32_T can_decoder_safe_cast_to_MCStreaming(int32_T input)
 {
   int32_T output;
 
@@ -69,7 +69,7 @@ static int32_T can_de_safe_cast_to_MCStreaming(int32_T input)
 static void can_decoder_ERROR_HANDLING(boolean_T rtu_pck_available,
   B_DecodingLogic_can_decoder_T *localB, DW_DecodingLogic_can_decoder_T *localDW)
 {
-  boolean_T guard1 = false;
+  boolean_T guard1;
   guard1 = false;
   switch (localDW->is_ERROR_HANDLING) {
    case can_decoder_IN_Event_Error:
@@ -78,15 +78,16 @@ static void can_decoder_ERROR_HANDLING(boolean_T rtu_pck_available,
     break;
 
    case can_decoder_IN_Home_k:
-    if (localDW->sfEvent == can_d_event_ev_error_pck_not4us) {
+    if (localDW->sfEvent == can_decoder_event_ev_error_pck_not4us) {
       localB->error_type = CANErrorTypes_Packet_Not4Us;
       localDW->ev_errorEventCounter++;
       guard1 = true;
-    } else if (localDW->sfEvent == ca_event_ev_error_pck_malformed) {
+    } else if (localDW->sfEvent == can_decoder_event_ev_error_pck_malformed) {
       localB->error_type = CANErrorTypes_Packet_Malformed;
       localDW->ev_errorEventCounter++;
       guard1 = true;
-    } else if (localDW->sfEvent == event_ev_error_mode_unrecognize) {
+    } else if (localDW->sfEvent == can_decoder_event_ev_error_mode_unrecognized)
+    {
       localB->error_type = CANErrorTypes_Mode_Unrecognized;
       localDW->ev_errorEventCounter++;
       guard1 = true;
@@ -127,7 +128,7 @@ static int16_T can_decoder_merge_2bytes_signed(uint16_T bl, uint16_T bh)
 }
 
 // Function for Chart: '<S2>/Decoding Logic'
-static boolean_T can_d_is_controlmode_recognized(int32_T mode)
+static boolean_T can_decoder_is_controlmode_recognized(int32_T mode)
 {
   return (mode == static_cast<int32_T>(MCControlModes_Idle)) || (mode ==
     static_cast<int32_T>(MCControlModes_OpenLoop)) || (mode ==
@@ -135,7 +136,7 @@ static boolean_T can_d_is_controlmode_recognized(int32_T mode)
     static_cast<int32_T>(MCControlModes_Current));
 }
 
-static int32_T can_safe_cast_to_MCControlModes(int32_T input)
+static int32_T can_decoder_safe_cast_to_MCControlModes(int32_T input)
 {
   int32_T output;
 
@@ -151,7 +152,7 @@ static int32_T can_safe_cast_to_MCControlModes(int32_T input)
 }
 
 // Function for Chart: '<S2>/Decoding Logic'
-static uint16_T can_decod_merge_2bytes_unsigned(uint16_T bl, uint16_T bh)
+static uint16_T can_decoder_merge_2bytes_unsigned(uint16_T bl, uint16_T bh)
 {
   return static_cast<uint16_T>(static_cast<uint16_T>(bh << 8) | bl);
 }
@@ -197,7 +198,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
   real32_T c;
   int16_T tmp_merged;
   uint8_T idx;
-  boolean_T guard1 = false;
+  boolean_T guard1;
   boolean_T tmp;
   boolean_T tmp_0;
   localDW->sfEvent = can_decoder_CALL_EVENT;
@@ -229,17 +230,18 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           if (rtu_pck_input->PAYLOAD.CMD.OPC == static_cast<int32_T>
               (MCOPC_Set_Control_Mode)) {
             if (rtu_pck_input->PAYLOAD.LEN >= 2) {
-              if (can_d_is_controlmode_recognized(static_cast<int32_T>
+              if (can_decoder_is_controlmode_recognized(static_cast<int32_T>
                    (rtu_pck_input->PAYLOAD.ARG[1]))) {
                 localB->msg_set_control_mode.motor =
                   rtu_pck_input->PAYLOAD.CMD.M;
                 localB->msg_set_control_mode.mode = static_cast<MCControlModes>
-                  (can_safe_cast_to_MCControlModes(rtu_pck_input->PAYLOAD.ARG[1]));
+                  (can_decoder_safe_cast_to_MCControlModes
+                   (rtu_pck_input->PAYLOAD.ARG[1]));
                 localDW->cmd_processed = static_cast<uint16_T>
                   (localDW->cmd_processed + 1);
                 localDW->ev_set_control_modeEventCounter++;
               } else {
-                localDW->sfEvent = event_ev_error_mode_unrecognize;
+                localDW->sfEvent = can_decoder_event_ev_error_mode_unrecognized;
                 if (localDW->is_active_ERROR_HANDLING != 0U) {
                   can_decoder_ERROR_HANDLING(true, localB, localDW);
                 }
@@ -248,7 +250,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
                 localDW->is_SET_CONTROL_MODE = can_decoder_IN_Home;
               }
             } else {
-              localDW->sfEvent = ca_event_ev_error_pck_malformed;
+              localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
               if (localDW->is_active_ERROR_HANDLING != 0U) {
                 can_decoder_ERROR_HANDLING(true, localB, localDW);
               }
@@ -258,7 +260,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
             }
           }
         } else {
-          localDW->sfEvent = ca_event_ev_error_pck_malformed;
+          localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
           if (localDW->is_active_ERROR_HANDLING != 0U) {
             can_decoder_ERROR_HANDLING(true, localB, localDW);
           }
@@ -267,7 +269,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           localDW->is_SET_CONTROL_MODE = can_decoder_IN_Home;
         }
       } else {
-        localDW->sfEvent = can_d_event_ev_error_pck_not4us;
+        localDW->sfEvent = can_decoder_event_ev_error_pck_not4us;
         if (localDW->is_active_ERROR_HANDLING != 0U) {
           can_decoder_ERROR_HANDLING(true, localB, localDW);
         }
@@ -280,7 +282,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
     if ((localDW->is_active_DESIRED_TARGETS != 0U) &&
         (localDW->is_DESIRED_TARGETS == can_decoder_IN_Home) && ((!tmp) &&
          (rtu_pck_input->ID.CLS == CANClassTypes_Motor_Control_Streaming) &&
-         (can_de_safe_cast_to_MCStreaming(rtu_pck_input->ID.DST_TYP) ==
+         (can_decoder_safe_cast_to_MCStreaming(rtu_pck_input->ID.DST_TYP) ==
           static_cast<int32_T>(MCStreaming_Desired_Targets)))) {
       if ((rtu_pck_input->PAYLOAD.LEN == 8) && (rtu_CAN_ID_DST <= 4)) {
         idx = static_cast<uint8_T>((rtu_CAN_ID_DST - 1) << 1);
@@ -289,9 +291,9 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           (rtu_pck_input->PAYLOAD.ARG[idx + 1]));
         localB->msg_desired_targets.current = 0.001F * static_cast<real32_T>
           (tmp_merged);
-        localB->msg_desired_targets.voltage = static_cast<real32_T>(static_cast<
-          int16_T>(tmp_merged >> (rtu_CAN_VOLT_REF_SHIFT -
-          rtu_ConfigurationParameters->CurLoopPID.shift_factor))) /
+        localB->msg_desired_targets.voltage = static_cast<real32_T>
+          (static_cast<int16_T>(tmp_merged >> (rtu_CAN_VOLT_REF_SHIFT -
+             rtu_ConfigurationParameters->CurLoopPID.shift_factor))) /
           rtu_CAN_VOLT_REF_GAIN;
         localB->msg_desired_targets.velocity = 1000.0F * static_cast<real32_T>
           (tmp_merged) * CAN_ANGLE_ICUB2DEG;
@@ -299,7 +301,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           1);
         localDW->ev_desired_targetsEventCounter++;
       } else {
-        localDW->sfEvent = ca_event_ev_error_pck_malformed;
+        localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
         if (localDW->is_active_ERROR_HANDLING != 0U) {
           can_decoder_ERROR_HANDLING(true, localB, localDW);
         }
@@ -323,16 +325,16 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
                 static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[2]),
                 static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[3])));
               localB->msg_set_current_limit.peak = 0.001F * static_cast<real32_T>
-                (can_decod_merge_2bytes_unsigned(static_cast<uint16_T>
+                (can_decoder_merge_2bytes_unsigned(static_cast<uint16_T>
                   (rtu_pck_input->PAYLOAD.ARG[4]), static_cast<uint16_T>
                   (rtu_pck_input->PAYLOAD.ARG[5])));
               localB->msg_set_current_limit.overload = 0.001F *
-                static_cast<real32_T>(can_decod_merge_2bytes_unsigned(
+                static_cast<real32_T>(can_decoder_merge_2bytes_unsigned(
                 static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[6]),
                 static_cast<uint16_T>(rtu_pck_input->PAYLOAD.ARG[7])));
               localDW->cmd_processed = static_cast<uint16_T>
                 (localDW->cmd_processed + 1);
-              localDW->ev_set_current_limitEventCounte++;
+              localDW->ev_set_current_limitEventCounter++;
             } else {
               guard1 = true;
             }
@@ -374,7 +376,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           }
 
           if (guard1) {
-            localDW->sfEvent = ca_event_ev_error_pck_malformed;
+            localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
             if (localDW->is_active_ERROR_HANDLING != 0U) {
               can_decoder_ERROR_HANDLING(true, localB, localDW);
             }
@@ -383,7 +385,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
             localDW->is_SET_OPTIONS = can_decoder_IN_Home;
           }
         } else {
-          localDW->sfEvent = ca_event_ev_error_pck_malformed;
+          localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
           if (localDW->is_active_ERROR_HANDLING != 0U) {
             can_decoder_ERROR_HANDLING(true, localB, localDW);
           }
@@ -392,7 +394,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           localDW->is_SET_OPTIONS = can_decoder_IN_Home;
         }
       } else {
-        localDW->sfEvent = can_d_event_ev_error_pck_not4us;
+        localDW->sfEvent = can_decoder_event_ev_error_pck_not4us;
         if (localDW->is_active_ERROR_HANDLING != 0U) {
           can_decoder_ERROR_HANDLING(true, localB, localDW);
         }
@@ -437,7 +439,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
                 (localDW->cmd_processed + 1);
               localDW->ev_set_motor_configEventCounter++;
             } else {
-              localDW->sfEvent = ca_event_ev_error_pck_malformed;
+              localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
               if (localDW->is_active_ERROR_HANDLING != 0U) {
                 can_decoder_ERROR_HANDLING(true, localB, localDW);
               }
@@ -447,7 +449,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
             }
           }
         } else {
-          localDW->sfEvent = ca_event_ev_error_pck_malformed;
+          localDW->sfEvent = can_decoder_event_ev_error_pck_malformed;
           if (localDW->is_active_ERROR_HANDLING != 0U) {
             can_decoder_ERROR_HANDLING(true, localB, localDW);
           }
@@ -456,7 +458,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
           localDW->is_SET_MOTOR_CONFIG = can_decoder_IN_Home;
         }
       } else {
-        localDW->sfEvent = can_d_event_ev_error_pck_not4us;
+        localDW->sfEvent = can_decoder_event_ev_error_pck_not4us;
         if (localDW->is_active_ERROR_HANDLING != 0U) {
           can_decoder_ERROR_HANDLING(true, localB, localDW);
         }
@@ -482,9 +484,9 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
     localDW->ev_set_control_modeEventCounter--;
   }
 
-  if (localDW->ev_set_current_limitEventCounte > 0U) {
+  if (localDW->ev_set_current_limitEventCounter > 0U) {
     localB->ev_set_current_limit = !localB->ev_set_current_limit;
-    localDW->ev_set_current_limitEventCounte--;
+    localDW->ev_set_current_limitEventCounter--;
   }
 
   if (localDW->ev_desired_targetsEventCounter > 0U) {
@@ -509,7 +511,7 @@ void can_decoder_DecodingLogic(boolean_T rtu_pck_available, const
 }
 
 // Function for MATLAB Function: '<S3>/RAW2STRUCT Decoding Logic'
-static CANClassTypes c_convert_to_enum_CANClassTypes(int32_T input)
+static CANClassTypes can_decoder_convert_to_enum_CANClassTypes(int32_T input)
 {
   CANClassTypes output;
 
@@ -594,8 +596,8 @@ void can_decoder(const BUS_CAN_MULTIPLE *rtu_pck_rx_raw, const
       rtu_pck_rx_raw->packets[ForEach_itr].available;
     rtu_pck_rx_raw_0 = rtu_pck_rx_raw->packets[ForEach_itr].packet.ID;
     can_decoder_B.CoreSubsys[ForEach_itr].pck_rx_struct.packet.ID.CLS =
-      c_convert_to_enum_CANClassTypes(static_cast<int32_T>(static_cast<uint16_T>
-      (static_cast<uint32_T>(rtu_pck_rx_raw_0 & 1792) >> 8)));
+      can_decoder_convert_to_enum_CANClassTypes(static_cast<int32_T>(
+      static_cast<uint16_T>(static_cast<uint32_T>(rtu_pck_rx_raw_0 & 1792) >> 8)));
     can_decoder_B.CoreSubsys[ForEach_itr].pck_rx_struct.packet.ID.SRC =
       static_cast<uint8_T>(static_cast<uint32_T>(rtu_pck_rx_raw_0 & 240) >> 4);
     can_decoder_B.CoreSubsys[ForEach_itr].pck_rx_struct.packet.ID.DST_TYP =

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:19 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:04 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -50,7 +50,7 @@ struct DW_DecodingLogic_can_decoder_T {
   int32_T sfEvent;                     // '<S2>/Decoding Logic'
   uint32_T ev_errorEventCounter;       // '<S2>/Decoding Logic'
   uint32_T ev_set_control_modeEventCounter;// '<S2>/Decoding Logic'
-  uint32_T ev_set_current_limitEventCounte;// '<S2>/Decoding Logic'
+  uint32_T ev_set_current_limitEventCounter;// '<S2>/Decoding Logic'
   uint32_T ev_desired_targetsEventCounter;// '<S2>/Decoding Logic'
   uint32_T ev_set_current_pidEventCounter;// '<S2>/Decoding Logic'
   uint32_T ev_set_velocity_pidEventCounter;// '<S2>/Decoding Logic'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:19 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:04 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-decoder/can_decoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_decoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:19 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:04 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -101,6 +101,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -122,6 +126,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -193,6 +200,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -209,6 +219,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:26 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:14 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:26 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:14 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:26 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:14 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/can-encoder/can_encoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:26 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:14 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -171,6 +171,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -192,6 +196,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -263,6 +270,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -279,6 +289,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/FOCInnerLoop.cpp
@@ -7,18 +7,18 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
 // Code generation objectives: Unspecified
 // Validation result: Not run
 //
-#include "control_foc_types.h"
+#include "rtwtypes.h"
 #include "FOCInnerLoop.h"
-#include "control_foc.h"
+#include "control_foc_types.h"
 
 extern "C"
 {
@@ -27,20 +27,177 @@ extern "C"
 
 }
 
-#include "arm_math.h"
 #include <cmath>
+#include "mw_cmsis.h"
+#include "arm_math.h"
 #include "control_foc_private.h"
-#include "rtwtypes.h"
 #include "zero_crossing_types.h"
 
-// System initialize for atomic system: '<Root>/FOC inner loop'
-void FOCInnerLoop_Init(void)
+// Forward declaration for local functions
+static void control_foc_SystemCore_setup(dsp_simulink_MovingRMS_control_foc_T
+  *obj);
+static void control_foc_SystemCore_setup(dsp_simulink_MovingRMS_control_foc_T
+  *obj)
 {
+  real32_T val;
+  boolean_T flag;
+  obj->isSetupComplete = false;
+  obj->isInitialized = 1;
+  flag = (obj->isInitialized == 1);
+  if (flag) {
+    obj->TunablePropsChanged = true;
+  }
+
+  obj->ForgettingFactor = 0.0F;
+  obj->TunablePropsChanged = false;
+  obj->NumChannels = 1;
+  obj->FrameLength = 1;
+  if (obj->ForgettingFactor != 0.0F) {
+    val = obj->ForgettingFactor;
+  } else {
+    val = 2.22044605E-16F;
+  }
+
+  obj->_pobj0.isInitialized = 0;
+  obj->_pobj0.isInitialized = 0;
+  flag = (obj->_pobj0.isInitialized == 1);
+  if (flag) {
+    obj->_pobj0.TunablePropsChanged = true;
+  }
+
+  obj->_pobj0.ForgettingFactor = val;
+  obj->pStatistic = &obj->_pobj0;
+  obj->isSetupComplete = true;
+  obj->TunablePropsChanged = false;
+}
+
+// System initialize for atomic system:
+void control_foc_MovingRMS_Init(DW_MovingRMS_control_foc_T *localDW)
+{
+  c_dsp_internal_ExponentialMovingAverage_control_foc_T *obj;
+
+  // Start for MATLABSystem: '<S1>/Moving RMS'
+  localDW->obj.isInitialized = 0;
+  localDW->obj.NumChannels = -1;
+  localDW->obj.FrameLength = -1;
+  localDW->obj.matlabCodegenIsDeleted = false;
+  localDW->objisempty = true;
+  control_foc_SystemCore_setup(&localDW->obj);
+
+  // InitializeConditions for MATLABSystem: '<S1>/Moving RMS'
+  obj = localDW->obj.pStatistic;
+  if (obj->isInitialized == 1) {
+    obj->pwN = 1.0F;
+    obj->pmN = 0.0F;
+  }
+
+  // End of InitializeConditions for MATLABSystem: '<S1>/Moving RMS'
+}
+
+// Output and update for atomic system:
+void control_foc_MovingRMS(real32_T rtu_0, real32_T rtu_1,
+  B_MovingRMS_control_foc_T *localB, DW_MovingRMS_control_foc_T *localDW)
+{
+  c_dsp_internal_ExponentialMovingAverage_control_foc_T *obj;
+  real32_T a;
+  real32_T lambda;
+  real32_T pmLocal;
+  real32_T varargin_1;
+  boolean_T p;
+
+  // MATLABSystem: '<S1>/Moving RMS'
+  varargin_1 = localDW->obj.ForgettingFactor;
+  if ((varargin_1 == rtu_1) || (rtIsNaNF(varargin_1) && rtIsNaNF(rtu_1))) {
+  } else {
+    p = (localDW->obj.isInitialized == 1);
+    if (p) {
+      localDW->obj.TunablePropsChanged = true;
+    }
+
+    localDW->obj.ForgettingFactor = rtu_1;
+  }
+
+  if (localDW->obj.TunablePropsChanged) {
+    localDW->obj.TunablePropsChanged = false;
+    obj = localDW->obj.pStatistic;
+    p = (obj->isInitialized == 1);
+    if (p) {
+      obj->TunablePropsChanged = true;
+    }
+
+    localDW->obj.pStatistic->ForgettingFactor = localDW->obj.ForgettingFactor;
+  }
+
+  a = std::abs(rtu_0);
+  obj = localDW->obj.pStatistic;
+  if (obj->isInitialized != 1) {
+    obj->isSetupComplete = false;
+    obj->isInitialized = 1;
+    obj->pwN = 1.0F;
+    obj->pmN = 0.0F;
+    obj->plambda = obj->ForgettingFactor;
+    obj->isSetupComplete = true;
+    obj->TunablePropsChanged = false;
+    obj->pwN = 1.0F;
+    obj->pmN = 0.0F;
+  }
+
+  if (obj->TunablePropsChanged) {
+    obj->TunablePropsChanged = false;
+    obj->plambda = obj->ForgettingFactor;
+  }
+
+  varargin_1 = obj->pwN;
+  pmLocal = obj->pmN;
+  lambda = obj->plambda;
+  a = (1.0F - 1.0F / varargin_1) * pmLocal + 1.0F / varargin_1 * (a * a);
+  obj->pwN = lambda * varargin_1 + 1.0F;
+  obj->pmN = a;
+
+  // MATLABSystem: '<S1>/Moving RMS'
+  mw_arm_sqrt_f32(a, &localB->MovingRMS);
+}
+
+// Termination for atomic system:
+void control_foc_MovingRMS_Term(DW_MovingRMS_control_foc_T *localDW)
+{
+  c_dsp_internal_ExponentialMovingAverage_control_foc_T *obj;
+
+  // Terminate for MATLABSystem: '<S1>/Moving RMS'
+  if (!localDW->obj.matlabCodegenIsDeleted) {
+    localDW->obj.matlabCodegenIsDeleted = true;
+    if ((localDW->obj.isInitialized == 1) && localDW->obj.isSetupComplete) {
+      obj = localDW->obj.pStatistic;
+      if (obj->isInitialized == 1) {
+        obj->isInitialized = 2;
+      }
+
+      localDW->obj.NumChannels = -1;
+      localDW->obj.FrameLength = -1;
+    }
+  }
+
+  // End of Terminate for MATLABSystem: '<S1>/Moving RMS'
+}
+
+// System initialize for atomic system: '<Root>/FOC inner loop'
+void FOCInnerLoop_Init(DW_FOCInnerLoop_T *localDW)
+{
+  // InitializeConditions for DiscreteTransferFcn: '<S90>/Filter Differentiator TF' 
+  localDW->FilterDifferentiatorTF_states = 0.0F;
+
   // InitializeConditions for DiscreteIntegrator: '<S97>/Integrator'
-  control_foc_DW.Integrator_PrevResetState = 2;
+  localDW->Integrator_DSTATE = 0.0F;
+  localDW->Integrator_PrevResetState = 2;
+
+  // InitializeConditions for DiscreteTransferFcn: '<S38>/Filter Differentiator TF' 
+  localDW->FilterDifferentiatorTF_states_k = 0.0F;
 
   // InitializeConditions for DiscreteIntegrator: '<S45>/Integrator'
-  control_foc_DW.Integrator_PrevResetState_k = 2;
+  localDW->Integrator_DSTATE_o = 0.0F;
+  localDW->Integrator_PrevResetState_k = 2;
+  control_foc_MovingRMS_Init(&localDW->MovingRMS);
+  control_foc_MovingRMS_Init(&localDW->MovingRMS1);
 }
 
 // Outputs for atomic system: '<Root>/FOC inner loop'
@@ -48,12 +205,18 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
                   const SensorsData *rtu_Sensors, const EstimatedData
                   *rtu_Estimates, const Targets *rtu_Targets, const
                   ControlOuterOutputs *rtu_OuterOutputs, ControlOutputs
-                  *rty_FOCOutputs)
+                  *rty_FOCOutputs, B_FOCInnerLoop_T *localB, const
+                  ConstB_FOCInnerLoop_T *localC, DW_FOCInnerLoop_T *localDW,
+                  ZCE_FOCInnerLoop_T *localZCE)
 {
+  // local block i/o variables
+  real32_T rtb_Saturation2;
+  real32_T rtb_algDD_o1;
+  real32_T rtb_algDD_o2;
+  int32_T i;
   real32_T rtb_IaIbIc0[2];
   real32_T DProdOut;
   real32_T rtb_Add;
-  real32_T rtb_Diff;
   real32_T rtb_Product;
   real32_T rtb_SinCos_o1;
   real32_T rtb_SinCos_o2;
@@ -86,13 +249,13 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   Gain: '<S1>/Gain4'
   //   MinMax: '<S1>/Min'
 
-  rtb_Product = 0.5F * rtb_sum_alpha * control_foc_ConstB.Sum5;
+  rtb_Product = 0.5F * rtb_sum_alpha * localC->Sum5;
 
   // Gain: '<S1>/Ia+Ib+Ic=0'
   rtb_algDD_o1_p = rtu_Sensors->motorsensors.Iabc[1];
   rtb_algDD_o2_n = rtu_Sensors->motorsensors.Iabc[0];
   rtb_Unary_Minus = rtu_Sensors->motorsensors.Iabc[2];
-  for (int32_T i = 0; i < 2; i++) {
+  for (i = 0; i < 2; i++) {
     rtb_IaIbIc0[i] = (rtCP_IaIbIc0_Gain[i + 2] * rtb_algDD_o1_p +
                       rtCP_IaIbIc0_Gain[i] * rtb_algDD_o2_n) +
       rtCP_IaIbIc0_Gain[i + 4] * rtb_Unary_Minus;
@@ -115,40 +278,32 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   rtb_SinCos_o2 = std::cos(rtb_Unary_Minus);
 
   // Outputs for Atomic SubSystem: '<S1>/Park Transform'
-  // Switch: '<S114>/Switch' incorporates:
-  //   Product: '<S7>/acos'
+  // AlgorithmDescriptorDelegate generated from: '<S7>/a16' incorporates:
   //   Product: '<S7>/asin'
   //   Product: '<S7>/bcos'
-  //   Product: '<S7>/bsin'
-  //   Sum: '<S7>/sum_Ds'
   //   Sum: '<S7>/sum_Qs'
   //   UnaryMinus: '<S114>/Unary_Minus'
 
-  rtb_IaIbIc0[0] = -(rtb_algDD_o2_n * rtb_SinCos_o2 - rtb_algDD_o1_p *
-                     rtb_SinCos_o1);
-  rtb_IaIbIc0[1] = rtb_algDD_o1_p * rtb_SinCos_o2 + rtb_algDD_o2_n *
-    rtb_SinCos_o1;
+  rtb_algDD_o1 = -(rtb_algDD_o2_n * rtb_SinCos_o2 - rtb_algDD_o1_p *
+                   rtb_SinCos_o1);
 
-  // AlgorithmDescriptorDelegate generated from: '<S7>/a16'
-  rtb_algDD_o1_p = rtb_IaIbIc0[0];
+  // AlgorithmDescriptorDelegate generated from: '<S7>/a16' incorporates:
+  //   Product: '<S7>/acos'
+  //   Product: '<S7>/bsin'
+  //   Sum: '<S7>/sum_Ds'
 
-  // BusCreator: '<S1>/Bus Creator1' incorporates:
-  //   AlgorithmDescriptorDelegate generated from: '<S7>/a16'
-
-  rty_FOCOutputs->Iq_fbk.current = rtb_IaIbIc0[1];
-
-  // Sum: '<S1>/Sum' incorporates:
-  //   AlgorithmDescriptorDelegate generated from: '<S7>/a16'
-
-  rtb_Unary_Minus = rtu_OuterOutputs->motorcurrent.current - rtb_IaIbIc0[1];
+  rtb_algDD_o2 = rtb_algDD_o1_p * rtb_SinCos_o2 + rtb_algDD_o2_n * rtb_SinCos_o1;
 
   // End of Outputs for SubSystem: '<S1>/Park Transform'
 
+  // Sum: '<S1>/Sum'
+  rtb_Unary_Minus = rtu_OuterOutputs->motorcurrent.current - rtb_algDD_o2;
+
   // Product: '<S102>/PProd Out'
-  rtb_algDD_o2_n = rtb_Unary_Minus * rtu_ConfigurationParameters->CurLoopPID.P;
+  rtb_algDD_o1_p = rtb_Unary_Minus * rtu_ConfigurationParameters->CurLoopPID.P;
 
   // Product: '<S94>/IProd Out'
-  rtb_Diff = rtb_Unary_Minus * rtu_ConfigurationParameters->CurLoopPID.I;
+  rtb_algDD_o2_n = rtb_Unary_Minus * rtu_ConfigurationParameters->CurLoopPID.I;
 
   // SampleTimeMath: '<S92>/Tsamp' incorporates:
   //   SampleTimeMath: '<S40>/Tsamp'
@@ -179,13 +334,12 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   rtb_sum_alpha = 1.0F / (DProdOut + 1.0F);
 
   // DiscreteTransferFcn: '<S90>/Filter Differentiator TF'
-  if (rtu_OuterOutputs->pid_reset &&
-      (control_foc_PrevZCX.FilterDifferentiatorTF_Reset_ZC != POS_ZCSIG)) {
-    control_foc_DW.FilterDifferentiatorTF_states = 0.0F;
+  if (rtu_OuterOutputs->pid_reset && (localZCE->FilterDifferentiatorTF_Reset_ZCE
+       != POS_ZCSIG)) {
+    localDW->FilterDifferentiatorTF_states = 0.0F;
   }
 
-  control_foc_PrevZCX.FilterDifferentiatorTF_Reset_ZC =
-    rtu_OuterOutputs->pid_reset;
+  localZCE->FilterDifferentiatorTF_Reset_ZCE = rtu_OuterOutputs->pid_reset;
 
   // Product: '<S90>/Divide' incorporates:
   //   Constant: '<S90>/Filter Den Constant'
@@ -206,9 +360,9 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   Product: '<S89>/DProd Out'
   //   Product: '<S90>/Divide'
 
-  control_foc_DW.FilterDifferentiatorTF_tmp = rtb_Unary_Minus *
+  localDW->FilterDifferentiatorTF_tmp = rtb_Unary_Minus *
     rtu_ConfigurationParameters->CurLoopPID.D - DProdOut *
-    control_foc_DW.FilterDifferentiatorTF_states;
+    localDW->FilterDifferentiatorTF_states;
 
   // Product: '<S100>/NProd Out' incorporates:
   //   DiscreteTransferFcn: '<S90>/Filter Differentiator TF'
@@ -218,27 +372,27 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //  About '<S90>/Reciprocal':
   //   Operator: reciprocal
 
-  rtb_Unary_Minus = (control_foc_DW.FilterDifferentiatorTF_tmp -
-                     control_foc_DW.FilterDifferentiatorTF_states) *
-    rtb_sum_alpha * rtu_ConfigurationParameters->CurLoopPID.N;
+  rtb_Unary_Minus = (localDW->FilterDifferentiatorTF_tmp -
+                     localDW->FilterDifferentiatorTF_states) * rtb_sum_alpha *
+    rtu_ConfigurationParameters->CurLoopPID.N;
 
   // Sum: '<S109>/SumI1' incorporates:
   //   Sum: '<S107>/Sum Fdbk'
   //   Sum: '<S108>/SumI3'
   //   UnitDelay: '<S1>/Unit Delay'
 
-  control_foc_B.SumI1 = (control_foc_DW.UnitDelay_DSTATE - ((rtb_algDD_o2_n +
-    control_foc_DW.Integrator_DSTATE) + rtb_Unary_Minus)) + rtb_Diff;
+  localB->SumI1 = (localDW->UnitDelay_DSTATE - ((rtb_algDD_o1_p +
+    localDW->Integrator_DSTATE) + rtb_Unary_Minus)) + rtb_algDD_o2_n;
 
   // DiscreteIntegrator: '<S97>/Integrator'
-  if (rtu_OuterOutputs->pid_reset && (control_foc_DW.Integrator_PrevResetState <=
-       0)) {
-    control_foc_DW.Integrator_DSTATE = 0.0F;
+  if (rtu_OuterOutputs->pid_reset && (localDW->Integrator_PrevResetState <= 0))
+  {
+    localDW->Integrator_DSTATE = 0.0F;
   }
 
   // DiscreteIntegrator: '<S97>/Integrator'
-  control_foc_B.Integrator = 1.82857148E-5F * control_foc_B.SumI1 +
-    control_foc_DW.Integrator_DSTATE;
+  localB->Integrator = 1.82857148E-5F * localB->SumI1 +
+    localDW->Integrator_DSTATE;
 
   // Switch: '<S1>/Switch1' incorporates:
   //   Gain: '<S1>/Gain6'
@@ -248,10 +402,10 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   Sum: '<S1>/Sum6'
 
   if (rtu_OuterOutputs->cur_en) {
-    rtb_algDD_o2_n = ((rtb_algDD_o2_n + control_foc_B.Integrator) +
-                      rtb_Unary_Minus) + rtb_Add;
+    rtb_algDD_o1_p = ((rtb_algDD_o1_p + localB->Integrator) + rtb_Unary_Minus) +
+      rtb_Add;
   } else {
-    rtb_algDD_o2_n = rtu_Targets->motorvoltage.voltage * rtb_Product * 0.01F +
+    rtb_algDD_o1_p = rtu_Targets->motorvoltage.voltage * rtb_Product * 0.01F +
       rtu_OuterOutputs->current_limiter;
   }
 
@@ -263,57 +417,47 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   RelationalOperator: '<S8>/UpperRelop'
   //   Switch: '<S8>/Switch'
 
-  if (rtb_algDD_o2_n > rtb_Product) {
-    rtb_algDD_o2_n = rtb_Product;
-  } else if (rtb_algDD_o2_n < -rtb_Product) {
+  if (rtb_algDD_o1_p > rtb_Product) {
+    rtb_algDD_o1_p = rtb_Product;
+  } else if (rtb_algDD_o1_p < -rtb_Product) {
     // Switch: '<S8>/Switch' incorporates:
     //   Gain: '<S1>/Gain2'
 
-    rtb_algDD_o2_n = -rtb_Product;
+    rtb_algDD_o1_p = -rtb_Product;
   }
 
   // End of Switch: '<S8>/Switch2'
 
-  // Outputs for Atomic SubSystem: '<S1>/Park Transform'
   // Product: '<S50>/PProd Out' incorporates:
-  //   AlgorithmDescriptorDelegate generated from: '<S7>/a16'
   //   Gain: '<S1>/Gain'
 
-  rtb_Unary_Minus = -rtb_IaIbIc0[0] * rtu_ConfigurationParameters->CurLoopPID.P;
-
-  // End of Outputs for SubSystem: '<S1>/Park Transform'
+  rtb_Unary_Minus = -rtb_algDD_o1 * rtu_ConfigurationParameters->CurLoopPID.P;
 
   // DiscreteTransferFcn: '<S38>/Filter Differentiator TF' incorporates:
-  //   AlgorithmDescriptorDelegate generated from: '<S7>/a16'
   //   DiscreteTransferFcn: '<S90>/Filter Differentiator TF'
   //   Gain: '<S1>/Gain'
   //   Product: '<S37>/DProd Out'
 
   if (rtu_OuterOutputs->pid_reset &&
-      (control_foc_PrevZCX.FilterDifferentiatorTF_Reset__o != POS_ZCSIG)) {
-    control_foc_DW.FilterDifferentiatorTF_states_k = 0.0F;
+      (localZCE->FilterDifferentiatorTF_Reset_ZCE_o != POS_ZCSIG)) {
+    localDW->FilterDifferentiatorTF_states_k = 0.0F;
   }
 
-  control_foc_PrevZCX.FilterDifferentiatorTF_Reset__o =
-    rtu_OuterOutputs->pid_reset;
-
-  // Outputs for Atomic SubSystem: '<S1>/Park Transform'
-  control_foc_DW.FilterDifferentiatorTF_tmp_c = -rtb_IaIbIc0[0] *
+  localZCE->FilterDifferentiatorTF_Reset_ZCE_o = rtu_OuterOutputs->pid_reset;
+  localDW->FilterDifferentiatorTF_tmp_c = -rtb_algDD_o1 *
     rtu_ConfigurationParameters->CurLoopPID.D - DProdOut *
-    control_foc_DW.FilterDifferentiatorTF_states_k;
-
-  // End of Outputs for SubSystem: '<S1>/Park Transform'
+    localDW->FilterDifferentiatorTF_states_k;
 
   // Product: '<S48>/NProd Out' incorporates:
   //   DiscreteTransferFcn: '<S38>/Filter Differentiator TF'
   //   Product: '<S38>/DenCoefOut'
 
-  DProdOut = (control_foc_DW.FilterDifferentiatorTF_tmp_c -
-              control_foc_DW.FilterDifferentiatorTF_states_k) * rtb_sum_alpha *
+  DProdOut = (localDW->FilterDifferentiatorTF_tmp_c -
+              localDW->FilterDifferentiatorTF_states_k) * rtb_sum_alpha *
     rtu_ConfigurationParameters->CurLoopPID.N;
 
   // Sum: '<S56>/Sum Fdbk'
-  rtb_Diff = (rtb_Unary_Minus + control_foc_DW.Integrator_DSTATE_o) + DProdOut;
+  rtb_algDD_o2_n = (rtb_Unary_Minus + localDW->Integrator_DSTATE_o) + DProdOut;
 
   // Switch: '<S36>/Switch' incorporates:
   //   Gain: '<S1>/Gain2'
@@ -321,11 +465,11 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   RelationalOperator: '<S36>/u_GT_lo'
   //   Switch: '<S36>/Switch1'
 
-  if (rtb_Diff >= rtb_Product) {
+  if (rtb_algDD_o2_n >= rtb_Product) {
     rtb_sum_alpha = rtb_Product;
-  } else if (rtb_Diff > -rtb_Product) {
+  } else if (rtb_algDD_o2_n > -rtb_Product) {
     // Switch: '<S36>/Switch1'
-    rtb_sum_alpha = rtb_Diff;
+    rtb_sum_alpha = rtb_algDD_o2_n;
   } else {
     rtb_sum_alpha = -rtb_Product;
   }
@@ -333,16 +477,12 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   // Sum: '<S36>/Diff' incorporates:
   //   Switch: '<S36>/Switch'
 
-  rtb_Diff -= rtb_sum_alpha;
+  rtb_algDD_o2_n -= rtb_sum_alpha;
 
-  // Outputs for Atomic SubSystem: '<S1>/Park Transform'
   // Product: '<S42>/IProd Out' incorporates:
-  //   AlgorithmDescriptorDelegate generated from: '<S7>/a16'
   //   Gain: '<S1>/Gain'
 
-  rtb_sum_alpha = -rtb_IaIbIc0[0] * rtu_ConfigurationParameters->CurLoopPID.I;
-
-  // End of Outputs for SubSystem: '<S1>/Park Transform'
+  rtb_sum_alpha = -rtb_algDD_o1 * rtu_ConfigurationParameters->CurLoopPID.I;
 
   // Switch: '<S33>/Switch1' incorporates:
   //   Constant: '<S33>/Clamping_zero'
@@ -350,7 +490,7 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   Constant: '<S33>/Constant2'
   //   RelationalOperator: '<S33>/fix for DT propagation issue'
 
-  if (rtb_Diff > 0.0F) {
+  if (rtb_algDD_o2_n > 0.0F) {
     tmp = 1;
   } else {
     tmp = -1;
@@ -376,43 +516,43 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   Switch: '<S33>/Switch1'
   //   Switch: '<S33>/Switch2'
 
-  if ((rtb_Diff != 0.0F) && (tmp == tmp_0)) {
+  if ((rtb_algDD_o2_n != 0.0F) && (tmp == tmp_0)) {
     // Switch: '<S33>/Switch' incorporates:
     //   Constant: '<S33>/Constant1'
 
-    control_foc_B.Switch = 0.0F;
+    localB->Switch = 0.0F;
   } else {
     // Switch: '<S33>/Switch'
-    control_foc_B.Switch = rtb_sum_alpha;
+    localB->Switch = rtb_sum_alpha;
   }
 
   // End of Switch: '<S33>/Switch'
 
   // DiscreteIntegrator: '<S45>/Integrator'
-  if (rtu_OuterOutputs->pid_reset && (control_foc_DW.Integrator_PrevResetState_k
-       <= 0)) {
-    control_foc_DW.Integrator_DSTATE_o = 0.0F;
+  if (rtu_OuterOutputs->pid_reset && (localDW->Integrator_PrevResetState_k <= 0))
+  {
+    localDW->Integrator_DSTATE_o = 0.0F;
   }
 
   // DiscreteIntegrator: '<S45>/Integrator'
-  control_foc_B.Integrator_j = 1.82857148E-5F * control_foc_B.Switch +
-    control_foc_DW.Integrator_DSTATE_o;
+  localB->Integrator_j = 1.82857148E-5F * localB->Switch +
+    localDW->Integrator_DSTATE_o;
 
   // Sum: '<S55>/Sum'
-  rtb_Diff = (rtb_Unary_Minus + control_foc_B.Integrator_j) + DProdOut;
+  rtb_algDD_o2_n = (rtb_Unary_Minus + localB->Integrator_j) + DProdOut;
 
   // Switch: '<S53>/Switch2' incorporates:
   //   RelationalOperator: '<S53>/LowerRelop1'
 
-  if (!(rtb_Diff > rtb_Product)) {
+  if (!(rtb_algDD_o2_n > rtb_Product)) {
     // Switch: '<S53>/Switch' incorporates:
     //   Gain: '<S1>/Gain2'
     //   RelationalOperator: '<S53>/UpperRelop'
 
-    if (rtb_Diff < -rtb_Product) {
+    if (rtb_algDD_o2_n < -rtb_Product) {
       rtb_Product = -rtb_Product;
     } else {
-      rtb_Product = rtb_Diff;
+      rtb_Product = rtb_algDD_o2_n;
     }
 
     // End of Switch: '<S53>/Switch'
@@ -426,7 +566,7 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   //   Product: '<S5>/qcos'
   //   Sum: '<S5>/sum_beta'
 
-  rtb_IaIbIc0[0] = rtb_algDD_o2_n * rtb_SinCos_o2 + rtb_Product * rtb_SinCos_o1;
+  rtb_IaIbIc0[0] = rtb_algDD_o1_p * rtb_SinCos_o2 + rtb_Product * rtb_SinCos_o1;
 
   // End of Outputs for SubSystem: '<S1>/Inverse Park Transform'
 
@@ -437,7 +577,7 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
     // Gain: '<S1>/Gain3' incorporates:
     //   Product: '<S1>/Divide1'
 
-    rtb_Unary_Minus = rtb_algDD_o2_n /
+    rtb_Unary_Minus = rtb_algDD_o1_p /
       rtu_ConfigurationParameters->motorconfig.Vcc * 100.0F;
 
     // Outputs for Atomic SubSystem: '<S1>/Inverse Park Transform'
@@ -447,8 +587,8 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
     //   Sum: '<S5>/sum_alpha'
     //   UnaryMinus: '<S63>/Unary_Minus'
 
-    rtb_Diff = -(rtb_Product * rtb_SinCos_o2 - rtb_algDD_o2_n * rtb_SinCos_o1) *
-      0.866025388F;
+    rtb_algDD_o2_n = -(rtb_Product * rtb_SinCos_o2 - rtb_algDD_o1_p *
+                       rtb_SinCos_o1) * 0.866025388F;
 
     // Gain: '<S4>/one_by_two' incorporates:
     //   AlgorithmDescriptorDelegate generated from: '<S5>/a16'
@@ -458,24 +598,24 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
     // End of Outputs for SubSystem: '<S1>/Inverse Park Transform'
 
     // Sum: '<S4>/add_c'
-    rtb_SinCos_o2 = (0.0F - rtb_SinCos_o1) - rtb_Diff;
+    rtb_SinCos_o2 = (0.0F - rtb_SinCos_o1) - rtb_algDD_o2_n;
 
     // Sum: '<S4>/add_b'
-    rtb_SinCos_o1 = rtb_Diff - rtb_SinCos_o1;
+    rtb_SinCos_o1 = rtb_algDD_o2_n - rtb_SinCos_o1;
 
     // Outputs for Atomic SubSystem: '<S1>/Inverse Park Transform'
     // MinMax: '<S1>/Min1' incorporates:
     //   AlgorithmDescriptorDelegate generated from: '<S5>/a16'
 
     if ((rtb_IaIbIc0[0] <= rtb_SinCos_o1) || rtIsNaNF(rtb_SinCos_o1)) {
-      rtb_Diff = rtb_IaIbIc0[0];
+      rtb_algDD_o2_n = rtb_IaIbIc0[0];
     } else {
-      rtb_Diff = rtb_SinCos_o1;
+      rtb_algDD_o2_n = rtb_SinCos_o1;
     }
 
     // End of Outputs for SubSystem: '<S1>/Inverse Park Transform'
-    if ((!(rtb_Diff <= rtb_SinCos_o2)) && (!rtIsNaNF(rtb_SinCos_o2))) {
-      rtb_Diff = rtb_SinCos_o2;
+    if ((!(rtb_algDD_o2_n <= rtb_SinCos_o2)) && (!rtIsNaNF(rtb_SinCos_o2))) {
+      rtb_algDD_o2_n = rtb_SinCos_o2;
     }
 
     // Saturate: '<S1>/Saturation1'
@@ -496,7 +636,7 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
     //   Product: '<S1>/Divide'
     //   Sum: '<S1>/Sum4'
 
-    rtb_Product = (rtb_IaIbIc0[0] - rtb_Diff) /
+    rtb_Product = (rtb_IaIbIc0[0] - rtb_algDD_o2_n) /
       rtu_ConfigurationParameters->motorconfig.Vcc * 100.0F + 5.0F;
 
     // End of Outputs for SubSystem: '<S1>/Inverse Park Transform'
@@ -515,7 +655,7 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
     //   Product: '<S1>/Divide'
     //   Sum: '<S1>/Sum4'
 
-    rtb_SinCos_o1 = (rtb_SinCos_o1 - rtb_Diff) /
+    rtb_SinCos_o1 = (rtb_SinCos_o1 - rtb_algDD_o2_n) /
       rtu_ConfigurationParameters->motorconfig.Vcc * 100.0F + 5.0F;
 
     // Saturate: '<S1>/Saturation'
@@ -532,7 +672,7 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
     //   Product: '<S1>/Divide'
     //   Sum: '<S1>/Sum4'
 
-    rtb_SinCos_o2 = (rtb_SinCos_o2 - rtb_Diff) /
+    rtb_SinCos_o2 = (rtb_SinCos_o2 - rtb_algDD_o2_n) /
       rtu_ConfigurationParameters->motorconfig.Vcc * 100.0F + 5.0F;
 
     // Saturate: '<S1>/Saturation'
@@ -550,8 +690,37 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
 
   // End of Switch: '<S1>/Switch2'
 
+  // BusCreator: '<S1>/Bus Creator1'
+  rty_FOCOutputs->Iq_fbk.current = rtb_algDD_o2;
+
   // BusCreator: '<S1>/Bus Creator2'
-  rty_FOCOutputs->Id_fbk.current = rtb_algDD_o1_p;
+  rty_FOCOutputs->Id_fbk.current = rtb_algDD_o1;
+
+  // Saturate: '<S1>/Saturation2'
+  if (rtu_ConfigurationParameters->estimationconfig.current_rms_lambda > 1.0F) {
+    // Saturate: '<S1>/Saturation2'
+    rtb_Saturation2 = 1.0F;
+  } else if (rtu_ConfigurationParameters->estimationconfig.current_rms_lambda <
+             0.0F) {
+    // Saturate: '<S1>/Saturation2'
+    rtb_Saturation2 = 0.0F;
+  } else {
+    // Saturate: '<S1>/Saturation2'
+    rtb_Saturation2 =
+      rtu_ConfigurationParameters->estimationconfig.current_rms_lambda;
+  }
+
+  // End of Saturate: '<S1>/Saturation2'
+  control_foc_MovingRMS(rtb_algDD_o2, rtb_Saturation2, &localB->MovingRMS,
+                        &localDW->MovingRMS);
+
+  // BusCreator: '<S1>/Bus Creator3'
+  rty_FOCOutputs->Iq_rms.current = localB->MovingRMS.MovingRMS;
+  control_foc_MovingRMS(rtb_algDD_o1, rtb_Saturation2, &localB->MovingRMS1,
+                        &localDW->MovingRMS1);
+
+  // BusCreator: '<S1>/Bus Creator4'
+  rty_FOCOutputs->Id_rms.current = localB->MovingRMS1.MovingRMS;
 
   // BusCreator: '<S1>/Bus Creator'
   rty_FOCOutputs->Vq = rtb_Unary_Minus;
@@ -560,36 +729,43 @@ void FOCInnerLoop(const ConfigurationParameters *rtu_ConfigurationParameters,
   rty_FOCOutputs->Vabc[2] = rtb_SinCos_o2;
 
   // Sum: '<S1>/Sum3'
-  control_foc_B.Sum3 = rtb_algDD_o2_n - rtb_Add;
+  localB->Sum3 = rtb_algDD_o1_p - rtb_Add;
 }
 
 // Update for atomic system: '<Root>/FOC inner loop'
-void FOCInnerLoop_Update(const ControlOuterOutputs *rtu_OuterOutputs)
+void FOCInnerLoop_Update(const ControlOuterOutputs *rtu_OuterOutputs,
+  B_FOCInnerLoop_T *localB, DW_FOCInnerLoop_T *localDW)
 {
   // Update for DiscreteTransferFcn: '<S90>/Filter Differentiator TF'
-  control_foc_DW.FilterDifferentiatorTF_states =
-    control_foc_DW.FilterDifferentiatorTF_tmp;
+  localDW->FilterDifferentiatorTF_states = localDW->FilterDifferentiatorTF_tmp;
 
   // Update for UnitDelay: '<S1>/Unit Delay'
-  control_foc_DW.UnitDelay_DSTATE = control_foc_B.Sum3;
+  localDW->UnitDelay_DSTATE = localB->Sum3;
 
   // Update for DiscreteIntegrator: '<S97>/Integrator'
-  control_foc_DW.Integrator_DSTATE = 1.82857148E-5F * control_foc_B.SumI1 +
-    control_foc_B.Integrator;
-  control_foc_DW.Integrator_PrevResetState = static_cast<int8_T>
+  localDW->Integrator_DSTATE = 1.82857148E-5F * localB->SumI1 +
+    localB->Integrator;
+  localDW->Integrator_PrevResetState = static_cast<int8_T>
     (rtu_OuterOutputs->pid_reset);
 
   // Update for DiscreteTransferFcn: '<S38>/Filter Differentiator TF'
-  control_foc_DW.FilterDifferentiatorTF_states_k =
-    control_foc_DW.FilterDifferentiatorTF_tmp_c;
+  localDW->FilterDifferentiatorTF_states_k =
+    localDW->FilterDifferentiatorTF_tmp_c;
 
   // Update for DiscreteIntegrator: '<S45>/Integrator' incorporates:
   //   DiscreteIntegrator: '<S97>/Integrator'
 
-  control_foc_DW.Integrator_DSTATE_o = 1.82857148E-5F * control_foc_B.Switch +
-    control_foc_B.Integrator_j;
-  control_foc_DW.Integrator_PrevResetState_k = static_cast<int8_T>
+  localDW->Integrator_DSTATE_o = 1.82857148E-5F * localB->Switch +
+    localB->Integrator_j;
+  localDW->Integrator_PrevResetState_k = static_cast<int8_T>
     (rtu_OuterOutputs->pid_reset);
+}
+
+// Termination for atomic system: '<Root>/FOC inner loop'
+void FOCInnerLoop_Term(DW_FOCInnerLoop_T *localDW)
+{
+  control_foc_MovingRMS_Term(&localDW->MovingRMS);
+  control_foc_MovingRMS_Term(&localDW->MovingRMS1);
 }
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/FOCInnerLoop.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,16 +20,78 @@
 #define RTW_HEADER_FOCInnerLoop_h_
 #include "rtwtypes.h"
 #include "control_foc_types.h"
-#ifndef control_foc_MDLREF_HIDE_CHILD_
+#include "zero_crossing_types.h"
 
-extern void FOCInnerLoop_Init(void);
-extern void FOCInnerLoop_Update(const ControlOuterOutputs *rtu_OuterOutputs);
+// Block signals for system '<S1>/Moving RMS'
+struct B_MovingRMS_control_foc_T {
+  real32_T MovingRMS;                  // '<S1>/Moving RMS'
+};
+
+// Block states (default storage) for system '<S1>/Moving RMS'
+struct DW_MovingRMS_control_foc_T {
+  dsp_simulink_MovingRMS_control_foc_T obj;// '<S1>/Moving RMS'
+  boolean_T objisempty;                // '<S1>/Moving RMS'
+};
+
+// Block signals for system '<Root>/FOC inner loop'
+struct B_FOCInnerLoop_T {
+  real32_T SumI1;                      // '<S109>/SumI1'
+  real32_T Integrator;                 // '<S97>/Integrator'
+  real32_T Switch;                     // '<S33>/Switch'
+  real32_T Integrator_j;               // '<S45>/Integrator'
+  real32_T Sum3;                       // '<S1>/Sum3'
+  B_MovingRMS_control_foc_T MovingRMS1;// '<S1>/Moving RMS'
+  B_MovingRMS_control_foc_T MovingRMS; // '<S1>/Moving RMS'
+};
+
+// Block states (default storage) for system '<Root>/FOC inner loop'
+struct DW_FOCInnerLoop_T {
+  real32_T FilterDifferentiatorTF_states;// '<S90>/Filter Differentiator TF'
+  real32_T UnitDelay_DSTATE;           // '<S1>/Unit Delay'
+  real32_T Integrator_DSTATE;          // '<S97>/Integrator'
+  real32_T FilterDifferentiatorTF_states_k;// '<S38>/Filter Differentiator TF'
+  real32_T Integrator_DSTATE_o;        // '<S45>/Integrator'
+  real32_T FilterDifferentiatorTF_tmp; // '<S90>/Filter Differentiator TF'
+  real32_T FilterDifferentiatorTF_tmp_c;// '<S38>/Filter Differentiator TF'
+  int8_T Integrator_PrevResetState;    // '<S97>/Integrator'
+  int8_T Integrator_PrevResetState_k;  // '<S45>/Integrator'
+  DW_MovingRMS_control_foc_T MovingRMS1;// '<S1>/Moving RMS'
+  DW_MovingRMS_control_foc_T MovingRMS;// '<S1>/Moving RMS'
+};
+
+// Zero-crossing (trigger) state for system '<Root>/FOC inner loop'
+struct ZCV_FOCInnerLoop_T {
+  real_T FilterDifferentiatorTF_Reset_ZC;// '<S90>/Filter Differentiator TF'
+  real_T FilterDifferentiatorTF_Reset_ZC_c;// '<S38>/Filter Differentiator TF'
+};
+
+// Zero-crossing (trigger) state for system '<Root>/FOC inner loop'
+struct ZCE_FOCInnerLoop_T {
+  ZCSigState FilterDifferentiatorTF_Reset_ZCE;// '<S90>/Filter Differentiator TF' 
+  ZCSigState FilterDifferentiatorTF_Reset_ZCE_o;// '<S38>/Filter Differentiator TF' 
+};
+
+// Invariant block signals for system '<Root>/FOC inner loop'
+struct ConstB_FOCInnerLoop_T {
+  real32_T Gain5;                      // '<S1>/Gain5'
+  real32_T Sum5;                       // '<S1>/Sum5'
+};
+
+extern void control_foc_MovingRMS_Init(DW_MovingRMS_control_foc_T *localDW);
+extern void control_foc_MovingRMS(real32_T rtu_0, real32_T rtu_1,
+  B_MovingRMS_control_foc_T *localB, DW_MovingRMS_control_foc_T *localDW);
+extern void FOCInnerLoop_Init(DW_FOCInnerLoop_T *localDW);
+extern void FOCInnerLoop_Update(const ControlOuterOutputs *rtu_OuterOutputs,
+  B_FOCInnerLoop_T *localB, DW_FOCInnerLoop_T *localDW);
 extern void FOCInnerLoop(const ConfigurationParameters
   *rtu_ConfigurationParameters, const SensorsData *rtu_Sensors, const
   EstimatedData *rtu_Estimates, const Targets *rtu_Targets, const
-  ControlOuterOutputs *rtu_OuterOutputs, ControlOutputs *rty_FOCOutputs);
+  ControlOuterOutputs *rtu_OuterOutputs, ControlOutputs *rty_FOCOutputs,
+  B_FOCInnerLoop_T *localB, const ConstB_FOCInnerLoop_T *localC,
+  DW_FOCInnerLoop_T *localDW, ZCE_FOCInnerLoop_T *localZCE);
+extern void control_foc_MovingRMS_Term(DW_MovingRMS_control_foc_T *localDW);
+extern void FOCInnerLoop_Term(DW_FOCInnerLoop_T *localDW);
 
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
 #endif                                 // RTW_HEADER_FOCInnerLoop_h_
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,7 @@
 #include "control_foc_types.h"
 #include "FOCInnerLoop.h"
 #include "control_foc_private.h"
+#include <cstring>
 
 extern "C"
 {
@@ -28,48 +29,51 @@ extern "C"
 
 }
 
-MdlrefDW_control_foc_T control_foc_MdlrefDW;
-
-// Block signals (default storage)
-B_control_foc_c_T control_foc_B;
-
-// Block states (default storage)
-DW_control_foc_f_T control_foc_DW;
-
-// Previous zero-crossings (trigger) states
-ZCE_control_foc_T control_foc_PrevZCX;
-
 // System initialize for referenced model: 'control_foc'
-void control_foc_Init(void)
+void control_foc_Init(DW_control_foc_f_T *localDW)
 {
   // SystemInitialize for Atomic SubSystem: '<Root>/FOC inner loop'
-  FOCInnerLoop_Init();
+  FOCInnerLoop_Init(&localDW->FOCinnerloop);
 
   // End of SystemInitialize for SubSystem: '<Root>/FOC inner loop'
 }
 
 // Output and update for referenced model: 'control_foc'
 void control_foc(const SensorsData *rtu_Sensors, const FOCSlowInputs
-                 *rtu_FOCSlowInputs, ControlOutputs *rty_FOCOutputs)
+                 *rtu_FOCSlowInputs, ControlOutputs *rty_FOCOutputs,
+                 B_control_foc_c_T *localB, DW_control_foc_f_T *localDW,
+                 ZCE_control_foc_T *localZCE)
 {
   // Outputs for Atomic SubSystem: '<Root>/FOC inner loop'
   FOCInnerLoop(&rtu_FOCSlowInputs->configurationparameters, rtu_Sensors,
                &rtu_FOCSlowInputs->estimateddata, &rtu_FOCSlowInputs->targets,
-               &rtu_FOCSlowInputs->controlouteroutputs, rty_FOCOutputs);
+               &rtu_FOCSlowInputs->controlouteroutputs, rty_FOCOutputs,
+               &localB->FOCinnerloop, &control_foc_ConstB.FOCinnerloop,
+               &localDW->FOCinnerloop, &localZCE->FOCinnerloop);
 
   // End of Outputs for SubSystem: '<Root>/FOC inner loop'
 
   // Update for Atomic SubSystem: '<Root>/FOC inner loop'
-  FOCInnerLoop_Update(&rtu_FOCSlowInputs->controlouteroutputs);
+  FOCInnerLoop_Update(&rtu_FOCSlowInputs->controlouteroutputs,
+                      &localB->FOCinnerloop, &localDW->FOCinnerloop);
 
   // End of Update for SubSystem: '<Root>/FOC inner loop'
 }
 
-// Model initialize function
-void control_foc_initialize(const char_T **rt_errorStatus)
+// Termination for referenced model: 'control_foc'
+void control_foc_Term(DW_control_foc_f_T *localDW)
 {
-  RT_MODEL_control_foc_T *const control_foc_M = &(control_foc_MdlrefDW.rtm);
+  // Terminate for Atomic SubSystem: '<Root>/FOC inner loop'
+  FOCInnerLoop_Term(&localDW->FOCinnerloop);
 
+  // End of Terminate for SubSystem: '<Root>/FOC inner loop'
+}
+
+// Model initialize function
+void control_foc_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_control_foc_T *const control_foc_M, B_control_foc_c_T *localB,
+  DW_control_foc_f_T *localDW, ZCE_control_foc_T *localZCE)
+{
   // Registration code
 
   // initialize non-finites
@@ -77,8 +81,16 @@ void control_foc_initialize(const char_T **rt_errorStatus)
 
   // initialize error status
   rtmSetErrorStatusPointer(control_foc_M, rt_errorStatus);
-  control_foc_PrevZCX.FilterDifferentiatorTF_Reset_ZC = POS_ZCSIG;
-  control_foc_PrevZCX.FilterDifferentiatorTF_Reset__o = POS_ZCSIG;
+
+  // block I/O
+  (void) std::memset((static_cast<void *>(localB)), 0,
+                     sizeof(B_control_foc_c_T));
+
+  // states (dwork)
+  (void) std::memset(static_cast<void *>(localDW), 0,
+                     sizeof(DW_control_foc_f_T));
+  localZCE->FOCinnerloop.FilterDifferentiatorTF_Reset_ZCE = POS_ZCSIG;
+  localZCE->FOCinnerloop.FilterDifferentiatorTF_Reset_ZCE_o = POS_ZCSIG;
 }
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,8 @@
 #define RTW_HEADER_control_foc_h_
 #include "rtwtypes.h"
 #include "control_foc_types.h"
+#include "FOCInnerLoop.h"
+#include <cstring>
 
 extern "C"
 {
@@ -31,115 +33,51 @@ extern "C"
 #include "zero_crossing_types.h"
 
 // Block signals for model 'control_foc'
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
 struct B_control_foc_c_T {
-  real32_T SumI1;                      // '<S109>/SumI1'
-  real32_T Integrator;                 // '<S97>/Integrator'
-  real32_T Switch;                     // '<S33>/Switch'
-  real32_T Integrator_j;               // '<S45>/Integrator'
-  real32_T Sum3;                       // '<S1>/Sum3'
+  B_FOCInnerLoop_T FOCinnerloop;       // '<Root>/FOC inner loop'
 };
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
 
 // Block states (default storage) for model 'control_foc'
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
 struct DW_control_foc_f_T {
-  real32_T FilterDifferentiatorTF_states;// '<S90>/Filter Differentiator TF'
-  real32_T UnitDelay_DSTATE;           // '<S1>/Unit Delay'
-  real32_T Integrator_DSTATE;          // '<S97>/Integrator'
-  real32_T FilterDifferentiatorTF_states_k;// '<S38>/Filter Differentiator TF'
-  real32_T Integrator_DSTATE_o;        // '<S45>/Integrator'
-  real32_T FilterDifferentiatorTF_tmp; // '<S90>/Filter Differentiator TF'
-  real32_T FilterDifferentiatorTF_tmp_c;// '<S38>/Filter Differentiator TF'
-  int8_T Integrator_PrevResetState;    // '<S97>/Integrator'
-  int8_T Integrator_PrevResetState_k;  // '<S45>/Integrator'
+  DW_FOCInnerLoop_T FOCinnerloop;      // '<Root>/FOC inner loop'
 };
 
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
 // Zero-crossing (trigger) state for model 'control_foc'
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
 struct ZCV_control_foc_g_T {
-  real_T FilterDifferentiatorTF_Reset_ZC;// '<S90>/Filter Differentiator TF'
-  real_T FilterDifferentiatorTF_Reset__c;// '<S38>/Filter Differentiator TF'
+  ZCV_FOCInnerLoop_T FOCinnerloop;     // '<Root>/FOC inner loop'
 };
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
 
 // Zero-crossing (trigger) state for model 'control_foc'
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
 struct ZCE_control_foc_T {
-  ZCSigState FilterDifferentiatorTF_Reset_ZC;// '<S90>/Filter Differentiator TF' 
-  ZCSigState FilterDifferentiatorTF_Reset__o;// '<S38>/Filter Differentiator TF' 
+  ZCE_FOCInnerLoop_T FOCinnerloop;     // '<Root>/FOC inner loop'
 };
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
 
 // Invariant block signals for model 'control_foc'
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
 struct ConstB_control_foc_h_T {
-  real32_T Gain5;                      // '<S1>/Gain5'
-  real32_T Sum5;                       // '<S1>/Sum5'
+  ConstB_FOCInnerLoop_T FOCinnerloop;  // '<Root>/FOC inner loop'
 };
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
-#ifndef control_foc_MDLREF_HIDE_CHILD_
 
 // Real-time Model Data Structure
 struct tag_RTM_control_foc_T {
   const char_T **errorStatus;
 };
 
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
 struct MdlrefDW_control_foc_T {
+  B_control_foc_c_T rtb;
+  DW_control_foc_f_T rtdw;
   RT_MODEL_control_foc_T rtm;
+  ZCE_control_foc_T rtzce;
 };
 
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
-extern void control_foc_Init(void);
-extern void control_foc(const SensorsData *rtu_Sensors, const FOCSlowInputs
-  *rtu_FOCSlowInputs, ControlOutputs *rty_FOCOutputs);
-
 // Model reference registration function
-extern void control_foc_initialize(const char_T **rt_errorStatus);
-
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
-extern MdlrefDW_control_foc_T control_foc_MdlrefDW;
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
-// Block signals (default storage)
-extern B_control_foc_c_T control_foc_B;
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
-// Block states (default storage)
-extern DW_control_foc_f_T control_foc_DW;
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
-
-#ifndef control_foc_MDLREF_HIDE_CHILD_
-
-// Previous zero-crossings (trigger) states
-extern ZCE_control_foc_T control_foc_PrevZCX;
-
-#endif                                 //control_foc_MDLREF_HIDE_CHILD_
+extern void control_foc_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_control_foc_T *const control_foc_M, B_control_foc_c_T *localB,
+  DW_control_foc_f_T *localDW, ZCE_control_foc_T *localZCE);
+extern void control_foc_Init(DW_control_foc_f_T *localDW);
+extern void control_foc(const SensorsData *rtu_Sensors, const FOCSlowInputs
+  *rtu_FOCSlowInputs, ControlOutputs *rty_FOCOutputs, B_control_foc_c_T *localB,
+  DW_control_foc_f_T *localDW, ZCE_control_foc_T *localZCE);
+extern void control_foc_Term(DW_control_foc_f_T *localDW);
 
 //-
 //  These blocks were eliminated from the model due to optimizations:

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc_data.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,10 +20,14 @@
 
 // Invariant block signals (default storage)
 const ConstB_control_foc_h_T control_foc_ConstB = {
-  0.0249999985F
-  ,                                    // '<S1>/Gain5'
-  0.975F
-  // '<S1>/Sum5'
+  // Start of '<Root>/FOC inner loop'
+  {
+    0.0249999985F
+    ,                                  // '<S1>/Gain5'
+    0.975F
+    // '<S1>/Sum5'
+  }
+  // End of '<Root>/FOC inner loop'
 };
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-foc/control_foc_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.7
+// Model version                  : 5.12
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:35 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -85,6 +85,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T enable_thermal_protection;
 };
 
 #endif
@@ -110,6 +111,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -131,6 +136,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -202,6 +210,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -218,6 +229,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif
@@ -244,14 +256,30 @@ struct MotorCurrent
 
 #endif
 
+#ifndef DEFINED_TYPEDEF_FOR_MotorTemperature_
+#define DEFINED_TYPEDEF_FOR_MotorTemperature_
+
+struct MotorTemperature
+{
+  // motor temperature
+  real32_T temperature;
+};
+
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
 #define DEFINED_TYPEDEF_FOR_EstimatedData_
 
 struct EstimatedData
 {
-  // velocities
+  // velocity
   JointVelocities jointvelocities;
+
+  // filtered motor current
   MotorCurrent Iq_filtered;
+
+  // motor temperature
+  MotorTemperature motor_temperature;
 };
 
 #endif
@@ -325,9 +353,60 @@ struct ControlOutputs
 
   // direct current
   MotorCurrent Id_fbk;
+
+  // RMS of Iq
+  MotorCurrent Iq_rms;
+
+  // RMS of Id
+  MotorCurrent Id_rms;
 };
 
 #endif
+
+#ifndef struct_c_dsp_internal_ExponentialMovingAverage_control_foc_T
+#define struct_c_dsp_internal_ExponentialMovingAverage_control_foc_T
+
+struct c_dsp_internal_ExponentialMovingAverage_control_foc_T
+{
+  int32_T isInitialized;
+  boolean_T isSetupComplete;
+  boolean_T TunablePropsChanged;
+  real32_T ForgettingFactor;
+  real32_T pwN;
+  real32_T pmN;
+  real32_T plambda;
+};
+
+#endif          // struct_c_dsp_internal_ExponentialMovingAverage_control_foc_T
+
+#ifndef struct_cell_wrap_control_foc_T
+#define struct_cell_wrap_control_foc_T
+
+struct cell_wrap_control_foc_T
+{
+  uint32_T f1[8];
+};
+
+#endif                                 // struct_cell_wrap_control_foc_T
+
+#ifndef struct_dsp_simulink_MovingRMS_control_foc_T
+#define struct_dsp_simulink_MovingRMS_control_foc_T
+
+struct dsp_simulink_MovingRMS_control_foc_T
+{
+  boolean_T matlabCodegenIsDeleted;
+  int32_T isInitialized;
+  boolean_T isSetupComplete;
+  boolean_T TunablePropsChanged;
+  cell_wrap_control_foc_T inputVarSize[2];
+  real32_T ForgettingFactor;
+  c_dsp_internal_ExponentialMovingAverage_control_foc_T *pStatistic;
+  int32_T NumChannels;
+  int32_T FrameLength;
+  c_dsp_internal_ExponentialMovingAverage_control_foc_T _pobj0;
+};
+
+#endif                           // struct_dsp_simulink_MovingRMS_control_foc_T
 
 // Forward declaration for rtModel
 typedef struct tag_RTM_control_foc_T RT_MODEL_control_foc_T;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-outer/control_outer.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 5.2
+// Model version                  : 5.5
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:44 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:44 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,20 +20,15 @@
 #define RTW_HEADER_control_outer_h_
 #include "rtwtypes.h"
 #include "control_outer_types.h"
+#include <cstring>
 #include "zero_crossing_types.h"
 
 // Block signals for model 'control_outer'
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
 struct B_control_outer_c_T {
   real32_T DiscreteTimeIntegrator;     // '<S1>/Discrete-Time Integrator'
 };
 
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
 // Block states (default storage) for model 'control_outer'
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
 struct DW_control_outer_f_T {
   real32_T FilterDifferentiatorTF_states;// '<S47>/Filter Differentiator TF'
   real32_T UnitDelay_DSTATE;           // '<Root>/Unit Delay'
@@ -51,89 +46,50 @@ struct DW_control_outer_f_T {
   int8_T Integrator_PrevResetState;    // '<S54>/Integrator'
   int8_T Integrator_PrevResetState_n;  // '<S104>/Integrator'
   int8_T Integrator_PrevResetState_c;  // '<S154>/Integrator'
-  int8_T DiscreteTimeIntegrator_PrevRese;// '<S1>/Discrete-Time Integrator'
-  uint8_T DiscreteTimeIntegrator_SYSTEM_E;// '<S1>/Discrete-Time Integrator'
+  int8_T DiscreteTimeIntegrator_PrevResetState;// '<S1>/Discrete-Time Integrator' 
+  uint8_T DiscreteTimeIntegrator_SYSTEM_ENABLE;// '<S1>/Discrete-Time Integrator' 
   boolean_T Memory_PreviousInput;      // '<S9>/Memory'
 };
 
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
 // Zero-crossing (trigger) state for model 'control_outer'
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
 struct ZCV_control_outer_g_T {
   real_T FilterDifferentiatorTF_Reset_ZC;// '<S47>/Filter Differentiator TF'
-  real_T FilterDifferentiatorTF_Reset__f;// '<S97>/Filter Differentiator TF'
-  real_T FilterDifferentiatorTF_Reset__m;// '<S147>/Filter Differentiator TF'
+  real_T FilterDifferentiatorTF_Reset_ZC_f;// '<S97>/Filter Differentiator TF'
+  real_T FilterDifferentiatorTF_Reset_ZC_m;// '<S147>/Filter Differentiator TF'
 };
-
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
 
 // Zero-crossing (trigger) state for model 'control_outer'
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
 struct ZCE_control_outer_T {
-  ZCSigState FilterDifferentiatorTF_Reset_ZC;// '<S47>/Filter Differentiator TF' 
-  ZCSigState FilterDifferentiatorTF_Reset__m;// '<S97>/Filter Differentiator TF' 
-  ZCSigState FilterDifferentiatorTF_Reset__e;// '<S147>/Filter Differentiator TF' 
+  ZCSigState FilterDifferentiatorTF_Reset_ZCE;// '<S47>/Filter Differentiator TF' 
+  ZCSigState FilterDifferentiatorTF_Reset_ZCE_m;// '<S97>/Filter Differentiator TF' 
+  ZCSigState FilterDifferentiatorTF_Reset_ZCE_e;// '<S147>/Filter Differentiator TF' 
 };
-
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
-#ifndef control_outer_MDLREF_HIDE_CHILD_
 
 // Real-time Model Data Structure
 struct tag_RTM_control_outer_T {
   const char_T **errorStatus;
 };
 
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
 struct MdlrefDW_control_outer_T {
+  B_control_outer_c_T rtb;
+  DW_control_outer_f_T rtdw;
   RT_MODEL_control_outer_T rtm;
+  ZCE_control_outer_T rtzce;
 };
 
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
-extern void control_outer_Init(void);
-extern void control_outer_Enable(void);
-extern void control_outer_Disable(void);
+// Model reference registration function
+extern void control_outer_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_control_outer_T *const control_outer_M, B_control_outer_c_T *localB,
+  DW_control_outer_f_T *localDW, ZCE_control_outer_T *localZCE);
+extern void control_outer_Init(DW_control_outer_f_T *localDW);
+extern void control_outer_Enable(DW_control_outer_f_T *localDW);
+extern void control_outer_Disable(B_control_outer_c_T *localB,
+  DW_control_outer_f_T *localDW);
 extern void control_outer(const Flags *rtu_Flags, const ConfigurationParameters *
   rtu_ConfigurationParameters, const Targets *rtu_Targets, const SensorsData
   *rtu_Sensors, const EstimatedData *rtu_Estimates, ControlOuterOutputs
-  *rty_OuterOutputs);
-
-// Model reference registration function
-extern void control_outer_initialize(const char_T **rt_errorStatus);
-
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
-extern MdlrefDW_control_outer_T control_outer_MdlrefDW;
-
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
-// Block signals (default storage)
-extern B_control_outer_c_T control_outer_B;
-
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
-// Block states (default storage)
-extern DW_control_outer_f_T control_outer_DW;
-
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
-
-#ifndef control_outer_MDLREF_HIDE_CHILD_
-
-// Previous zero-crossings (trigger) states
-extern ZCE_control_outer_T control_outer_PrevZCX;
-
-#endif                                 //control_outer_MDLREF_HIDE_CHILD_
+  *rty_OuterOutputs, B_control_outer_c_T *localB, DW_control_outer_f_T *localDW,
+  ZCE_control_outer_T *localZCE);
 
 //-
 //  These blocks were eliminated from the model due to optimizations:

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-outer/control_outer_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 5.2
+// Model version                  : 5.5
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:44 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:44 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/control-outer/control_outer_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_outer'.
 //
-// Model version                  : 5.2
+// Model version                  : 5.5
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:44 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:44 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -45,6 +45,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T enable_thermal_protection;
 };
 
 #endif
@@ -70,6 +71,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -91,6 +96,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -162,6 +170,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -178,6 +189,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif
@@ -268,14 +280,30 @@ struct SensorsData
 
 #endif
 
+#ifndef DEFINED_TYPEDEF_FOR_MotorTemperature_
+#define DEFINED_TYPEDEF_FOR_MotorTemperature_
+
+struct MotorTemperature
+{
+  // motor temperature
+  real32_T temperature;
+};
+
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
 #define DEFINED_TYPEDEF_FOR_EstimatedData_
 
 struct EstimatedData
 {
-  // velocities
+  // velocity
   JointVelocities jointvelocities;
+
+  // filtered motor current
   MotorCurrent Iq_filtered;
+
+  // motor temperature
+  MotorTemperature motor_temperature;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/estimator/estimation_velocity.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:55 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:55 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -21,6 +21,7 @@
 #include "rtwtypes.h"
 #include "estimation_velocity_types.h"
 #include "rtGetNaN.h"
+#include <cstring>
 
 extern "C"
 {
@@ -30,56 +31,33 @@ extern "C"
 }
 
 // Block states (default storage) for model 'estimation_velocity'
-#ifndef estimation_velocity_MDLREF_HIDE_CHILD_
-
 struct DW_estimation_velocity_f_T {
   real32_T DelayLine_Buff[15];         // '<Root>/Delay Line'
   real32_T Delay_DSTATE[16];           // '<Root>/Delay'
   int32_T DelayLine_BUFF_OFFSET;       // '<Root>/Delay Line'
   uint32_T CircBufIdx;                 // '<Root>/Delay'
-  dsp_simulink_QRSolver_estimat_T obj; // '<S1>/QR Solver'
+  dsp_simulink_QRSolver_estimation_velocity_T obj;// '<S1>/QR Solver'
   boolean_T objisempty;                // '<S1>/QR Solver'
 };
-
-#endif                                 //estimation_velocity_MDLREF_HIDE_CHILD_
-
-#ifndef estimation_velocity_MDLREF_HIDE_CHILD_
 
 // Real-time Model Data Structure
 struct tag_RTM_estimation_velocity_T {
   const char_T **errorStatus;
 };
 
-#endif                                 //estimation_velocity_MDLREF_HIDE_CHILD_
-
-#ifndef estimation_velocity_MDLREF_HIDE_CHILD_
-
 struct MdlrefDW_estimation_velocity_T {
+  DW_estimation_velocity_f_T rtdw;
   RT_MODEL_estimation_velocity_T rtm;
 };
 
-#endif                                 //estimation_velocity_MDLREF_HIDE_CHILD_
-
-extern void estimation_velocity_Init(void);
+// Model reference registration function
+extern void estimation_velocity_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_estimation_velocity_T *const estimation_velocity_M,
+  DW_estimation_velocity_f_T *localDW);
+extern void estimation_velocity_Init(DW_estimation_velocity_f_T *localDW);
 extern void estimation_velocity(const SensorsData *rtu_SensorsData, const
   ConfigurationParameters *rtu_ConfigurationParameters, JointVelocities
-  *rty_EstimatedVelocity);
-
-// Model reference registration function
-extern void estimation_velocity_initialize(const char_T **rt_errorStatus);
-
-#ifndef estimation_velocity_MDLREF_HIDE_CHILD_
-
-extern MdlrefDW_estimation_velocity_T estimation_velocity_MdlrefDW;
-
-#endif                                 //estimation_velocity_MDLREF_HIDE_CHILD_
-
-#ifndef estimation_velocity_MDLREF_HIDE_CHILD_
-
-// Block states (default storage)
-extern DW_estimation_velocity_f_T estimation_velocity_DW;
-
-#endif                                 //estimation_velocity_MDLREF_HIDE_CHILD_
+  *rty_EstimatedVelocity, DW_estimation_velocity_f_T *localDW);
 
 //-
 //  These blocks were eliminated from the model due to optimizations:

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/estimator/estimation_velocity_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:55 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:55 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/estimator/estimation_velocity_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:55 2023
+// C/C++ source code generated on : Tue Jun 27 10:18:55 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -80,6 +80,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -101,6 +105,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -172,6 +179,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -188,6 +198,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif
@@ -203,15 +214,15 @@ struct JointVelocities
 
 #endif
 
-#ifndef struct_dsp_simulink_QRSolver_estimat_T
-#define struct_dsp_simulink_QRSolver_estimat_T
+#ifndef struct_dsp_simulink_QRSolver_estimation_velocity_T
+#define struct_dsp_simulink_QRSolver_estimation_velocity_T
 
-struct dsp_simulink_QRSolver_estimat_T
+struct dsp_simulink_QRSolver_estimation_velocity_T
 {
   int32_T isInitialized;
 };
 
-#endif                                // struct_dsp_simulink_QRSolver_estimat_T
+#endif                    // struct_dsp_simulink_QRSolver_estimation_velocity_T
 
 // Forward declaration for rtModel
 typedef struct tag_RTM_estimation_velocity_T RT_MODEL_estimation_velocity_T;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:03 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:02 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -23,18 +23,15 @@
 #include <cstring>
 #include "filter_current_private.h"
 
-MdlrefDW_filter_current_T filter_current_MdlrefDW;
-
-// Block states (default storage)
-DW_filter_current_f_T filter_current_DW;
-
 // Forward declaration for local functions
-static void filter_MedianFilterCG_resetImpl(c_dsp_internal_MedianFilterCG_T *obj);
-static void f_MedianFilterCG_trickleDownMax(c_dsp_internal_MedianFilterCG_T *obj,
-  real32_T i);
-static void f_MedianFilterCG_trickleDownMin(c_dsp_internal_MedianFilterCG_T *obj,
-  real32_T i);
-static void filter_MedianFilterCG_resetImpl(c_dsp_internal_MedianFilterCG_T *obj)
+static void filter_current_MedianFilterCG_resetImpl
+  (c_dsp_internal_MedianFilterCG_filter_current_T *obj);
+static void filter_current_MedianFilterCG_trickleDownMax
+  (c_dsp_internal_MedianFilterCG_filter_current_T *obj, real32_T i);
+static void filter_current_MedianFilterCG_trickleDownMin
+  (c_dsp_internal_MedianFilterCG_filter_current_T *obj, real32_T i);
+static void filter_current_MedianFilterCG_resetImpl
+  (c_dsp_internal_MedianFilterCG_filter_current_T *obj)
 {
   real32_T cnt1;
   real32_T cnt2;
@@ -75,8 +72,8 @@ static void filter_MedianFilterCG_resetImpl(c_dsp_internal_MedianFilterCG_T *obj
   }
 }
 
-static void f_MedianFilterCG_trickleDownMax(c_dsp_internal_MedianFilterCG_T *obj,
-  real32_T i)
+static void filter_current_MedianFilterCG_trickleDownMax
+  (c_dsp_internal_MedianFilterCG_filter_current_T *obj, real32_T i)
 {
   boolean_T exitg1;
   exitg1 = false;
@@ -125,8 +122,8 @@ static void f_MedianFilterCG_trickleDownMax(c_dsp_internal_MedianFilterCG_T *obj
   }
 }
 
-static void f_MedianFilterCG_trickleDownMin(c_dsp_internal_MedianFilterCG_T *obj,
-  real32_T i)
+static void filter_current_MedianFilterCG_trickleDownMin
+  (c_dsp_internal_MedianFilterCG_filter_current_T *obj, real32_T i)
 {
   boolean_T exitg1;
   exitg1 = false;
@@ -176,19 +173,19 @@ static void f_MedianFilterCG_trickleDownMin(c_dsp_internal_MedianFilterCG_T *obj
 }
 
 // System initialize for referenced model: 'filter_current'
-void filter_current_Init(void)
+void filter_current_Init(DW_filter_current_f_T *localDW)
 {
   // Start for MATLABSystem: '<Root>/Median Filter'
-  filter_current_DW.obj.matlabCodegenIsDeleted = false;
-  filter_current_DW.objisempty = true;
-  filter_current_DW.obj.isInitialized = 1;
-  filter_current_DW.obj.NumChannels = 1;
-  filter_current_DW.obj.pMID.isInitialized = 0;
-  filter_current_DW.obj.isSetupComplete = true;
+  localDW->obj.matlabCodegenIsDeleted = false;
+  localDW->objisempty = true;
+  localDW->obj.isInitialized = 1;
+  localDW->obj.NumChannels = 1;
+  localDW->obj.pMID.isInitialized = 0;
+  localDW->obj.isSetupComplete = true;
 
   // InitializeConditions for MATLABSystem: '<Root>/Median Filter'
-  if (filter_current_DW.obj.pMID.isInitialized == 1) {
-    filter_MedianFilterCG_resetImpl(&filter_current_DW.obj.pMID);
+  if (localDW->obj.pMID.isInitialized == 1) {
+    filter_current_MedianFilterCG_resetImpl(&localDW->obj.pMID);
   }
 
   // End of InitializeConditions for MATLABSystem: '<Root>/Median Filter'
@@ -196,9 +193,9 @@ void filter_current_Init(void)
 
 // Output and update for referenced model: 'filter_current'
 void filter_current(const ControlOutputs *rtu_ControlOutputs, MotorCurrent
-                    *rty_FilteredCurrent)
+                    *rty_FilteredCurrent, DW_filter_current_f_T *localDW)
 {
-  c_dsp_internal_MedianFilterCG_T *obj;
+  c_dsp_internal_MedianFilterCG_filter_current_T *obj;
   int32_T vprev_tmp;
   real32_T ind2;
   real32_T p;
@@ -209,31 +206,29 @@ void filter_current(const ControlOutputs *rtu_ControlOutputs, MotorCurrent
   boolean_T flag;
 
   // MATLABSystem: '<Root>/Median Filter'
-  obj = &filter_current_DW.obj.pMID;
-  if (filter_current_DW.obj.pMID.isInitialized != 1) {
-    filter_current_DW.obj.pMID.isInitialized = 1;
-    filter_current_DW.obj.pMID.isSetupComplete = true;
-    filter_MedianFilterCG_resetImpl(&filter_current_DW.obj.pMID);
+  obj = &localDW->obj.pMID;
+  if (localDW->obj.pMID.isInitialized != 1) {
+    localDW->obj.pMID.isInitialized = 1;
+    localDW->obj.pMID.isSetupComplete = true;
+    filter_current_MedianFilterCG_resetImpl(&localDW->obj.pMID);
   }
 
-  vprev_tmp = static_cast<int32_T>(filter_current_DW.obj.pMID.pIdx) - 1;
-  vprev = filter_current_DW.obj.pMID.pBuf[vprev_tmp];
-  filter_current_DW.obj.pMID.pBuf[vprev_tmp] =
-    rtu_ControlOutputs->Iq_fbk.current;
-  p = filter_current_DW.obj.pMID.pPos[static_cast<int32_T>
-    (filter_current_DW.obj.pMID.pIdx) - 1];
-  filter_current_DW.obj.pMID.pIdx++;
-  if (filter_current_DW.obj.pMID.pWinLen + 1.0F ==
-      filter_current_DW.obj.pMID.pIdx) {
-    filter_current_DW.obj.pMID.pIdx = 1.0F;
+  vprev_tmp = static_cast<int32_T>(localDW->obj.pMID.pIdx) - 1;
+  vprev = localDW->obj.pMID.pBuf[vprev_tmp];
+  localDW->obj.pMID.pBuf[vprev_tmp] = rtu_ControlOutputs->Iq_fbk.current;
+  p = localDW->obj.pMID.pPos[static_cast<int32_T>(localDW->obj.pMID.pIdx) - 1];
+  localDW->obj.pMID.pIdx++;
+  if (localDW->obj.pMID.pWinLen + 1.0F == localDW->obj.pMID.pIdx) {
+    localDW->obj.pMID.pIdx = 1.0F;
   }
 
-  if (p > filter_current_DW.obj.pMID.pMidHeap) {
+  if (p > localDW->obj.pMID.pMidHeap) {
     if (vprev < rtu_ControlOutputs->Iq_fbk.current) {
-      vprev = p - filter_current_DW.obj.pMID.pMidHeap;
-      f_MedianFilterCG_trickleDownMin(&filter_current_DW.obj.pMID, vprev * 2.0F);
+      vprev = p - localDW->obj.pMID.pMidHeap;
+      filter_current_MedianFilterCG_trickleDownMin(&localDW->obj.pMID, vprev *
+        2.0F);
     } else {
-      vprev = p - filter_current_DW.obj.pMID.pMidHeap;
+      vprev = p - localDW->obj.pMID.pMidHeap;
       exitg1 = false;
       while ((!exitg1) && (vprev > 0.0F)) {
         u_tmp = std::floor(vprev / 2.0F);
@@ -259,15 +254,16 @@ void filter_current(const ControlOutputs *rtu_ControlOutputs, MotorCurrent
       }
 
       if (vprev == 0.0F) {
-        f_MedianFilterCG_trickleDownMax(&filter_current_DW.obj.pMID, -1.0F);
+        filter_current_MedianFilterCG_trickleDownMax(&localDW->obj.pMID, -1.0F);
       }
     }
-  } else if (p < filter_current_DW.obj.pMID.pMidHeap) {
+  } else if (p < localDW->obj.pMID.pMidHeap) {
     if (rtu_ControlOutputs->Iq_fbk.current < vprev) {
-      vprev = p - filter_current_DW.obj.pMID.pMidHeap;
-      f_MedianFilterCG_trickleDownMax(&filter_current_DW.obj.pMID, vprev * 2.0F);
+      vprev = p - localDW->obj.pMID.pMidHeap;
+      filter_current_MedianFilterCG_trickleDownMax(&localDW->obj.pMID, vprev *
+        2.0F);
     } else {
-      vprev = p - filter_current_DW.obj.pMID.pMidHeap;
+      vprev = p - localDW->obj.pMID.pMidHeap;
       exitg1 = false;
       while ((!exitg1) && (vprev < 0.0F)) {
         u_tmp = vprev / 2.0F;
@@ -309,41 +305,38 @@ void filter_current(const ControlOutputs *rtu_ControlOutputs, MotorCurrent
       }
 
       if (vprev == 0.0F) {
-        f_MedianFilterCG_trickleDownMin(&filter_current_DW.obj.pMID, 1.0F);
+        filter_current_MedianFilterCG_trickleDownMin(&localDW->obj.pMID, 1.0F);
       }
     }
   } else {
-    if (filter_current_DW.obj.pMID.pMaxHeapLength != 0.0F) {
-      f_MedianFilterCG_trickleDownMax(&filter_current_DW.obj.pMID, -1.0F);
+    if (localDW->obj.pMID.pMaxHeapLength != 0.0F) {
+      filter_current_MedianFilterCG_trickleDownMax(&localDW->obj.pMID, -1.0F);
     }
 
-    if (filter_current_DW.obj.pMID.pMinHeapLength > 0.0F) {
-      f_MedianFilterCG_trickleDownMin(&filter_current_DW.obj.pMID, 1.0F);
+    if (localDW->obj.pMID.pMinHeapLength > 0.0F) {
+      filter_current_MedianFilterCG_trickleDownMin(&localDW->obj.pMID, 1.0F);
     }
   }
 
-  vprev = filter_current_DW.obj.pMID.pBuf[static_cast<int32_T>
-    (filter_current_DW.obj.pMID.pHeap[static_cast<int32_T>
-     (filter_current_DW.obj.pMID.pMidHeap) - 1]) - 1];
-  vprev += filter_current_DW.obj.pMID.pBuf[static_cast<int32_T>
-    (filter_current_DW.obj.pMID.pHeap[static_cast<int32_T>
-     (filter_current_DW.obj.pMID.pMidHeap - 1.0F) - 1]) - 1];
+  vprev = localDW->obj.pMID.pBuf[static_cast<int32_T>(localDW->obj.pMID.pHeap[
+    static_cast<int32_T>(localDW->obj.pMID.pMidHeap) - 1]) - 1];
+  vprev += localDW->obj.pMID.pBuf[static_cast<int32_T>(localDW->obj.pMID.pHeap[
+    static_cast<int32_T>(localDW->obj.pMID.pMidHeap - 1.0F) - 1]) - 1];
   rty_FilteredCurrent->current = vprev / 2.0F;
 
   // End of MATLABSystem: '<Root>/Median Filter'
 }
 
 // Termination for referenced model: 'filter_current'
-void filter_current_Term(void)
+void filter_current_Term(DW_filter_current_f_T *localDW)
 {
   // Terminate for MATLABSystem: '<Root>/Median Filter'
-  if (!filter_current_DW.obj.matlabCodegenIsDeleted) {
-    filter_current_DW.obj.matlabCodegenIsDeleted = true;
-    if ((filter_current_DW.obj.isInitialized == 1) &&
-        filter_current_DW.obj.isSetupComplete) {
-      filter_current_DW.obj.NumChannels = -1;
-      if (filter_current_DW.obj.pMID.isInitialized == 1) {
-        filter_current_DW.obj.pMID.isInitialized = 2;
+  if (!localDW->obj.matlabCodegenIsDeleted) {
+    localDW->obj.matlabCodegenIsDeleted = true;
+    if ((localDW->obj.isInitialized == 1) && localDW->obj.isSetupComplete) {
+      localDW->obj.NumChannels = -1;
+      if (localDW->obj.pMID.isInitialized == 1) {
+        localDW->obj.pMID.isInitialized = 2;
       }
     }
   }
@@ -352,15 +345,18 @@ void filter_current_Term(void)
 }
 
 // Model initialize function
-void filter_current_initialize(const char_T **rt_errorStatus)
+void filter_current_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_filter_current_T *const filter_current_M, DW_filter_current_f_T
+  *localDW)
 {
-  RT_MODEL_filter_current_T *const filter_current_M =
-    &(filter_current_MdlrefDW.rtm);
-
   // Registration code
 
   // initialize error status
   rtmSetErrorStatusPointer(filter_current_M, rt_errorStatus);
+
+  // states (dwork)
+  (void) std::memset(static_cast<void *>(localDW), 0,
+                     sizeof(DW_filter_current_f_T));
 }
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:03 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:02 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,54 +20,32 @@
 #define RTW_HEADER_filter_current_h_
 #include "rtwtypes.h"
 #include "filter_current_types.h"
+#include <cstring>
 
 // Block states (default storage) for model 'filter_current'
-#ifndef filter_current_MDLREF_HIDE_CHILD_
-
 struct DW_filter_current_f_T {
-  dsp_simulink_MedianFilter_fil_T obj; // '<Root>/Median Filter'
+  dsp_simulink_MedianFilter_filter_current_T obj;// '<Root>/Median Filter'
   boolean_T objisempty;                // '<Root>/Median Filter'
 };
-
-#endif                                 //filter_current_MDLREF_HIDE_CHILD_
-
-#ifndef filter_current_MDLREF_HIDE_CHILD_
 
 // Real-time Model Data Structure
 struct tag_RTM_filter_current_T {
   const char_T **errorStatus;
 };
 
-#endif                                 //filter_current_MDLREF_HIDE_CHILD_
-
-#ifndef filter_current_MDLREF_HIDE_CHILD_
-
 struct MdlrefDW_filter_current_T {
+  DW_filter_current_f_T rtdw;
   RT_MODEL_filter_current_T rtm;
 };
 
-#endif                                 //filter_current_MDLREF_HIDE_CHILD_
-
-extern void filter_current_Init(void);
-extern void filter_current(const ControlOutputs *rtu_ControlOutputs,
-  MotorCurrent *rty_FilteredCurrent);
-extern void filter_current_Term(void);
-
 // Model reference registration function
-extern void filter_current_initialize(const char_T **rt_errorStatus);
-
-#ifndef filter_current_MDLREF_HIDE_CHILD_
-
-extern MdlrefDW_filter_current_T filter_current_MdlrefDW;
-
-#endif                                 //filter_current_MDLREF_HIDE_CHILD_
-
-#ifndef filter_current_MDLREF_HIDE_CHILD_
-
-// Block states (default storage)
-extern DW_filter_current_f_T filter_current_DW;
-
-#endif                                 //filter_current_MDLREF_HIDE_CHILD_
+extern void filter_current_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_filter_current_T *const filter_current_M, DW_filter_current_f_T
+  *localDW);
+extern void filter_current_Init(DW_filter_current_f_T *localDW);
+extern void filter_current(const ControlOutputs *rtu_ControlOutputs,
+  MotorCurrent *rty_FilteredCurrent, DW_filter_current_f_T *localDW);
+extern void filter_current_Term(DW_filter_current_f_T *localDW);
 
 //-
 //  The generated code includes comments that allow you to trace directly

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:03 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:02 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/filter-current/filter_current_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'filter_current'.
 //
-// Model version                  : 4.0
+// Model version                  : 5.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:47:03 2023
+// C/C++ source code generated on : Tue Jun 27 10:19:02 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -46,14 +46,20 @@ struct ControlOutputs
 
   // direct current
   MotorCurrent Id_fbk;
+
+  // RMS of Iq
+  MotorCurrent Iq_rms;
+
+  // RMS of Id
+  MotorCurrent Id_rms;
 };
 
 #endif
 
-#ifndef struct_c_dsp_internal_MedianFilterCG_T
-#define struct_c_dsp_internal_MedianFilterCG_T
+#ifndef struct_c_dsp_internal_MedianFilterCG_filter_current_T
+#define struct_c_dsp_internal_MedianFilterCG_filter_current_T
 
-struct c_dsp_internal_MedianFilterCG_T
+struct c_dsp_internal_MedianFilterCG_filter_current_T
 {
   int32_T isInitialized;
   boolean_T isSetupComplete;
@@ -67,7 +73,7 @@ struct c_dsp_internal_MedianFilterCG_T
   real32_T pMaxHeapLength;
 };
 
-#endif                                // struct_c_dsp_internal_MedianFilterCG_T
+#endif                 // struct_c_dsp_internal_MedianFilterCG_filter_current_T
 
 #ifndef struct_cell_wrap_filter_current_T
 #define struct_cell_wrap_filter_current_T
@@ -79,20 +85,20 @@ struct cell_wrap_filter_current_T
 
 #endif                                 // struct_cell_wrap_filter_current_T
 
-#ifndef struct_dsp_simulink_MedianFilter_fil_T
-#define struct_dsp_simulink_MedianFilter_fil_T
+#ifndef struct_dsp_simulink_MedianFilter_filter_current_T
+#define struct_dsp_simulink_MedianFilter_filter_current_T
 
-struct dsp_simulink_MedianFilter_fil_T
+struct dsp_simulink_MedianFilter_filter_current_T
 {
   boolean_T matlabCodegenIsDeleted;
   int32_T isInitialized;
   boolean_T isSetupComplete;
   cell_wrap_filter_current_T inputVarSize;
   int32_T NumChannels;
-  c_dsp_internal_MedianFilterCG_T pMID;
+  c_dsp_internal_MedianFilterCG_filter_current_T pMID;
 };
 
-#endif                                // struct_dsp_simulink_MedianFilter_fil_T
+#endif                     // struct_dsp_simulink_MedianFilter_filter_current_T
 
 // Forward declaration for rtModel
 typedef struct tag_RTM_filter_current_T RT_MODEL_filter_current_T;

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/const_params.cpp
@@ -9,7 +9,7 @@
 //
 //  Model version              : 4.0
 //  Simulink Coder version : 9.9 (R2023a) 19-Nov-2022
-//  C++ source code generated on : Thu Mar 23 18:06:40 2023
+//  C++ source code generated on : Wed May 10 16:29:55 2023
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetInf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetInf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetNaN.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtGetNaN.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_hypotf_snf.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:40 2023
+// C/C++ source code generated on : Wed May 10 16:29:55 2023
 //
 #include "rtwtypes.h"
 #include "rt_hypotf_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_hypotf_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_hypotf_snf.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 4.0
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:40 2023
+// C/C++ source code generated on : Wed May 10 16:29:55 2023
 //
 #ifndef RTW_HEADER_rt_hypotf_snf_h_
 #define RTW_HEADER_rt_hypotf_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_nonfinite.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 extern "C"
 {

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_nonfinite.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_roundd_snf.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_roundd_snf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.3
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:05:34 2023
+// C/C++ source code generated on : Wed May 10 16:28:45 2023
 //
 #include "rtwtypes.h"
 #include "rt_roundd_snf.h"

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_roundd_snf.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rt_roundd_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.3
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:05:34 2023
+// C/C++ source code generated on : Wed May 10 16:28:45 2023
 //
 #ifndef RTW_HEADER_rt_roundd_snf_h_
 #define RTW_HEADER_rt_roundd_snf_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtw_defines.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtw_defines.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.3
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:05:34 2023
+// C/C++ source code generated on : Wed May 10 16:28:45 2023
 //
 
 #ifndef RTW_HEADER_rtw_defines_h_

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.3
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:05:34 2023
+// C/C++ source code generated on : Wed May 10 16:28:45 2023
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/sharedutils/zero_crossing_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 5.1
+// Model version                  : 5.7
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Mar 23 18:06:21 2023
+// C/C++ source code generated on : Wed May 10 16:29:34 2023
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.4
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:45:52 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -21,27 +21,27 @@
 #include "SupervisorFSM_RX_types.h"
 #include <cmath>
 #include "rt_roundd_snf.h"
-#include "rtw_defines.h"
 #include "SupervisorFSM_RX_private.h"
+#include "rtw_defines.h"
 
 // Named constants for Chart: '<S2>/ControlMode_SM_motor0'
 const uint8_T SupervisorFSM_RX_IN_Current = 1U;
 const uint8_T SupervisorFSM_RX_IN_HWFault = 2U;
 const uint8_T SupervisorFSM_RX_IN_Idle = 3U;
+const uint8_T SupervisorFSM_RX_IN_NotConfigured = 4U;
 const uint8_T SupervisorFSM_RX_IN_Position = 5U;
 const uint8_T SupervisorFSM_RX_IN_Velocity = 6U;
 const uint8_T SupervisorFSM_RX_IN_Voltage = 7U;
-const uint8_T SupervisorFSM__IN_NotConfigured = 4U;
 
 // Named constants for Chart: '<Root>/SupervisorRX State Handler'
-const uint8_T Superviso_IN_LimitNonConfigured = 1U;
+const uint8_T SupervisorFSM_RX_IN_ButtonPressed = 1U;
 const uint8_T SupervisorFSM_RX_IN_Configured = 1U;
 const uint8_T SupervisorFSM_RX_IN_Fault = 2U;
+const uint8_T SupervisorFSM_RX_IN_LimitNonConfigured = 1U;
 const uint8_T SupervisorFSM_RX_IN_NoFault = 2U;
+const uint8_T SupervisorFSM_RX_IN_NotConfigured_g = 3U;
+const uint8_T SupervisorFSM_RX_IN_OverCurrentFault = 3U;
 const uint8_T SupervisorFSM_RX_IN_state1 = 1U;
-const uint8_T SupervisorFSM__IN_ButtonPressed = 1U;
-const uint8_T SupervisorFS_IN_NotConfigured_g = 3U;
-const uint8_T SupervisorF_IN_OverCurrentFault = 3U;
 MdlrefDW_SupervisorFSM_RX_T SupervisorFSM_RX_MdlrefDW;
 
 // Block signals (default storage)
@@ -51,62 +51,62 @@ B_SupervisorFSM_RX_c_T SupervisorFSM_RX_B;
 DW_SupervisorFSM_RX_f_T SupervisorFSM_RX_DW;
 
 // Forward declaration for local functions
-static boolean_T Supervisor_CheckSetPointVoltage(void);
-static boolean_T Supervisor_CheckSetPointCurrent(void);
-static boolean_T Superviso_CheckSetPointVelocity(void);
-static boolean_T Superviso_CheckSetPointPosition(void);
+static boolean_T SupervisorFSM_RX_CheckSetPointVoltage(void);
+static boolean_T SupervisorFSM_RX_CheckSetPointCurrent(void);
+static boolean_T SupervisorFSM_RX_CheckSetPointVelocity(void);
+static boolean_T SupervisorFSM_RX_CheckSetPointPosition(void);
 
 // Forward declaration for local functions
 static boolean_T SupervisorFSM_RX_IsBoardReady(void);
-static boolean_T SupervisorFS_isConfigurationSet(void);
-static boolean_T SupervisorFS_IsNewCtrl_Velocity(void);
-static boolean_T SupervisorFSM_IsNewCtrl_Voltage(void);
-static boolean_T SupervisorFSM_IsNewCtrl_Current(void);
-static boolean_T SupervisorFS_IsNewCtrl_Position(void);
+static boolean_T SupervisorFSM_RX_isConfigurationSet(void);
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Velocity(void);
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Voltage(void);
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Current(void);
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Position(void);
 static boolean_T SupervisorFSM_RX_IsNewCtrl_Idle(void);
 static void SupervisorFSM_RX_Voltage(void);
 
 // Forward declaration for local functions
 static ControlModes SupervisorFSM_RX_convert(MCControlModes mccontrolmode);
-static void SupervisorFSM_formatMotorConfig(const BUS_MESSAGES_RX *Selector2);
-static void SupervisorF_hardwareConfigMotor(void);
+static void SupervisorFSM_RX_formatMotorConfig(const BUS_MESSAGES_RX *Selector2);
+static void SupervisorFSM_RX_hardwareConfigMotor(void);
 
 // Forward declaration for local functions
-static boolean_T SupervisorFSM_isBoardConfigured(void);
+static boolean_T SupervisorFSM_RX_isBoardConfigured(void);
 
 // Declare global variables for system: model 'SupervisorFSM_RX'
-const SensorsData *SupervisorFSM_R_rtu_SensorsData;// '<Root>/SensorsData'
-const ControlOutputs *SupervisorFS_rtu_ControlOutputs;// '<Root>/ControlOutputs' 
+const SensorsData *SupervisorFSM_RX_rtu_SensorsData;// '<Root>/SensorsData'
+const ControlOutputs *SupervisorFSM_RX_rtu_ControlOutputs;// '<Root>/ControlOutputs' 
 const BUS_MESSAGES_RX_MULTIPLE *SupervisorFSM_RX_rtu_MessagesRx;// '<Root>/MessagesRx' 
 const BUS_STATUS_RX_MULTIPLE *SupervisorFSM_RX_rtu_StatusRx;// '<Root>/StatusRx' 
 const BUS_CAN_RX_ERRORS_MULTIPLE *SupervisorFSM_RX_rtu_ErrorsRx;// '<Root>/ErrorsRx' 
 
 // Function for Chart: '<S5>/Chart1'
-static boolean_T Supervisor_CheckSetPointVoltage(void)
+static boolean_T SupervisorFSM_RX_CheckSetPointVoltage(void)
 {
   return SupervisorFSM_RX_B.controlModeDefined == ControlModes_Voltage;
 }
 
 // Function for Chart: '<S5>/Chart1'
-static boolean_T Supervisor_CheckSetPointCurrent(void)
+static boolean_T SupervisorFSM_RX_CheckSetPointCurrent(void)
 {
   return SupervisorFSM_RX_B.controlModeDefined == ControlModes_Current;
 }
 
 // Function for Chart: '<S5>/Chart1'
-static boolean_T Superviso_CheckSetPointVelocity(void)
+static boolean_T SupervisorFSM_RX_CheckSetPointVelocity(void)
 {
   return SupervisorFSM_RX_B.controlModeDefined == ControlModes_Velocity;
 }
 
 // Function for Chart: '<S5>/Chart1'
-static boolean_T Superviso_CheckSetPointPosition(void)
+static boolean_T SupervisorFSM_RX_CheckSetPointPosition(void)
 {
   return SupervisorFSM_RX_B.controlModeDefined == ControlModes_Position;
 }
 
 // System initialize for function-call system: '<Root>/SetpointHandler'
-void Supervisor_SetpointHandler_Init(void)
+void SupervisorFSM_RX_SetpointHandler_Init(void)
 {
   // SystemInitialize for Chart: '<S5>/Chart1'
   SupervisorFSM_RX_B.targets.jointpositions.position = 0.0F;
@@ -116,7 +116,7 @@ void Supervisor_SetpointHandler_Init(void)
 }
 
 // Output and update for function-call system: '<Root>/SetpointHandler'
-void SupervisorFSM_R_SetpointHandler(void)
+void SupervisorFSM_RX_SetpointHandler(void)
 {
   real32_T newSetpoint;
 
@@ -124,11 +124,11 @@ void SupervisorFSM_R_SetpointHandler(void)
   if (SupervisorFSM_RX_DW.is_active_c4_SupervisorFSM_RX == 0U) {
     SupervisorFSM_RX_DW.is_active_c4_SupervisorFSM_RX = 1U;
     if (SupervisorFSM_RX_B.receivedNewSetpoint) {
-      if (Supervisor_CheckSetPointVoltage()) {
+      if (SupervisorFSM_RX_CheckSetPointVoltage()) {
         newSetpoint = SupervisorFSM_RX_B.newSetpoint.voltage;
-      } else if (Supervisor_CheckSetPointCurrent()) {
+      } else if (SupervisorFSM_RX_CheckSetPointCurrent()) {
         newSetpoint = SupervisorFSM_RX_B.newSetpoint.current;
-      } else if (Superviso_CheckSetPointVelocity()) {
+      } else if (SupervisorFSM_RX_CheckSetPointVelocity()) {
         newSetpoint = SupervisorFSM_RX_B.newSetpoint.velocity;
       } else {
         newSetpoint = 0.0F;
@@ -141,26 +141,26 @@ void SupervisorFSM_R_SetpointHandler(void)
     SupervisorFSM_RX_B.targets.motorcurrent.current = 0.0F;
     SupervisorFSM_RX_B.targets.jointvelocities.velocity = 0.0F;
     SupervisorFSM_RX_B.targets.jointpositions.position = 0.0F;
-    if (Supervisor_CheckSetPointCurrent()) {
+    if (SupervisorFSM_RX_CheckSetPointCurrent()) {
       SupervisorFSM_RX_B.targets.motorcurrent.current = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
-    } else if (Supervisor_CheckSetPointVoltage()) {
+    } else if (SupervisorFSM_RX_CheckSetPointVoltage()) {
       SupervisorFSM_RX_B.targets.motorvoltage.voltage = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
-    } else if (Superviso_CheckSetPointVelocity()) {
+    } else if (SupervisorFSM_RX_CheckSetPointVelocity()) {
       SupervisorFSM_RX_B.targets.jointvelocities.velocity = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
-    } else if (Superviso_CheckSetPointPosition()) {
+    } else if (SupervisorFSM_RX_CheckSetPointPosition()) {
       SupervisorFSM_RX_B.targets.jointpositions.position = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
     }
   } else {
     if (SupervisorFSM_RX_B.receivedNewSetpoint) {
-      if (Supervisor_CheckSetPointVoltage()) {
+      if (SupervisorFSM_RX_CheckSetPointVoltage()) {
         newSetpoint = SupervisorFSM_RX_B.newSetpoint.voltage;
-      } else if (Supervisor_CheckSetPointCurrent()) {
+      } else if (SupervisorFSM_RX_CheckSetPointCurrent()) {
         newSetpoint = SupervisorFSM_RX_B.newSetpoint.current;
-      } else if (Superviso_CheckSetPointVelocity()) {
+      } else if (SupervisorFSM_RX_CheckSetPointVelocity()) {
         newSetpoint = SupervisorFSM_RX_B.newSetpoint.velocity;
       } else {
         newSetpoint = 0.0F;
@@ -173,16 +173,16 @@ void SupervisorFSM_R_SetpointHandler(void)
     SupervisorFSM_RX_B.targets.motorcurrent.current = 0.0F;
     SupervisorFSM_RX_B.targets.jointvelocities.velocity = 0.0F;
     SupervisorFSM_RX_B.targets.jointpositions.position = 0.0F;
-    if (Supervisor_CheckSetPointCurrent()) {
+    if (SupervisorFSM_RX_CheckSetPointCurrent()) {
       SupervisorFSM_RX_B.targets.motorcurrent.current = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
-    } else if (Supervisor_CheckSetPointVoltage()) {
+    } else if (SupervisorFSM_RX_CheckSetPointVoltage()) {
       SupervisorFSM_RX_B.targets.motorvoltage.voltage = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
-    } else if (Superviso_CheckSetPointVelocity()) {
+    } else if (SupervisorFSM_RX_CheckSetPointVelocity()) {
       SupervisorFSM_RX_B.targets.jointvelocities.velocity = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
-    } else if (Superviso_CheckSetPointPosition()) {
+    } else if (SupervisorFSM_RX_CheckSetPointPosition()) {
       SupervisorFSM_RX_B.targets.jointpositions.position = newSetpoint;
       SupervisorFSM_RX_B.hasSetpointChanged = true;
     }
@@ -198,31 +198,31 @@ static boolean_T SupervisorFSM_RX_IsBoardReady(void)
 }
 
 // Function for Chart: '<S2>/ControlMode_SM_motor0'
-static boolean_T SupervisorFS_isConfigurationSet(void)
+static boolean_T SupervisorFSM_RX_isConfigurationSet(void)
 {
   return SupervisorFSM_RX_B.areLimitsSet;
 }
 
 // Function for Chart: '<S2>/ControlMode_SM_motor0'
-static boolean_T SupervisorFS_IsNewCtrl_Velocity(void)
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Velocity(void)
 {
   return SupervisorFSM_RX_B.requiredControlMode == ControlModes_Velocity;
 }
 
 // Function for Chart: '<S2>/ControlMode_SM_motor0'
-static boolean_T SupervisorFSM_IsNewCtrl_Voltage(void)
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Voltage(void)
 {
   return SupervisorFSM_RX_B.requiredControlMode == ControlModes_Voltage;
 }
 
 // Function for Chart: '<S2>/ControlMode_SM_motor0'
-static boolean_T SupervisorFSM_IsNewCtrl_Current(void)
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Current(void)
 {
   return SupervisorFSM_RX_B.requiredControlMode == ControlModes_Current;
 }
 
 // Function for Chart: '<S2>/ControlMode_SM_motor0'
-static boolean_T SupervisorFS_IsNewCtrl_Position(void)
+static boolean_T SupervisorFSM_RX_IsNewCtrl_Position(void)
 {
   return SupervisorFSM_RX_B.requiredControlMode == ControlModes_Position;
 }
@@ -236,9 +236,9 @@ static boolean_T SupervisorFSM_RX_IsNewCtrl_Idle(void)
 // Function for Chart: '<S2>/ControlMode_SM_motor0'
 static void SupervisorFSM_RX_Voltage(void)
 {
-  boolean_T guard1 = false;
-  boolean_T guard2 = false;
-  boolean_T guard3 = false;
+  boolean_T guard1;
+  boolean_T guard2;
+  boolean_T guard3;
   SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
   guard1 = false;
   guard2 = false;
@@ -252,7 +252,7 @@ static void SupervisorFSM_RX_Voltage(void)
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       // this updates the targets value
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     } else if (SupervisorFSM_RX_B.isFaultButtonPressed) {
@@ -265,45 +265,45 @@ static void SupervisorFSM_RX_Voltage(void)
   }
 
   if (guard3) {
-    if (SupervisorFS_IsNewCtrl_Velocity()) {
-      if ((!SupervisorFSM_IsNewCtrl_Voltage()) &&
-          SupervisorFS_IsNewCtrl_Velocity()) {
+    if (SupervisorFSM_RX_IsNewCtrl_Velocity()) {
+      if ((!SupervisorFSM_RX_IsNewCtrl_Voltage()) &&
+          SupervisorFSM_RX_IsNewCtrl_Velocity()) {
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
           SupervisorFSM_RX_IN_Velocity;
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
         SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       } else {
         guard2 = true;
       }
-    } else if (!SupervisorFSM_IsNewCtrl_Voltage()) {
-      if (SupervisorFSM_IsNewCtrl_Current()) {
+    } else if (!SupervisorFSM_RX_IsNewCtrl_Voltage()) {
+      if (SupervisorFSM_RX_IsNewCtrl_Current()) {
         // Chart: '<S2>/ControlMode_SM_motor0'
         SupervisorFSM_RX_B.newSetpoint_i =
-          SupervisorFS_rtu_ControlOutputs->Iq_fbk.current;
+          SupervisorFSM_RX_rtu_ControlOutputs->Iq_fbk.current;
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
           SupervisorFSM_RX_IN_Current;
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_Current;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-      } else if (SupervisorFS_IsNewCtrl_Position()) {
+      } else if (SupervisorFSM_RX_IsNewCtrl_Position()) {
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
           SupervisorFSM_RX_IN_Position;
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
 
         // Chart: '<S2>/ControlMode_SM_motor0'
         SupervisorFSM_RX_B.newSetpoint_i =
-          SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
+          SupervisorFSM_RX_rtu_SensorsData->jointpositions.position;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       } else if (SupervisorFSM_RX_IsNewCtrl_Idle()) {
@@ -321,7 +321,7 @@ static void SupervisorFSM_RX_Voltage(void)
     SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
 
     // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-    SupervisorFSM_R_SetpointHandler();
+    SupervisorFSM_RX_SetpointHandler();
 
     // End of Outputs for SubSystem: '<Root>/SetpointHandler'
   }
@@ -333,44 +333,45 @@ static void SupervisorFSM_RX_Voltage(void)
 
     // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
     // this updates the targets value
-    SupervisorFSM_R_SetpointHandler();
+    SupervisorFSM_RX_SetpointHandler();
 
     // End of Outputs for SubSystem: '<Root>/SetpointHandler'
   }
 }
 
 // Output and update for function-call system: '<Root>/Control Mode Handler Motor 0'
-void Superv_ControlModeHandlerMotor0(void)
+void SupervisorFSM_RX_ControlModeHandlerMotor0(void)
 {
-  boolean_T guard1 = false;
-  boolean_T guard10 = false;
-  boolean_T guard11 = false;
-  boolean_T guard2 = false;
-  boolean_T guard3 = false;
-  boolean_T guard4 = false;
-  boolean_T guard5 = false;
-  boolean_T guard6 = false;
-  boolean_T guard7 = false;
-  boolean_T guard8 = false;
-  boolean_T guard9 = false;
+  boolean_T guard1;
+  boolean_T guard10;
+  boolean_T guard11;
+  boolean_T guard2;
+  boolean_T guard3;
+  boolean_T guard4;
+  boolean_T guard5;
+  boolean_T guard6;
+  boolean_T guard7;
+  boolean_T guard8;
+  boolean_T guard9;
   boolean_T tmp;
 
   // Chart: '<S2>/ControlMode_SM_motor0'
   if (SupervisorFSM_RX_DW.is_active_c12_SupervisorFSM_RX == 0U) {
     SupervisorFSM_RX_DW.is_active_c12_SupervisorFSM_RX = 1U;
-    if (SupervisorFSM_RX_IsBoardReady() && SupervisorFS_isConfigurationSet()) {
+    if (SupervisorFSM_RX_IsBoardReady() && SupervisorFSM_RX_isConfigurationSet())
+    {
       SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX = SupervisorFSM_RX_IN_Idle;
       SupervisorFSM_RX_B.controlModeDefined = ControlModes_Idle;
       rtw_disableMotor();
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       // this updates the targets value
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     } else {
       SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
-        SupervisorFSM__IN_NotConfigured;
+        SupervisorFSM_RX_IN_NotConfigured;
       SupervisorFSM_RX_B.controlModeDefined = ControlModes_NotConfigured;
       rtw_disableMotor();
     }
@@ -399,7 +400,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
           // this updates the targets value
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_RX_B.isFaultButtonPressed) {
@@ -416,9 +417,9 @@ void Superv_ControlModeHandlerMotor0(void)
       SupervisorFSM_RX_B.controlModeDefined = ControlModes_HwFaultCM;
       tmp = !SupervisorFSM_RX_B.isInOverCurrent;
       if (tmp && SupervisorFSM_RX_IsNewCtrl_Idle() &&
-          (!SupervisorFS_isConfigurationSet())) {
+          (!SupervisorFSM_RX_isConfigurationSet())) {
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
-          SupervisorFSM__IN_NotConfigured;
+          SupervisorFSM_RX_IN_NotConfigured;
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_NotConfigured;
         rtw_disableMotor();
       } else if (tmp && SupervisorFSM_RX_IsNewCtrl_Idle()) {
@@ -428,7 +429,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
         // this updates the targets value
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       }
@@ -446,7 +447,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
           // this updates the targets value
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_RX_B.isFaultButtonPressed) {
@@ -459,17 +460,17 @@ void Superv_ControlModeHandlerMotor0(void)
       }
       break;
 
-     case SupervisorFSM__IN_NotConfigured:
+     case SupervisorFSM_RX_IN_NotConfigured:
       SupervisorFSM_RX_B.controlModeDefined = ControlModes_NotConfigured;
-      if (SupervisorFSM_RX_IsBoardReady() && SupervisorFS_isConfigurationSet())
-      {
+      if (SupervisorFSM_RX_IsBoardReady() && SupervisorFSM_RX_isConfigurationSet
+          ()) {
         SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX = SupervisorFSM_RX_IN_Idle;
         SupervisorFSM_RX_B.controlModeDefined = ControlModes_Idle;
         rtw_disableMotor();
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
         // this updates the targets value
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       } else if (SupervisorFSM_RX_B.isInOverCurrent) {
@@ -480,7 +481,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
         // this updates the targets value
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       }
@@ -498,7 +499,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
           // this updates the targets value
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_RX_B.isFaultButtonPressed) {
@@ -523,7 +524,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
           // this updates the targets value
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_RX_B.isFaultButtonPressed) {
@@ -544,36 +545,37 @@ void Superv_ControlModeHandlerMotor0(void)
 
     if (guard11) {
       if ((!SupervisorFSM_RX_IsNewCtrl_Idle()) &&
-          (!SupervisorFS_IsNewCtrl_Position())) {
-        if (SupervisorFSM_IsNewCtrl_Current()) {
+          (!SupervisorFSM_RX_IsNewCtrl_Position())) {
+        if (SupervisorFSM_RX_IsNewCtrl_Current()) {
           SupervisorFSM_RX_B.newSetpoint_i =
-            SupervisorFS_rtu_ControlOutputs->Iq_fbk.current;
+            SupervisorFSM_RX_rtu_ControlOutputs->Iq_fbk.current;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Current;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Current;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFSM_IsNewCtrl_Voltage()) {
-          SupervisorFSM_RX_B.newSetpoint_i = SupervisorFS_rtu_ControlOutputs->Vq;
+        } else if (SupervisorFSM_RX_IsNewCtrl_Voltage()) {
+          SupervisorFSM_RX_B.newSetpoint_i =
+            SupervisorFSM_RX_rtu_ControlOutputs->Vq;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Voltage;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFS_IsNewCtrl_Velocity()) {
+        } else if (SupervisorFSM_RX_IsNewCtrl_Velocity()) {
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Velocity;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
           SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else {
@@ -585,37 +587,38 @@ void Superv_ControlModeHandlerMotor0(void)
     }
 
     if (guard10) {
-      if (!SupervisorFS_IsNewCtrl_Velocity()) {
-        if (SupervisorFSM_IsNewCtrl_Voltage()) {
-          SupervisorFSM_RX_B.newSetpoint_i = SupervisorFS_rtu_ControlOutputs->Vq;
+      if (!SupervisorFSM_RX_IsNewCtrl_Velocity()) {
+        if (SupervisorFSM_RX_IsNewCtrl_Voltage()) {
+          SupervisorFSM_RX_B.newSetpoint_i =
+            SupervisorFSM_RX_rtu_ControlOutputs->Vq;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Voltage;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFSM_IsNewCtrl_Current()) {
+        } else if (SupervisorFSM_RX_IsNewCtrl_Current()) {
           SupervisorFSM_RX_B.newSetpoint_i =
-            SupervisorFS_rtu_ControlOutputs->Iq_fbk.current;
+            SupervisorFSM_RX_rtu_ControlOutputs->Iq_fbk.current;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Current;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Current;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFS_IsNewCtrl_Position()) {
+        } else if (SupervisorFSM_RX_IsNewCtrl_Position()) {
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Position;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
           SupervisorFSM_RX_B.newSetpoint_i =
-            SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
+            SupervisorFSM_RX_rtu_SensorsData->jointpositions.position;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_RX_IsNewCtrl_Idle()) {
@@ -637,45 +640,45 @@ void Superv_ControlModeHandlerMotor0(void)
     if (guard8) {
       if (!SupervisorFSM_RX_IsNewCtrl_Idle()) {
         rtw_enableMotor();
-        if (SupervisorFS_IsNewCtrl_Position()) {
+        if (SupervisorFSM_RX_IsNewCtrl_Position()) {
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Position;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
           SupervisorFSM_RX_B.newSetpoint_i =
-            SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
+            SupervisorFSM_RX_rtu_SensorsData->jointpositions.position;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFSM_IsNewCtrl_Current()) {
+        } else if (SupervisorFSM_RX_IsNewCtrl_Current()) {
           SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Current;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Current;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFSM_IsNewCtrl_Voltage()) {
+        } else if (SupervisorFSM_RX_IsNewCtrl_Voltage()) {
           SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Voltage;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-        } else if (SupervisorFS_IsNewCtrl_Velocity()) {
+        } else if (SupervisorFSM_RX_IsNewCtrl_Velocity()) {
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Velocity;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
           SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else {
@@ -688,27 +691,27 @@ void Superv_ControlModeHandlerMotor0(void)
 
     if (guard7) {
       if ((!SupervisorFSM_RX_IsNewCtrl_Idle()) &&
-          (!SupervisorFS_IsNewCtrl_Position())) {
-        if (!SupervisorFSM_IsNewCtrl_Current()) {
-          if (SupervisorFSM_IsNewCtrl_Voltage()) {
+          (!SupervisorFSM_RX_IsNewCtrl_Position())) {
+        if (!SupervisorFSM_RX_IsNewCtrl_Current()) {
+          if (SupervisorFSM_RX_IsNewCtrl_Voltage()) {
             SupervisorFSM_RX_B.newSetpoint_i =
-              SupervisorFS_rtu_ControlOutputs->Vq;
+              SupervisorFSM_RX_rtu_ControlOutputs->Vq;
             SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
               SupervisorFSM_RX_IN_Voltage;
             SupervisorFSM_RX_B.controlModeDefined = ControlModes_Voltage;
 
             // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-            SupervisorFSM_R_SetpointHandler();
+            SupervisorFSM_RX_SetpointHandler();
 
             // End of Outputs for SubSystem: '<Root>/SetpointHandler'
-          } else if (SupervisorFS_IsNewCtrl_Velocity()) {
+          } else if (SupervisorFSM_RX_IsNewCtrl_Velocity()) {
             SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
               SupervisorFSM_RX_IN_Velocity;
             SupervisorFSM_RX_B.controlModeDefined = ControlModes_Velocity;
             SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
 
             // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-            SupervisorFSM_R_SetpointHandler();
+            SupervisorFSM_RX_SetpointHandler();
 
             // End of Outputs for SubSystem: '<Root>/SetpointHandler'
           } else {
@@ -717,16 +720,16 @@ void Superv_ControlModeHandlerMotor0(void)
         } else {
           guard2 = true;
         }
-      } else if (!SupervisorFSM_IsNewCtrl_Current()) {
-        if (SupervisorFS_IsNewCtrl_Position()) {
+      } else if (!SupervisorFSM_RX_IsNewCtrl_Current()) {
+        if (SupervisorFSM_RX_IsNewCtrl_Position()) {
           SupervisorFSM_RX_DW.is_c12_SupervisorFSM_RX =
             SupervisorFSM_RX_IN_Position;
           SupervisorFSM_RX_B.controlModeDefined = ControlModes_Position;
           SupervisorFSM_RX_B.newSetpoint_i =
-            SupervisorFSM_R_rtu_SensorsData->jointpositions.position;
+            SupervisorFSM_RX_rtu_SensorsData->jointpositions.position;
 
           // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-          SupervisorFSM_R_SetpointHandler();
+          SupervisorFSM_RX_SetpointHandler();
 
           // End of Outputs for SubSystem: '<Root>/SetpointHandler'
         } else if (SupervisorFSM_RX_IsNewCtrl_Idle()) {
@@ -745,7 +748,7 @@ void Superv_ControlModeHandlerMotor0(void)
       SupervisorFSM_RX_B.newSetpoint_i = 0.0F;
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     }
@@ -757,7 +760,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       // this updates the targets value
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     }
@@ -769,7 +772,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       // this updates the targets value
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     }
@@ -781,7 +784,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       // this updates the targets value
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     }
@@ -791,7 +794,7 @@ void Superv_ControlModeHandlerMotor0(void)
       SupervisorFSM_RX_B.controlModeDefined = ControlModes_Current;
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     }
@@ -803,7 +806,7 @@ void Superv_ControlModeHandlerMotor0(void)
 
       // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
       // this updates the targets value
-      SupervisorFSM_R_SetpointHandler();
+      SupervisorFSM_RX_SetpointHandler();
 
       // End of Outputs for SubSystem: '<Root>/SetpointHandler'
     }
@@ -813,7 +816,7 @@ void Superv_ControlModeHandlerMotor0(void)
 }
 
 // System initialize for function-call system: '<Root>/Limits Handler'
-void SupervisorFS_LimitsHandler_Init(void)
+void SupervisorFSM_RX_LimitsHandler_Init(void)
 {
   // SystemInitialize for Chart: '<S3>/Chart'
   SupervisorFSM_RX_B.thresholds.jntPosMin = 0.0F;
@@ -828,6 +831,7 @@ void SupervisorFS_LimitsHandler_Init(void)
   SupervisorFSM_RX_B.thresholds.motorPeakCurrents = 0.0F;
   SupervisorFSM_RX_B.thresholds.motorOverloadCurrents = 0.0F;
   SupervisorFSM_RX_B.thresholds.motorPwmLimit = 0U;
+  SupervisorFSM_RX_B.thresholds.motorCriticalTemperature = 0.0F;
 }
 
 // Output and update for function-call system: '<Root>/Limits Handler'
@@ -848,7 +852,7 @@ void SupervisorFSM_RX_LimitsHandler(void)
         SupervisorFSM_RX_B.areLimitsSet = true;
 
         // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-        Superv_ControlModeHandlerMotor0();
+        SupervisorFSM_RX_ControlModeHandlerMotor0();
 
         // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0'
       }
@@ -864,7 +868,7 @@ void SupervisorFSM_RX_LimitsHandler(void)
       SupervisorFSM_RX_B.areLimitsSet = true;
 
       // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-      Superv_ControlModeHandlerMotor0();
+      SupervisorFSM_RX_ControlModeHandlerMotor0();
 
       // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0'
     }
@@ -874,7 +878,7 @@ void SupervisorFSM_RX_LimitsHandler(void)
 }
 
 // System initialize for function-call system: '<Root>/PID Handler'
-void SupervisorFSM_R_PIDHandler_Init(void)
+void SupervisorFSM_RX_PIDHandler_Init(void)
 {
   // SystemInitialize for Chart: '<S4>/Chart'
   SupervisorFSM_RX_B.CurrentPID.OutMax = 0.0F;
@@ -1018,7 +1022,7 @@ static ControlModes SupervisorFSM_RX_convert(MCControlModes mccontrolmode)
 }
 
 // Function for Chart: '<S1>/CAN Event Dispatcher'
-static void SupervisorFSM_formatMotorConfig(const BUS_MESSAGES_RX *Selector2)
+static void SupervisorFSM_RX_formatMotorConfig(const BUS_MESSAGES_RX *Selector2)
 {
   SupervisorFSM_RX_B.motorConfig.use_index = Selector2->motor_config.use_index;
   SupervisorFSM_RX_B.motorConfig.pole_pairs = static_cast<uint8_T>(rt_roundd_snf
@@ -1042,7 +1046,7 @@ static void SupervisorFSM_formatMotorConfig(const BUS_MESSAGES_RX *Selector2)
 }
 
 // Function for Chart: '<S1>/CAN Event Dispatcher'
-static void SupervisorF_hardwareConfigMotor(void)
+static void SupervisorFSM_RX_hardwareConfigMotor(void)
 {
   rtw_configMotor(static_cast<uint8_T>
                   (SupervisorFSM_RX_B.motorConfig.has_quadrature_encoder),
@@ -1052,7 +1056,7 @@ static void SupervisorF_hardwareConfigMotor(void)
 }
 
 // System initialize for function-call system: '<Root>/CAN Message Handler'
-void Supervis_CANMessageHandler_Init(void)
+void SupervisorFSM_RX_CANMessageHandler_Init(void)
 {
   // SystemInitialize for Chart: '<S1>/CAN Event Dispatcher'
   SupervisorFSM_RX_B.newSetpoint.current = 0.0F;
@@ -1083,27 +1087,32 @@ void Supervis_CANMessageHandler_Init(void)
   SupervisorFSM_RX_B.motorConfig.Imax = 0.0F;
   SupervisorFSM_RX_B.motorConfig.Vcc = 0.0F;
   SupervisorFSM_RX_B.motorConfig.Vmax = 0.0F;
+  SupervisorFSM_RX_B.motorConfig.resistance = 0.0F;
+  SupervisorFSM_RX_B.motorConfig.inductance = 0.0F;
+  SupervisorFSM_RX_B.motorConfig.thermal_resistance = 0.0F;
+  SupervisorFSM_RX_B.motorConfig.thermal_time_constant = 0.0F;
   SupervisorFSM_RX_B.estimationConfig.velocity_mode =
     EstimationVelocityModes_Disabled;
+  SupervisorFSM_RX_B.estimationConfig.current_rms_lambda = 0.0F;
 
   // SystemInitialize for Function Call SubSystem: '<Root>/SetpointHandler'
-  Supervisor_SetpointHandler_Init();
+  SupervisorFSM_RX_SetpointHandler_Init();
 
   // End of SystemInitialize for SubSystem: '<Root>/SetpointHandler'
 
   // SystemInitialize for Function Call SubSystem: '<Root>/Limits Handler'
-  SupervisorFS_LimitsHandler_Init();
+  SupervisorFSM_RX_LimitsHandler_Init();
 
   // End of SystemInitialize for SubSystem: '<Root>/Limits Handler'
 
   // SystemInitialize for Function Call SubSystem: '<Root>/PID Handler'
-  SupervisorFSM_R_PIDHandler_Init();
+  SupervisorFSM_RX_PIDHandler_Init();
 
   // End of SystemInitialize for SubSystem: '<Root>/PID Handler'
 }
 
 // Output and update for function-call system: '<Root>/CAN Message Handler'
-void SupervisorFSM_CANMessageHandler(void)
+void SupervisorFSM_RX_CANMessageHandler(void)
 {
   BUS_MESSAGES_RX Selector2;
 
@@ -1130,7 +1139,7 @@ void SupervisorFSM_CANMessageHandler(void)
         SupervisorFSM_RX_B.receivedNewSetpoint = false;
 
         // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-        Superv_ControlModeHandlerMotor0();
+        SupervisorFSM_RX_ControlModeHandlerMotor0();
 
         // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0'
       } else if (SupervisorFSM_RX_rtu_StatusRx->
@@ -1172,8 +1181,8 @@ void SupervisorFSM_CANMessageHandler(void)
         // End of Outputs for SubSystem: '<Root>/PID Handler'
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].motor_config) {
-        SupervisorFSM_formatMotorConfig(&Selector2);
-        SupervisorF_hardwareConfigMotor();
+        SupervisorFSM_RX_formatMotorConfig(&Selector2);
+        SupervisorFSM_RX_hardwareConfigMotor();
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].desired_targets) {
         SupervisorFSM_RX_B.newSetpoint =
@@ -1183,7 +1192,7 @@ void SupervisorFSM_CANMessageHandler(void)
         SupervisorFSM_RX_B.receivedNewSetpoint = true;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       }
@@ -1202,7 +1211,7 @@ void SupervisorFSM_CANMessageHandler(void)
         SupervisorFSM_RX_B.receivedNewSetpoint = false;
 
         // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-        Superv_ControlModeHandlerMotor0();
+        SupervisorFSM_RX_ControlModeHandlerMotor0();
 
         // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0'
       } else if (SupervisorFSM_RX_rtu_StatusRx->
@@ -1244,8 +1253,8 @@ void SupervisorFSM_CANMessageHandler(void)
         // End of Outputs for SubSystem: '<Root>/PID Handler'
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].motor_config) {
-        SupervisorFSM_formatMotorConfig(&Selector2);
-        SupervisorF_hardwareConfigMotor();
+        SupervisorFSM_RX_formatMotorConfig(&Selector2);
+        SupervisorFSM_RX_hardwareConfigMotor();
       } else if (SupervisorFSM_RX_rtu_StatusRx->
                  status[SupervisorFSM_RX_B.messageIndex - 1].desired_targets) {
         SupervisorFSM_RX_B.newSetpoint =
@@ -1255,7 +1264,7 @@ void SupervisorFSM_CANMessageHandler(void)
         SupervisorFSM_RX_B.receivedNewSetpoint = true;
 
         // Outputs for Function Call SubSystem: '<Root>/SetpointHandler'
-        SupervisorFSM_R_SetpointHandler();
+        SupervisorFSM_RX_SetpointHandler();
 
         // End of Outputs for SubSystem: '<Root>/SetpointHandler'
       }
@@ -1266,7 +1275,7 @@ void SupervisorFSM_CANMessageHandler(void)
 }
 
 // Function for Chart: '<Root>/SupervisorRX State Handler'
-static boolean_T SupervisorFSM_isBoardConfigured(void)
+static boolean_T SupervisorFSM_RX_isBoardConfigured(void)
 {
   return true;
 }
@@ -1278,15 +1287,18 @@ void SupervisorFSM_RX_Init(Flags *rty_Flags, ConfigurationParameters
   // SystemInitialize for Chart: '<Root>/SupervisorRX State Handler' incorporates:
   //   SubSystem: '<Root>/CAN Message Handler'
 
-  Supervis_CANMessageHandler_Init();
+  SupervisorFSM_RX_CANMessageHandler_Init();
 
   // SystemInitialize for BusCreator: '<Root>/Bus Creator'
   rty_Flags->control_mode = SupervisorFSM_RX_B.controlModeDefined;
   rty_Flags->enable_sending_msg_status =
     SupervisorFSM_RX_B.enableSendingMsgStatus;
   rty_Flags->fault_button = false;
+  rty_Flags->enable_thermal_protection = SupervisorFSM_RX_ConstB.Constant5;
 
-  // SystemInitialize for BusCreator: '<Root>/Bus Creator1'
+  // SystemInitialize for BusCreator: '<Root>/Bus Creator1' incorporates:
+  //   Constant: '<Root>/Constant4'
+
   rty_ConfigurationParameters->motorconfig = SupervisorFSM_RX_B.motorConfig;
   rty_ConfigurationParameters->estimationconfig =
     SupervisorFSM_RX_B.estimationConfig;
@@ -1295,6 +1307,8 @@ void SupervisorFSM_RX_Init(Flags *rty_Flags, ConfigurationParameters
   rty_ConfigurationParameters->VelLoopPID = SupervisorFSM_RX_B.VelocityPID;
   rty_ConfigurationParameters->DirLoopPID = SupervisorFSM_RX_B.OpenLoopPID;
   rty_ConfigurationParameters->thresholds = SupervisorFSM_RX_B.thresholds;
+  rty_ConfigurationParameters->environment_temperature =
+    InitConfParams.environment_temperature;
 }
 
 // Output and update for referenced model: 'SupervisorFSM_RX'
@@ -1307,39 +1321,39 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
                       Targets *rty_Targets, ConfigurationParameters
                       *rty_ConfigurationParameters)
 {
-  real32_T rtb_UnitDelay_thresholds_motorO;
-  SupervisorFSM_R_rtu_SensorsData = rtu_SensorsData;
-  SupervisorFS_rtu_ControlOutputs = rtu_ControlOutputs;
+  real32_T rtb_UnitDelay_thresholds_motorOverloadCurrents;
+  SupervisorFSM_RX_rtu_SensorsData = rtu_SensorsData;
+  SupervisorFSM_RX_rtu_ControlOutputs = rtu_ControlOutputs;
   SupervisorFSM_RX_rtu_MessagesRx = rtu_MessagesRx;
   SupervisorFSM_RX_rtu_StatusRx = rtu_StatusRx;
   SupervisorFSM_RX_rtu_ErrorsRx = rtu_ErrorsRx;
 
   // UnitDelay: '<Root>/Unit Delay'
-  rtb_UnitDelay_thresholds_motorO =
+  rtb_UnitDelay_thresholds_motorOverloadCurrents =
     SupervisorFSM_RX_DW.UnitDelay_DSTATE.thresholds.motorOverloadCurrents;
 
   // Chart: '<Root>/SupervisorRX State Handler' incorporates:
   //   UnitDelay: '<Root>/Unit Delay'
 
   SupervisorFSM_RX_DW.ExternalFlags_fault_button_prev =
-    SupervisorFSM_RX_DW.ExternalFlags_fault_button_star;
-  SupervisorFSM_RX_DW.ExternalFlags_fault_button_star =
+    SupervisorFSM_RX_DW.ExternalFlags_fault_button_start;
+  SupervisorFSM_RX_DW.ExternalFlags_fault_button_start =
     rtu_ExternalFlags->fault_button;
   if (SupervisorFSM_RX_DW.is_active_c2_SupervisorFSM_RX == 0U) {
     SupervisorFSM_RX_DW.ExternalFlags_fault_button_prev =
       rtu_ExternalFlags->fault_button;
-    SupervisorFSM_RX_DW.ExternalFlags_fault_button_star =
+    SupervisorFSM_RX_DW.ExternalFlags_fault_button_start =
       rtu_ExternalFlags->fault_button;
     SupervisorFSM_RX_DW.is_active_c2_SupervisorFSM_RX = 1U;
     SupervisorFSM_RX_DW.is_active_STATE_HANDLER = 1U;
-    SupervisorFSM_RX_DW.is_STATE_HANDLER = SupervisorFS_IN_NotConfigured_g;
+    SupervisorFSM_RX_DW.is_STATE_HANDLER = SupervisorFSM_RX_IN_NotConfigured_g;
     SupervisorFSM_RX_B.BoardSt = BoardState_NotConfigured;
     SupervisorFSM_RX_DW.is_active_FAULT_HANDLER = 1U;
     SupervisorFSM_RX_DW.is_active_FaultButtonPressed = 1U;
     SupervisorFSM_RX_DW.is_FaultButtonPressed = SupervisorFSM_RX_IN_NoFault;
     SupervisorFSM_RX_B.isFaultButtonPressed = false;
     SupervisorFSM_RX_DW.is_active_OverCurrent = 1U;
-    SupervisorFSM_RX_DW.is_OverCurrent = Superviso_IN_LimitNonConfigured;
+    SupervisorFSM_RX_DW.is_OverCurrent = SupervisorFSM_RX_IN_LimitNonConfigured;
     SupervisorFSM_RX_DW.is_active_CAN_MESSAGES_FOR_LOOP = 1U;
 
     // Outputs for Function Call SubSystem: '<Root>/PID Handler'
@@ -1354,7 +1368,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
     SupervisorFSM_RX_B.messageIndex = 1;
     while (SupervisorFSM_RX_B.messageIndex <= CAN_MAX_NUM_PACKETS) {
       // Outputs for Function Call SubSystem: '<Root>/CAN Message Handler'
-      SupervisorFSM_CANMessageHandler();
+      SupervisorFSM_RX_CANMessageHandler();
 
       // End of Outputs for SubSystem: '<Root>/CAN Message Handler'
       SupervisorFSM_RX_B.messageIndex++;
@@ -1372,9 +1386,9 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
         SupervisorFSM_RX_B.BoardSt = BoardState_Fault;
         break;
 
-       case SupervisorFS_IN_NotConfigured_g:
+       case SupervisorFSM_RX_IN_NotConfigured_g:
         SupervisorFSM_RX_B.BoardSt = BoardState_NotConfigured;
-        if (SupervisorFSM_isBoardConfigured()) {
+        if (SupervisorFSM_RX_isBoardConfigured()) {
           SupervisorFSM_RX_DW.is_STATE_HANDLER = SupervisorFSM_RX_IN_Configured;
           SupervisorFSM_RX_B.BoardSt = BoardState_Configured;
         }
@@ -1385,11 +1399,11 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
     if (SupervisorFSM_RX_DW.is_active_FAULT_HANDLER != 0U) {
       if (SupervisorFSM_RX_DW.is_active_FaultButtonPressed != 0U) {
         switch (SupervisorFSM_RX_DW.is_FaultButtonPressed) {
-         case SupervisorFSM__IN_ButtonPressed:
+         case SupervisorFSM_RX_IN_ButtonPressed:
           SupervisorFSM_RX_B.isFaultButtonPressed = true;
           if ((SupervisorFSM_RX_DW.ExternalFlags_fault_button_prev !=
-               SupervisorFSM_RX_DW.ExternalFlags_fault_button_star) &&
-              (!SupervisorFSM_RX_DW.ExternalFlags_fault_button_star)) {
+               SupervisorFSM_RX_DW.ExternalFlags_fault_button_start) &&
+              (!SupervisorFSM_RX_DW.ExternalFlags_fault_button_start)) {
             SupervisorFSM_RX_DW.is_FaultButtonPressed =
               SupervisorFSM_RX_IN_NoFault;
             SupervisorFSM_RX_B.isFaultButtonPressed = false;
@@ -1399,14 +1413,14 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
          case SupervisorFSM_RX_IN_NoFault:
           SupervisorFSM_RX_B.isFaultButtonPressed = false;
           if ((SupervisorFSM_RX_DW.ExternalFlags_fault_button_prev !=
-               SupervisorFSM_RX_DW.ExternalFlags_fault_button_star) &&
-              SupervisorFSM_RX_DW.ExternalFlags_fault_button_star) {
+               SupervisorFSM_RX_DW.ExternalFlags_fault_button_start) &&
+              SupervisorFSM_RX_DW.ExternalFlags_fault_button_start) {
             SupervisorFSM_RX_DW.is_FaultButtonPressed =
-              SupervisorFSM__IN_ButtonPressed;
+              SupervisorFSM_RX_IN_ButtonPressed;
             SupervisorFSM_RX_B.isFaultButtonPressed = true;
 
             // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-            Superv_ControlModeHandlerMotor0();
+            SupervisorFSM_RX_ControlModeHandlerMotor0();
 
             // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0' 
           }
@@ -1416,7 +1430,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
 
       if (SupervisorFSM_RX_DW.is_active_OverCurrent != 0U) {
         switch (SupervisorFSM_RX_DW.is_OverCurrent) {
-         case Superviso_IN_LimitNonConfigured:
+         case SupervisorFSM_RX_IN_LimitNonConfigured:
           if (SupervisorFSM_RX_B.areLimitsSet) {
             SupervisorFSM_RX_DW.is_OverCurrent = SupervisorFSM_RX_IN_NoFault;
             SupervisorFSM_RX_B.isInOverCurrent = false;
@@ -1428,23 +1442,24 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
          case SupervisorFSM_RX_IN_NoFault:
           SupervisorFSM_RX_B.isInOverCurrent = false;
           if (std::abs(rtu_EstimatedData->Iq_filtered.current) >=
-              rtb_UnitDelay_thresholds_motorO) {
-            SupervisorFSM_RX_DW.is_OverCurrent = SupervisorF_IN_OverCurrentFault;
+              rtb_UnitDelay_thresholds_motorOverloadCurrents) {
+            SupervisorFSM_RX_DW.is_OverCurrent =
+              SupervisorFSM_RX_IN_OverCurrentFault;
 
             // MotorFaultFlags.overCurrent=1;
             SupervisorFSM_RX_B.isInOverCurrent = true;
 
             // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
-            Superv_ControlModeHandlerMotor0();
+            SupervisorFSM_RX_ControlModeHandlerMotor0();
 
             // End of Outputs for SubSystem: '<Root>/Control Mode Handler Motor 0' 
           }
           break;
 
-         case SupervisorF_IN_OverCurrentFault:
+         case SupervisorFSM_RX_IN_OverCurrentFault:
           SupervisorFSM_RX_B.isInOverCurrent = true;
           if (std::abs(rtu_EstimatedData->Iq_filtered.current) <
-              rtb_UnitDelay_thresholds_motorO) {
+              rtb_UnitDelay_thresholds_motorOverloadCurrents) {
             SupervisorFSM_RX_DW.is_OverCurrent = SupervisorFSM_RX_IN_NoFault;
             SupervisorFSM_RX_B.isInOverCurrent = false;
 
@@ -1461,7 +1476,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
       SupervisorFSM_RX_B.messageIndex = 1;
       while (SupervisorFSM_RX_B.messageIndex <= CAN_MAX_NUM_PACKETS) {
         // Outputs for Function Call SubSystem: '<Root>/CAN Message Handler'
-        SupervisorFSM_CANMessageHandler();
+        SupervisorFSM_RX_CANMessageHandler();
 
         // End of Outputs for SubSystem: '<Root>/CAN Message Handler'
         SupervisorFSM_RX_B.messageIndex++;
@@ -1478,8 +1493,11 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
   rty_Flags->enable_sending_msg_status =
     SupervisorFSM_RX_B.enableSendingMsgStatus;
   rty_Flags->fault_button = SupervisorFSM_RX_B.isFaultButtonPressed;
+  rty_Flags->enable_thermal_protection = SupervisorFSM_RX_ConstB.Constant5;
 
-  // BusCreator: '<Root>/Bus Creator1'
+  // BusCreator: '<Root>/Bus Creator1' incorporates:
+  //   Constant: '<Root>/Constant4'
+
   rty_ConfigurationParameters->motorconfig = SupervisorFSM_RX_B.motorConfig;
   rty_ConfigurationParameters->estimationconfig =
     SupervisorFSM_RX_B.estimationConfig;
@@ -1488,6 +1506,8 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
   rty_ConfigurationParameters->VelLoopPID = SupervisorFSM_RX_B.VelocityPID;
   rty_ConfigurationParameters->DirLoopPID = SupervisorFSM_RX_B.OpenLoopPID;
   rty_ConfigurationParameters->thresholds = SupervisorFSM_RX_B.thresholds;
+  rty_ConfigurationParameters->environment_temperature =
+    InitConfParams.environment_temperature;
 
   // Switch: '<Root>/Switch2' incorporates:
   //   BusCreator: '<Root>/Bus Creator2'

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.4
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:45:52 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -33,11 +33,11 @@
 
 struct B_SupervisorFSM_RX_c_T {
   Thresholds thresholds;               // '<S3>/Chart'
+  MotorConfig motorConfig;             // '<S1>/CAN Event Dispatcher'
   PIDConfig CurrentPID;                // '<S4>/Chart'
   PIDConfig VelocityPID;               // '<S4>/Chart'
   PIDConfig PositionPID;               // '<S4>/Chart'
   PIDConfig OpenLoopPID;               // '<S4>/Chart'
-  MotorConfig motorConfig;             // '<S1>/CAN Event Dispatcher'
   Targets targets;                     // '<S5>/Chart1'
   BUS_MSG_PID newPID;                  // '<S1>/CAN Event Dispatcher'
   SV_Limits newLimit;                  // '<S1>/CAN Event Dispatcher'
@@ -81,7 +81,16 @@ struct DW_SupervisorFSM_RX_f_T {
   uint8_T is_c12_SupervisorFSM_RX;     // '<S2>/ControlMode_SM_motor0'
   uint8_T is_active_c4_SupervisorFSM_RX;// '<S5>/Chart1'
   boolean_T ExternalFlags_fault_button_prev;// '<Root>/SupervisorRX State Handler' 
-  boolean_T ExternalFlags_fault_button_star;// '<Root>/SupervisorRX State Handler' 
+  boolean_T ExternalFlags_fault_button_start;// '<Root>/SupervisorRX State Handler' 
+};
+
+#endif                                 //SupervisorFSM_RX_MDLREF_HIDE_CHILD_
+
+// Invariant block signals for model 'SupervisorFSM_RX'
+#ifndef SupervisorFSM_RX_MDLREF_HIDE_CHILD_
+
+struct ConstB_SupervisorFSM_RX_h_T {
+  boolean_T Constant5;                 // '<Root>/Constant5'
 };
 
 #endif                                 //SupervisorFSM_RX_MDLREF_HIDE_CHILD_
@@ -113,6 +122,7 @@ struct MdlrefDW_SupervisorFSM_RX_T {
 
 extern ConfigurationParameters InitConfParams;// Variable: InitConfParams
                                                  //  Referenced by:
+                                                 //    '<Root>/Constant4'
                                                  //    '<S1>/CAN Event Dispatcher'
                                                  //    '<S3>/Chart'
                                                  //    '<S4>/Chart'
@@ -131,15 +141,15 @@ extern void SupervisorFSM_RX_initialize(const char_T **rt_errorStatus);
 
 #ifndef SupervisorFSM_RX_MDLREF_HIDE_CHILD_
 
-extern void Supervisor_SetpointHandler_Init(void);
-extern void SupervisorFSM_R_SetpointHandler(void);
-extern void Superv_ControlModeHandlerMotor0(void);
-extern void SupervisorFS_LimitsHandler_Init(void);
+extern void SupervisorFSM_RX_SetpointHandler_Init(void);
+extern void SupervisorFSM_RX_SetpointHandler(void);
+extern void SupervisorFSM_RX_ControlModeHandlerMotor0(void);
+extern void SupervisorFSM_RX_LimitsHandler_Init(void);
 extern void SupervisorFSM_RX_LimitsHandler(void);
-extern void SupervisorFSM_R_PIDHandler_Init(void);
+extern void SupervisorFSM_RX_PIDHandler_Init(void);
 extern void SupervisorFSM_RX_PIDHandler(void);
-extern void Supervis_CANMessageHandler_Init(void);
-extern void SupervisorFSM_CANMessageHandler(void);
+extern void SupervisorFSM_RX_CANMessageHandler_Init(void);
+extern void SupervisorFSM_RX_CANMessageHandler(void);
 
 #endif                                 //SupervisorFSM_RX_MDLREF_HIDE_CHILD_
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX_data.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX_data.cpp
@@ -1,0 +1,31 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: SupervisorFSM_RX_data.cpp
+//
+// Code generated for Simulink model 'SupervisorFSM_RX'.
+//
+// Model version                  : 6.4
+// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
+// C/C++ source code generated on : Tue Jun 27 10:17:32 2023
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#include "SupervisorFSM_RX_private.h"
+
+// Invariant block signals (default storage)
+const ConstB_SupervisorFSM_RX_h_T SupervisorFSM_RX_ConstB = {
+  0
+  // '<Root>/Constant5'
+};
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.4
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:45:52 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -20,6 +20,7 @@
 #define RTW_HEADER_SupervisorFSM_RX_private_h_
 #include "rtwtypes.h"
 #include "SupervisorFSM_RX_types.h"
+#include "SupervisorFSM_RX.h"
 
 // Macros for accessing real-time model data structure
 #ifndef rtmGetErrorStatus
@@ -37,6 +38,10 @@
 #ifndef rtmSetErrorStatusPointer
 #define rtmSetErrorStatusPointer(rtm, val) ((rtm)->errorStatus = (val))
 #endif
+
+// Invariant block signals (default storage)
+extern const ConstB_SupervisorFSM_RX_h_T SupervisorFSM_RX_ConstB;
+
 #endif                                // RTW_HEADER_SupervisorFSM_RX_private_h_
 
 //

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 5.9
+// Model version                  : 6.4
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:45:52 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:32 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -97,6 +97,12 @@ struct ControlOutputs
 
   // direct current
   MotorCurrent Id_fbk;
+
+  // RMS of Iq
+  MotorCurrent Iq_rms;
+
+  // RMS of Id
+  MotorCurrent Id_rms;
 };
 
 #endif
@@ -257,14 +263,30 @@ struct JointVelocities
 
 #endif
 
+#ifndef DEFINED_TYPEDEF_FOR_MotorTemperature_
+#define DEFINED_TYPEDEF_FOR_MotorTemperature_
+
+struct MotorTemperature
+{
+  // motor temperature
+  real32_T temperature;
+};
+
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
 #define DEFINED_TYPEDEF_FOR_EstimatedData_
 
 struct EstimatedData
 {
-  // velocities
+  // velocity
   JointVelocities jointvelocities;
+
+  // filtered motor current
   MotorCurrent Iq_filtered;
+
+  // motor temperature
+  MotorTemperature motor_temperature;
 };
 
 #endif
@@ -358,6 +380,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T enable_thermal_protection;
 };
 
 #endif
@@ -383,6 +406,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -404,6 +431,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -475,6 +505,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -491,6 +524,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 6.0
+// Model version                  : 6.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:10 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:51 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 6.0
+// Model version                  : 6.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:10 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:51 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 6.0
+// Model version                  : 6.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:10 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:51 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/supervisor-tx/SupervisorFSM_TX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 6.0
+// Model version                  : 6.1
 // Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Thu Apr  6 14:46:10 2023
+// C/C++ source code generated on : Tue Jun 27 10:17:51 2023
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -81,14 +81,30 @@ struct MotorCurrent
 
 #endif
 
+#ifndef DEFINED_TYPEDEF_FOR_MotorTemperature_
+#define DEFINED_TYPEDEF_FOR_MotorTemperature_
+
+struct MotorTemperature
+{
+  // motor temperature
+  real32_T temperature;
+};
+
+#endif
+
 #ifndef DEFINED_TYPEDEF_FOR_EstimatedData_
 #define DEFINED_TYPEDEF_FOR_EstimatedData_
 
 struct EstimatedData
 {
-  // velocities
+  // velocity
   JointVelocities jointvelocities;
+
+  // filtered motor current
   MotorCurrent Iq_filtered;
+
+  // motor temperature
+  MotorTemperature motor_temperature;
 };
 
 #endif
@@ -119,6 +135,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T enable_thermal_protection;
 };
 
 #endif
@@ -139,6 +156,12 @@ struct ControlOutputs
 
   // direct current
   MotorCurrent Id_fbk;
+
+  // RMS of Iq
+  MotorCurrent Iq_rms;
+
+  // RMS of Id
+  MotorCurrent Id_rms;
 };
 
 #endif
@@ -164,6 +187,10 @@ struct MotorConfig
   real32_T Imax;
   real32_T Vcc;
   real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
 };
 
 #endif
@@ -185,6 +212,9 @@ typedef enum {
 struct EstimationConfig
 {
   EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
 };
 
 #endif
@@ -256,6 +286,9 @@ struct Thresholds
   // Max value is 32000
   // Can be only non-negative
   uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
 };
 
 #endif
@@ -272,6 +305,7 @@ struct ConfigurationParameters
   PIDConfig VelLoopPID;
   PIDConfig DirLoopPID;
   Thresholds thresholds;
+  real32_T environment_temperature;
 };
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model.cpp
@@ -1,0 +1,99 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: thermal_model.cpp
+//
+// Code generated for Simulink model 'thermal_model'.
+//
+// Model version                  : 5.21
+// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
+// C/C++ source code generated on : Tue Jun 27 10:19:07 2023
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#include "thermal_model.h"
+#include "thermal_model_types.h"
+#include "mw_cmsis.h"
+#include "rtwtypes.h"
+#include "thermal_model_private.h"
+#include <cstring>
+
+// System initialize for referenced model: 'thermal_model'
+void thermal_model_Init(DW_thermal_model_f_T *localDW)
+{
+  // InitializeConditions for DiscreteFilter: '<Root>/DigitalFilter'
+  localDW->DigitalFilter_states = 0.0F;
+}
+
+// Output and update for referenced model: 'thermal_model'
+void thermal_model(const ControlOutputs *rtu_ControlOutputs, const
+                   ConfigurationParameters *rtu_ConfigurationParameters,
+                   MotorTemperature *rty_MotorTemperature, DW_thermal_model_f_T *
+                   localDW)
+{
+  real32_T rtb_Product1[2];
+  real32_T rtb_Square[2];
+  real32_T rtb_Gain2;
+  real32_T rtb_Sum_a;
+  real32_T rtb_Sum_p_tmp;
+
+  // SignalConversion generated from: '<Root>/Square'
+  rtb_Product1[0] = rtu_ControlOutputs->Iq_rms.current;
+  rtb_Product1[1] = rtu_ControlOutputs->Id_rms.current;
+
+  // Math: '<Root>/Square'
+  mw_arm_mult_f32(&rtb_Product1[0], &rtb_Product1[0], &rtb_Square[0], 2U);
+
+  // Gain: '<S1>/Gain2'
+  rtb_Gain2 = 2.0F *
+    rtu_ConfigurationParameters->motorconfig.thermal_time_constant;
+
+  // DiscreteFilter: '<Root>/DigitalFilter' incorporates:
+  //   Constant: '<Root>/Ts'
+  //   Constant: '<S1>/Constant2'
+  //   Product: '<S1>/Divide'
+  //   Product: '<S1>/Divide1'
+  //   Product: '<S1>/Product'
+  //   Product: '<S1>/Product1'
+  //   Sum: '<Root>/Sum1'
+  //   Sum: '<S1>/Sum'
+  //   Sum: '<S1>/Sum1'
+
+  rtb_Sum_p_tmp = 0.01F * rtu_ConfigurationParameters->motorconfig.resistance *
+    rtu_ConfigurationParameters->motorconfig.thermal_resistance / (rtb_Gain2 +
+    0.01F) * (rtb_Square[0] + rtb_Square[1]);
+  rtb_Sum_a = rtb_Sum_p_tmp + localDW->DigitalFilter_states;
+  localDW->DigitalFilter_states = rtb_Sum_p_tmp - (0.01F - rtb_Gain2) /
+    (rtb_Gain2 + 0.01F) * rtb_Sum_a;
+
+  // BusCreator: '<Root>/Bus Creator1' incorporates:
+  //   Sum: '<Root>/Sum'
+
+  rty_MotorTemperature->temperature = rtb_Sum_a +
+    rtu_ConfigurationParameters->environment_temperature;
+}
+
+// Model initialize function
+void thermal_model_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_thermal_model_T *const thermal_model_M, DW_thermal_model_f_T *localDW)
+{
+  // Registration code
+
+  // initialize error status
+  rtmSetErrorStatusPointer(thermal_model_M, rt_errorStatus);
+
+  // states (dwork)
+  (void) std::memset(static_cast<void *>(localDW), 0,
+                     sizeof(DW_thermal_model_f_T));
+}
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model.h
@@ -1,0 +1,78 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: thermal_model.h
+//
+// Code generated for Simulink model 'thermal_model'.
+//
+// Model version                  : 5.21
+// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
+// C/C++ source code generated on : Tue Jun 27 10:19:07 2023
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef RTW_HEADER_thermal_model_h_
+#define RTW_HEADER_thermal_model_h_
+#include "rtwtypes.h"
+#include "thermal_model_types.h"
+#include <cstring>
+
+// Block states (default storage) for model 'thermal_model'
+struct DW_thermal_model_f_T {
+  real32_T DigitalFilter_states;       // '<Root>/DigitalFilter'
+};
+
+// Real-time Model Data Structure
+struct tag_RTM_thermal_model_T {
+  const char_T **errorStatus;
+};
+
+struct MdlrefDW_thermal_model_T {
+  DW_thermal_model_f_T rtdw;
+  RT_MODEL_thermal_model_T rtm;
+};
+
+// Model reference registration function
+extern void thermal_model_initialize(const char_T **rt_errorStatus,
+  RT_MODEL_thermal_model_T *const thermal_model_M, DW_thermal_model_f_T *localDW);
+extern void thermal_model_Init(DW_thermal_model_f_T *localDW);
+extern void thermal_model(const ControlOutputs *rtu_ControlOutputs, const
+  ConfigurationParameters *rtu_ConfigurationParameters, MotorTemperature
+  *rty_MotorTemperature, DW_thermal_model_f_T *localDW);
+
+//-
+//  These blocks were eliminated from the model due to optimizations:
+//
+//  Block '<S1>/Cast To Single1' : Eliminate redundant data type conversion
+//  Block '<S1>/Cast To Single2' : Eliminate redundant data type conversion
+
+
+//-
+//  The generated code includes comments that allow you to trace directly
+//  back to the appropriate location in the model.  The basic format
+//  is <system>/block_name, where system is the system number (uniquely
+//  assigned by Simulink) and block_name is the name of the block.
+//
+//  Use the MATLAB hilite_system command to trace the generated code back
+//  to the model.  For example,
+//
+//  hilite_system('<S3>')    - opens system 3
+//  hilite_system('<S3>/Kp') - opens and selects block Kp which resides in S3
+//
+//  Here is the system hierarchy for this model
+//
+//  '<Root>' : 'thermal_model'
+//  '<S1>'   : 'thermal_model/Compute coefficients'
+
+#endif                                 // RTW_HEADER_thermal_model_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model_private.h
@@ -1,0 +1,46 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: thermal_model_private.h
+//
+// Code generated for Simulink model 'thermal_model'.
+//
+// Model version                  : 5.21
+// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
+// C/C++ source code generated on : Tue Jun 27 10:19:07 2023
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef RTW_HEADER_thermal_model_private_h_
+#define RTW_HEADER_thermal_model_private_h_
+#include "rtwtypes.h"
+#include "thermal_model_types.h"
+
+// Macros for accessing real-time model data structure
+#ifndef rtmGetErrorStatus
+#define rtmGetErrorStatus(rtm)         (*((rtm)->errorStatus))
+#endif
+
+#ifndef rtmSetErrorStatus
+#define rtmSetErrorStatus(rtm, val)    (*((rtm)->errorStatus) = (val))
+#endif
+
+#ifndef rtmGetErrorStatusPointer
+#define rtmGetErrorStatusPointer(rtm)  (rtm)->errorStatus
+#endif
+
+#ifndef rtmSetErrorStatusPointer
+#define rtmSetErrorStatusPointer(rtm, val) ((rtm)->errorStatus = (val))
+#endif
+#endif                                 // RTW_HEADER_thermal_model_private_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/model-based-design/thermal-model/thermal_model_types.h
@@ -1,0 +1,223 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: thermal_model_types.h
+//
+// Code generated for Simulink model 'thermal_model'.
+//
+// Model version                  : 5.21
+// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
+// C/C++ source code generated on : Tue Jun 27 10:19:07 2023
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef RTW_HEADER_thermal_model_types_h_
+#define RTW_HEADER_thermal_model_types_h_
+#include "rtwtypes.h"
+#ifndef DEFINED_TYPEDEF_FOR_MotorCurrent_
+#define DEFINED_TYPEDEF_FOR_MotorCurrent_
+
+struct MotorCurrent
+{
+  // motor current
+  real32_T current;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_ControlOutputs_
+#define DEFINED_TYPEDEF_FOR_ControlOutputs_
+
+struct ControlOutputs
+{
+  // control effort (quadrature)
+  real32_T Vq;
+
+  // control effort (3-phases)
+  real32_T Vabc[3];
+
+  // quadrature current
+  MotorCurrent Iq_fbk;
+
+  // direct current
+  MotorCurrent Id_fbk;
+
+  // RMS of Iq
+  MotorCurrent Iq_rms;
+
+  // RMS of Id
+  MotorCurrent Id_rms;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_MotorConfig_
+#define DEFINED_TYPEDEF_FOR_MotorConfig_
+
+struct MotorConfig
+{
+  boolean_T has_hall_sens;
+  boolean_T has_quadrature_encoder;
+  boolean_T has_speed_quadrature_encoder;
+  boolean_T has_torque_sens;
+  boolean_T use_index;
+  boolean_T enable_verbosity;
+  int16_T rotor_encoder_resolution;
+  int16_T rotor_index_offset;
+  uint8_T encoder_tolerance;
+  uint8_T pole_pairs;
+  real32_T Kbemf;
+  real32_T Rphase;
+  real32_T Imin;
+  real32_T Imax;
+  real32_T Vcc;
+  real32_T Vmax;
+  real32_T resistance;
+  real32_T inductance;
+  real32_T thermal_resistance;
+  real32_T thermal_time_constant;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_EstimationVelocityModes_
+#define DEFINED_TYPEDEF_FOR_EstimationVelocityModes_
+
+typedef enum {
+  EstimationVelocityModes_Disabled = 0,// Default value
+  EstimationVelocityModes_MovingAverage,
+  EstimationVelocityModes_LeastSquares
+} EstimationVelocityModes;
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_EstimationConfig_
+#define DEFINED_TYPEDEF_FOR_EstimationConfig_
+
+struct EstimationConfig
+{
+  EstimationVelocityModes velocity_mode;
+
+  // Forgetting factor in [0, 1] for exponential weighting-based estimation of RMS current value 
+  real32_T current_rms_lambda;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_PIDConfig_
+#define DEFINED_TYPEDEF_FOR_PIDConfig_
+
+struct PIDConfig
+{
+  real32_T OutMax;
+  real32_T OutMin;
+  real32_T P;
+  real32_T I;
+  real32_T D;
+  real32_T N;
+  real32_T I0;
+  real32_T D0;
+  uint8_T shift_factor;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_Thresholds_
+#define DEFINED_TYPEDEF_FOR_Thresholds_
+
+struct Thresholds
+{
+  // It shall be greater than hardwareJntPosMin
+  real32_T jntPosMin;
+
+  // It shall be smaller than hardwareJntPosMax
+  real32_T jntPosMax;
+
+  // Imposed by hardware constraint
+  real32_T hardwareJntPosMin;
+
+  // Imposed by hardware constraint
+  real32_T hardwareJntPosMax;
+
+  // If robotMin == rotorMax == 0, there's no check
+  real32_T rotorPosMin;
+
+  // If robotMin == rotorMax == 0, there's no check
+  real32_T rotorPosMax;
+
+  // Can be only non-negative
+  real32_T jntVelMax;
+
+  // Timeout on reception of velocity setpoint
+  // Can be only non-negative
+  uint32_T velocityTimeout;
+
+  // Current that can be kept for an indefinite period of time w/o damaging the motor
+  // Expressed in [A] as all the internal computations are done this way
+  // Can be only non-negative
+  real32_T motorNominalCurrents;
+
+  // Current that can be applied for a short period of time
+  // Expressed in [A] as all the internal computations are done this way
+  // Can be only non-negative
+  real32_T motorPeakCurrents;
+
+  // Currents over this threshold can instantaneously damages the motor
+  // Expressed in [A] as all the internal computations are done this way
+  // Can be only non-negative
+  real32_T motorOverloadCurrents;
+
+  // Expressed in ticks
+  // Max value is 32000
+  // Can be only non-negative
+  uint32_T motorPwmLimit;
+
+  // The critical temperature of the motor that triggers i2t current protection. 
+  real32_T motorCriticalTemperature;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_ConfigurationParameters_
+#define DEFINED_TYPEDEF_FOR_ConfigurationParameters_
+
+struct ConfigurationParameters
+{
+  MotorConfig motorconfig;
+  EstimationConfig estimationconfig;
+  PIDConfig CurLoopPID;
+  PIDConfig PosLoopPID;
+  PIDConfig VelLoopPID;
+  PIDConfig DirLoopPID;
+  Thresholds thresholds;
+  real32_T environment_temperature;
+};
+
+#endif
+
+#ifndef DEFINED_TYPEDEF_FOR_MotorTemperature_
+#define DEFINED_TYPEDEF_FOR_MotorTemperature_
+
+struct MotorTemperature
+{
+  // motor temperature
+  real32_T temperature;
+};
+
+#endif
+
+// Forward declaration for rtModel
+typedef struct tag_RTM_thermal_model_T RT_MODEL_thermal_model_T;
+
+#endif                                 // RTW_HEADER_thermal_model_types_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          3
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          20
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          68
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          69
 
 //  </h>version
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheCANdiscovery2.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheCANdiscovery2.c
@@ -966,6 +966,7 @@ static eOresult_t s_eo_candiscovery2_getFWversion(uint8_t boardtype, eObrd_canlo
         case eobrd_cantype_pmc:
         case eobrd_cantype_sg3:
         case eobrd_cantype_mtb4c:
+        case eobrd_cantype_strain2c:
         {
             found = eobool_true;
             command.clas = eocanprot_msgclass_pollingAnalogSensor;

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,16 +75,16 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          50
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          51
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          3
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -86,7 +86,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          71
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          72
 
 //  </h>version
 
@@ -94,9 +94,9 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          3
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>


### PR DESCRIPTION
This PR aligns the AMCBLDC code to the [latest mbd  code generation](https://github.com/robotology/icub-firmware-models/commit/2e2670b37640340f0e34f3cd745920b43e2ff54c), with the following features:
- A linear thermal model is added, running at 10ms, to estimate the temperature: this is a first stepping stone for the i2t protection, no supervisor infrastructure is added yet
- Adapted architectural model to allow reusable functions

cc @pattacini 