### PR TITLE
Fix/battery charge

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
@@ -130,5 +130,6 @@ extern adc_measure_t adc_measure;
 extern adc_measure_t mean;
 extern uint32_t adc_values[9];
 extern fifo adc_samples;
+extern uint32_t vBatterydV;
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -96,13 +96,14 @@ uint16_t Battery_low=3300*7;    // 7s5p battery
 
 #ifdef BAT_B_iCub3
 uint32_t VTH[7]={32000, 34000, 36000, 38000, 40000, 42000, 44000};   // threshold in mV iCub 2.5 Battery
-uint16_t Battery_high=4200*0.1;   // 10s3p battery - Use deciVolt to be compliant with BMS
-uint16_t Battery_low=3300*0.1;    // 10s3p battery - - Use deciVolt to be compliant with BMS
+uint16_t Battery_high=4200*10;   // 10s3p battery
+uint16_t Battery_low=3300*10;    // 10s3p battery
 #endif
 
 adc_measure_t adc_measure = {0};  // initialize all adc values to 0
 adc_measure_t mean = {0};         // initialize all average values to 0
 uint32_t adc_values[9];           // contains all ADC channels conversion
+uint32_t vBatterydV = 0;          // varibale used for sending mean.V_BATTERY to EMS in deciVolt
 
 uint16_t adc_sample = 0;
 

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -11,7 +11,7 @@
 
 char Firmware_vers = 1;
 char Revision_vers = 2;
-char Build_number  = 0;
+char Build_number  = 1;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis
 uint32_t vhyst=0;    // voltage hysteresis
@@ -96,8 +96,8 @@ uint16_t Battery_low=3300*7;    // 7s5p battery
 
 #ifdef BAT_B_iCub3
 uint32_t VTH[7]={32000, 34000, 36000, 38000, 40000, 42000, 44000};   // threshold in mV iCub 2.5 Battery
-uint16_t Battery_high=4200*10;   // 10s3p battery
-uint16_t Battery_low=3300*10;    // 10s3p battery
+uint16_t Battery_high=4200*0.1;   // 10s3p battery - Use deciVolt to be compliant with BMS
+uint16_t Battery_low=3300*0.1;    // 10s3p battery - - Use deciVolt to be compliant with BMS
 #endif
 
 adc_measure_t adc_measure = {0};  // initialize all adc values to 0

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
@@ -476,7 +476,7 @@ void calcMean(){
   
   mean.V_VINPUT   = mean.V_VINPUT   / nr_adc_sample;
   mean.V_EXTPS    = mean.V_EXTPS    / nr_adc_sample;
-  mean.V_BATTERY  = mean.V_BATTERY  / nr_adc_sample;
+  mean.V_BATTERY  = 0.01 * (mean.V_BATTERY  / nr_adc_sample); // in deciVolt to be compliant with BMS
   mean.V_V12board = mean.V_V12board / nr_adc_sample;
   mean.V_V12motor = mean.V_V12motor / nr_adc_sample;
   mean.I_V12board = mean.I_V12board / nr_adc_sample;
@@ -589,8 +589,8 @@ void CANBUS(void){
     case 0x05:
     {
         // Battery Pack Info message
-        TxData_620[0] = (mean.V_BATTERY >> 8) & 0xFF;   // b7-b6 Battery pack voltage            
-        TxData_620[1] = mean.V_BATTERY & 0xFF;
+        TxData_620[0] = mean.V_BATTERY & 0xFF;          // b7-b6 Battery pack voltage            
+        TxData_620[1] = (mean.V_BATTERY >> 8) & 0xFF; 
         TxData_620[2] = 0x00;                           // b5-b4 Instant current
         TxData_620[3] = 0x00;
         TxData_620[4] = Battery_charge & 0xFF;          // b3-b2 State of charge of battery

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
@@ -476,7 +476,7 @@ void calcMean(){
   
   mean.V_VINPUT   = mean.V_VINPUT   / nr_adc_sample;
   mean.V_EXTPS    = mean.V_EXTPS    / nr_adc_sample;
-  mean.V_BATTERY  = 0.01 * (mean.V_BATTERY  / nr_adc_sample); // in deciVolt to be compliant with BMS
+  mean.V_BATTERY  = mean.V_BATTERY  / nr_adc_sample;  
   mean.V_V12board = mean.V_V12board / nr_adc_sample;
   mean.V_V12motor = mean.V_V12motor / nr_adc_sample;
   mean.I_V12board = mean.I_V12board / nr_adc_sample;
@@ -589,8 +589,9 @@ void CANBUS(void){
     case 0x05:
     {
         // Battery Pack Info message
-        TxData_620[0] = mean.V_BATTERY & 0xFF;          // b7-b6 Battery pack voltage            
-        TxData_620[1] = (mean.V_BATTERY >> 8) & 0xFF; 
+        vBatterydV = 0.01 * (mean.V_BATTERY);
+        TxData_620[0] = vBatterydV & 0xFF;           // b7-b6 Battery pack voltage            
+        TxData_620[1] = (vBatterydV >> 8) & 0xFF;
         TxData_620[2] = 0x00;                           // b5-b4 Instant current
         TxData_620[3] = 0x00;
         TxData_620[4] = Battery_charge & 0xFF;          // b3-b2 State of charge of battery
@@ -1118,6 +1119,19 @@ void dcdc_management(void){
               ((V12motor		& 0x01)	<< 5) +
               ((HSM           & 0x01)	<< 3) +
               (((PB1_restart || PB2_restart) & 0x01)	<< 0);
+    
+    
+  DCDC_status_A = ((V12board      & 0x01) << 7) +
+                  ((V12board_F    & 0x01) << 6) +
+                  ((V12motor      & 0x01) << 5) +
+                  ((V12motor_F    & 0x01) << 4) +
+                  ((HSM           & 0x01) << 3) +
+                  ((HSM_PG        & 0x01) << 2) +
+                  ((HSM_F         & 0x01) << 1) +
+                  ((HSM_broken    & 0x01) << 0);
+    
+  DCDC_status_B = (( PB1_restart & 0x01) << 7) + 
+                  ((PB2_restart    & 0x01) << 6);
     
   if(DCrestart){
     PB1_restart=0;

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.cpp
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.cpp
@@ -554,7 +554,7 @@ eOresult_t embot::app::eth::theBATservice::Impl::AcceptCANframe(
   if (nullptr == bat) { // something is wrong
     return eores_NOK_generic;
   }
-
+  
   switch (cfd.type) {
   case canFrameDescriptor::Type::unspecified: {
     bat->status.timedvalue.temperature =
@@ -571,8 +571,9 @@ eOresult_t embot::app::eth::theBATservice::Impl::AcceptCANframe(
         0.1 * static_cast<float32_t>(
                   (static_cast<uint16_t>(cfd.frame->data[1]) << 8) +
                   static_cast<uint16_t>(cfd.frame->data[0]));
-    break;
+    
   }
+  break;
   default:
     return eores_NOK_unsupported;
   }

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.cpp
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.cpp
@@ -554,7 +554,7 @@ eOresult_t embot::app::eth::theBATservice::Impl::AcceptCANframe(
   if (nullptr == bat) { // something is wrong
     return eores_NOK_generic;
   }
-  
+
   switch (cfd.type) {
   case canFrameDescriptor::Type::unspecified: {
     bat->status.timedvalue.temperature =
@@ -571,9 +571,8 @@ eOresult_t embot::app::eth::theBATservice::Impl::AcceptCANframe(
         0.1 * static_cast<float32_t>(
                   (static_cast<uint16_t>(cfd.frame->data[1]) << 8) +
                   static_cast<uint16_t>(cfd.frame->data[0]));
-    
+    break;
   }
-  break;
   default:
     return eores_NOK_unsupported;
   }


### PR DESCRIPTION
This PR brings the following fixes to the BAT code:
- fix the battery voltage send to the specific port to be shown in deciVolt
- align the message send from BAT to EMS board to be aligned with the BMS protocol info