### PR TITLE
Motor Control library used by ETH boards is now compiled in C++

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvoptx
@@ -1503,7 +1503,7 @@
 
   <Group>
     <GroupName>embot::app::eth::config</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1567,7 +1567,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1899,7 +1899,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1967,7 +1967,7 @@
 
   <Group>
     <GroupName>embot::os</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2071,7 +2071,7 @@
 
   <Group>
     <GroupName>embot::os::EOM</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2947,7 +2947,7 @@
 
   <Group>
     <GroupName>brd-state-idle [former cfg]</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2967,7 +2967,7 @@
 
   <Group>
     <GroupName>brd-state-fatalerror</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2987,7 +2987,7 @@
 
   <Group>
     <GroupName>brd-state-run</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3007,7 +3007,7 @@
 
   <Group>
     <GroupName>can-protocol</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3051,7 +3051,7 @@
 
   <Group>
     <GroupName>can-protocol-callbacks</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3143,7 +3143,7 @@
 
   <Group>
     <GroupName>services</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3199,7 +3199,7 @@
 
   <Group>
     <GroupName>appl-sm</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3219,7 +3219,7 @@
 
   <Group>
     <GroupName>icub-fw-sha/icub</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3275,7 +3275,7 @@
 
   <Group>
     <GroupName>embot::app::eth-services</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3319,7 +3319,7 @@
 
   <Group>
     <GroupName>hal over embot::hw</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3339,7 +3339,7 @@
 
   <Group>
     <GroupName>theHandler</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3371,7 +3371,7 @@
 
   <Group>
     <GroupName>overridden</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3439,7 +3439,7 @@
 
   <Group>
     <GroupName>scope</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-00/proj/appl-00.uvprojx
@@ -4619,7 +4619,7 @@
       <TargetName>amc-appl-00-osal-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -5276,57 +5276,6 @@
               <FileName>embot_hw_flash.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_flash.cpp</FilePath>
-              <FileOption>
-                <CommonProperty>
-                  <UseCPPCompiler>2</UseCPPCompiler>
-                  <RVCTCodeConst>0</RVCTCodeConst>
-                  <RVCTZI>0</RVCTZI>
-                  <RVCTOtherData>0</RVCTOtherData>
-                  <ModuleSelection>0</ModuleSelection>
-                  <IncludeInBuild>0</IncludeInBuild>
-                  <AlwaysBuild>2</AlwaysBuild>
-                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
-                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
-                  <PublicsOnly>2</PublicsOnly>
-                  <StopOnExitCode>11</StopOnExitCode>
-                  <CustomArgument></CustomArgument>
-                  <IncludeLibraryModules></IncludeLibraryModules>
-                  <ComprImg>1</ComprImg>
-                </CommonProperty>
-                <FileArmAds>
-                  <Cads>
-                    <interw>2</interw>
-                    <Optim>0</Optim>
-                    <oTime>2</oTime>
-                    <SplitLS>2</SplitLS>
-                    <OneElfS>2</OneElfS>
-                    <Strict>2</Strict>
-                    <EnumInt>2</EnumInt>
-                    <PlainCh>2</PlainCh>
-                    <Ropi>2</Ropi>
-                    <Rwpi>2</Rwpi>
-                    <wLevel>0</wLevel>
-                    <uThumb>2</uThumb>
-                    <uSurpInc>2</uSurpInc>
-                    <uC99>2</uC99>
-                    <uGnu>2</uGnu>
-                    <useXO>2</useXO>
-                    <v6Lang>0</v6Lang>
-                    <v6LangP>0</v6LangP>
-                    <vShortEn>2</vShortEn>
-                    <vShortWch>2</vShortWch>
-                    <v6Lto>2</v6Lto>
-                    <v6WtE>2</v6WtE>
-                    <v6Rtti>2</v6Rtti>
-                    <VariousControls>
-                      <MiscControls></MiscControls>
-                      <Define></Define>
-                      <Undefine></Undefine>
-                      <IncludePath></IncludePath>
-                    </VariousControls>
-                  </Cads>
-                </FileArmAds>
-              </FileOption>
             </File>
             <File>
               <FileName>embot_hw_spi.cpp</FileName>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvoptx
@@ -3212,7 +3212,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>170</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3272,7 +3272,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>175</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3284,7 +3284,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>176</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3296,7 +3296,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>177</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3308,7 +3308,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>178</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvprojx
@@ -2454,7 +2454,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -2479,22 +2479,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
             <File>
@@ -4802,7 +4802,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -4827,22 +4827,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
             <File>
@@ -7660,7 +7660,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -7685,22 +7685,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
             <File>
@@ -9294,7 +9294,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -9319,22 +9319,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
             <File>
@@ -10928,7 +10928,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -10953,22 +10953,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
             <File>
@@ -12919,7 +12919,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -12944,22 +12944,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
             <File>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01.uvoptx
@@ -1596,7 +1596,7 @@
 
   <Group>
     <GroupName>rtos</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3623,7 +3623,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>164</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3672,7 +3672,7 @@
       <GroupNumber>34</GroupNumber>
       <FileNumber>168</FileNumber>
       <FileType>8</FileType>
-      <tvExp>1</tvExp>
+      <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embobj\plus\mc\JointSet.c</PathWithFileName>
@@ -3683,7 +3683,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>169</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3695,7 +3695,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>170</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3707,7 +3707,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>171</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3719,7 +3719,7 @@
     <File>
       <GroupNumber>34</GroupNumber>
       <FileNumber>172</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -2526,7 +2526,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -2551,22 +2551,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -2598,8 +2598,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -4834,7 +4834,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -4859,22 +4859,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -4900,14 +4900,14 @@
       <TargetName>amc-appl-01-osal-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -7671,7 +7671,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -7696,22 +7696,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -7743,8 +7743,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -9265,7 +9265,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -9290,22 +9290,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -9337,8 +9337,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -10859,7 +10859,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -10884,22 +10884,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -10931,8 +10931,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -12810,7 +12810,7 @@
           <Files>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -12835,22 +12835,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -1,5 +1,6 @@
 
 /*
+
  * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -1,6 +1,5 @@
 
 /*
-
  * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -3485,7 +3485,7 @@
     <File>
       <GroupNumber>14</GroupNumber>
       <FileNumber>102</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3533,7 +3533,7 @@
     <File>
       <GroupNumber>14</GroupNumber>
       <FileNumber>106</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3545,7 +3545,7 @@
     <File>
       <GroupNumber>14</GroupNumber>
       <FileNumber>107</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3557,7 +3557,7 @@
     <File>
       <GroupNumber>14</GroupNumber>
       <FileNumber>108</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3569,7 +3569,7 @@
     <File>
       <GroupNumber>14</GroupNumber>
       <FileNumber>109</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3770,7 +3770,7 @@
 
   <Group>
     <GroupName>eo-protocol</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3970,7 +3970,7 @@
 
   <Group>
     <GroupName>eo-protocol-cfg-callbacks</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -953,7 +953,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -973,22 +973,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -2440,7 +2440,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -2460,22 +2460,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -4029,7 +4029,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -4049,22 +4049,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -5669,7 +5669,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -5689,22 +5689,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -2651,7 +2651,7 @@ static eOresult_t s_eo_motioncontrol_updatePositionFromEncoder(uint8_t index, eO
     {
         if(encoder->errortype != encreader_err_NONE)
         {
-            MController_invalid_absEncoder_fbk(index, (ae_errortype_t)encoder->errortype);
+            MController_invalid_absEncoder_fbk(index, (uint8_t)encoder->errortype);
             res = eores_NOK_generic;
         }
         else

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvoptx
@@ -2243,7 +2243,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>102</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2291,7 +2291,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>106</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2303,7 +2303,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>107</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2315,7 +2315,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>108</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2327,7 +2327,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>109</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
@@ -10,7 +10,7 @@
       <TargetName>mc2plus</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -1020,7 +1020,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -1040,22 +1040,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>
@@ -2326,7 +2326,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -2346,22 +2346,22 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
             </File>
           </Files>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvoptx
@@ -1611,7 +1611,7 @@
 
   <Group>
     <GroupName>eo-emsappl-cfg</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1715,7 +1715,7 @@
 
   <Group>
     <GroupName>appl-services</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2078,7 +2078,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>103</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2126,7 +2126,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>107</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2138,7 +2138,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>108</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2150,7 +2150,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>109</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2162,24 +2162,12 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>110</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embobj\plus\mc\WatchDog.c</PathWithFileName>
       <FilenameWithoutPath>WatchDog.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>111</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\mc\Joint_hid.h</PathWithFileName>
-      <FilenameWithoutPath>Joint_hid.h</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -2193,7 +2181,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>112</FileNumber>
+      <FileNumber>111</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2205,7 +2193,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>113</FileNumber>
+      <FileNumber>112</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2217,7 +2205,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>114</FileNumber>
+      <FileNumber>113</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2229,7 +2217,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>115</FileNumber>
+      <FileNumber>114</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2241,7 +2229,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>116</FileNumber>
+      <FileNumber>115</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2253,7 +2241,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <FileNumber>116</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2265,7 +2253,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2277,7 +2265,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2289,7 +2277,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2301,7 +2289,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2313,7 +2301,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2325,7 +2313,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2337,7 +2325,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2349,7 +2337,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2361,7 +2349,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2381,7 +2369,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2393,7 +2381,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <FileNumber>127</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2405,7 +2393,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2417,7 +2405,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2429,7 +2417,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2441,7 +2429,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2453,7 +2441,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <FileNumber>132</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2465,7 +2453,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2477,7 +2465,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2489,7 +2477,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <FileNumber>135</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2501,7 +2489,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2513,7 +2501,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2525,7 +2513,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2537,7 +2525,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2549,7 +2537,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2561,7 +2549,7 @@
     </File>
     <File>
       <GroupNumber>15</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2581,7 +2569,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <FileNumber>142</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2593,7 +2581,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <FileNumber>143</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2605,7 +2593,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <FileNumber>144</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2617,7 +2605,7 @@
     </File>
     <File>
       <GroupNumber>16</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <FileNumber>145</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2637,7 +2625,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <FileNumber>146</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2649,7 +2637,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2661,7 +2649,7 @@
     </File>
     <File>
       <GroupNumber>17</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <FileNumber>148</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2681,7 +2669,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <FileNumber>149</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2693,7 +2681,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <FileNumber>150</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2705,7 +2693,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <FileNumber>151</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2717,7 +2705,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <FileNumber>152</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2729,7 +2717,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <FileNumber>153</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2741,7 +2729,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <FileNumber>154</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2753,7 +2741,7 @@
     </File>
     <File>
       <GroupNumber>18</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <FileNumber>155</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2773,7 +2761,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <FileNumber>156</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2785,7 +2773,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>158</FileNumber>
+      <FileNumber>157</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2797,7 +2785,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>159</FileNumber>
+      <FileNumber>158</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2809,7 +2797,7 @@
     </File>
     <File>
       <GroupNumber>19</GroupNumber>
-      <FileNumber>160</FileNumber>
+      <FileNumber>159</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2829,7 +2817,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>161</FileNumber>
+      <FileNumber>160</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2841,7 +2829,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>162</FileNumber>
+      <FileNumber>161</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2853,7 +2841,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>163</FileNumber>
+      <FileNumber>162</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2865,7 +2853,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>164</FileNumber>
+      <FileNumber>163</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2877,7 +2865,7 @@
     </File>
     <File>
       <GroupNumber>20</GroupNumber>
-      <FileNumber>165</FileNumber>
+      <FileNumber>164</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2897,9 +2885,9 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>166</FileNumber>
+      <FileNumber>165</FileNumber>
       <FileType>8</FileType>
-      <tvExp>1</tvExp>
+      <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\mbd\kalman_filter\kalman_filter.cpp</PathWithFileName>
@@ -2909,7 +2897,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>167</FileNumber>
+      <FileNumber>166</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
@@ -955,7 +955,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -975,28 +975,23 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
-            </File>
-            <File>
-              <FileName>Joint_hid.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Joint_hid.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -2360,7 +2355,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -2380,28 +2375,23 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
-            </File>
-            <File>
-              <FileName>Joint_hid.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Joint_hid.h</FilePath>
             </File>
           </Files>
         </Group>
@@ -3765,7 +3755,7 @@
             </File>
             <File>
               <FileName>AbsEncoder.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
             </File>
             <File>
@@ -3785,28 +3775,23 @@
             </File>
             <File>
               <FileName>Motor.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Motor.c</FilePath>
             </File>
             <File>
               <FileName>Pid.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Pid.c</FilePath>
             </File>
             <File>
               <FileName>Trajectory.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Trajectory.c</FilePath>
             </File>
             <File>
               <FileName>WatchDog.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\WatchDog.c</FilePath>
-            </File>
-            <File>
-              <FileName>Joint_hid.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Joint_hid.h</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -16,18 +16,23 @@
  * Public License foFITNESSr more details
 */
 
+#if !defined(__cplusplus)
+    #error this AbsEncoder.c file must be compiled in C++
+#endif
+    
+// - API    
+#include "AbsEncoder.h"
+    
+    
+// - dependencies
 #include "EoCommon.h"
-
 #include "EoError.h"
 #include "EOtheErrorManager.h"
-
 #include "EOtheEntities.h"
-
 #include "EOMtheEMSrunner.h"
-
 #include "EOemsControllerCfg.h"
 
-#include "AbsEncoder.h"
+
 
 #if defined(USE_EMBOT_theServices) 
 #warning removed some code

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.h
@@ -19,15 +19,9 @@
 #ifndef MC_ABS_ENCODER_H___
 #define MC_ABS_ENCODER_H___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EoCommon.h"
-
-//#include "EOtheEncoderReader.h"
 #include "EoMotionControl.h"
-
 #include "EOemsControllerCfg.h"
 
 /////////////////////////////////////////////////////////
@@ -183,9 +177,6 @@ extern void AbsEncoder_start_hard_stop_calibrate(AbsEncoder* o, int32_t hard_sto
 extern BOOL AbsEncoder_is_hard_stop_calibrating(AbsEncoder* o);
 extern void AbsEncoder_calibrate_in_hard_stop(AbsEncoder* o);
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
@@ -19,9 +19,6 @@
 #ifndef MC_CALIBRATION_HELPER_DATA_H___
 #define MC_CALIBRATION_HELPER_DATA_H___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EOemsControllerCfg.h"
 
@@ -43,9 +40,6 @@ typedef struct // CableCalib
 } CableCalib;
 
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -16,7 +16,15 @@
  * Public License foFITNESSr more details
 */
 
+#if !defined(__cplusplus)
+    #error this Calibrator.c file must be compiled in C++
+#endif
+
+// - API
 #include "Calibrators.h"
+    
+    
+// - dependencies    
 #include "JointSet.h"
 #include "Joint_hid.h"
 #include "CalibrationHelperData.h"

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.h
@@ -23,9 +23,6 @@
 #include "JointSet.h"
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EOemsControllerCfg.h"
 
@@ -45,9 +42,6 @@ extern BOOL JointSet_do_wait_calibration_14(JointSet* o);
 extern BOOL JointSet_do_wait_calibration_mixed(JointSet* o); //calib type 6 and 7
 
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
@@ -16,40 +16,96 @@
  * Public License foFITNESSr more details
 */
 
+#if !defined(__cplusplus)
+    #error this Controller.c file must be compiled in C++
+#endif
+
+// - API
+#include "Controller.h"
+
+    
+// - dependencies
 #include "EoCommon.h"
-
 #include "EOtheMemoryPool.h"
-
-
 #include "EOemsControllerCfg.h"
-
 #include "EOtheErrorManager.h"
-
 #include "EoError.h"
-
 #include "EOtheEntities.h"
-
 #include "Joint_hid.h"
+#include "JointSet.h"
+#include "Joint.h"
 #include "Motor.h"
 #include "AbsEncoder.h"
 #include "Pid.h"
-
-#include "Controller.h"
-
 #include "hal_led.h"
-
 #include "hal_trace.h"
+#include "stdio.h"
+
+#ifdef WRIST_MK2
+#include "JointSet.h"
+#endif
+
+#include "Joint.h"
+#include "Motor.h"
+#include "AbsEncoder.h"
+#include "Pid.h"
+#ifndef WRIST_MK2
+#include "JointSet.h"
+#endif
+
+// - OPAQUE STRUCT
+
+struct MController_hid
+{
+    uint8_t nEncods;
+    uint8_t nJoints;
+    uint8_t nSets;
+    
+    JointSet *jointSet;
+    
+    uint8_t* set_dim;
+    uint8_t* enc_set_dim;
+    
+    uint8_t multi_encs;
+    
+    uint8_t** jos;
+    uint8_t** mos;
+    uint8_t** eos;
+    
+    uint8_t *j2s;
+    uint8_t *m2s;
+    uint8_t *e2s;
+    
+    Motor *motor;
+    Joint *joint;
+    
+    float **Jjm;
+    float **Jmj;
+    
+    float **Sjm;
+    float **Smj;
+    
+    float **Sje;
+    
+    uint8_t part_type;
+    uint8_t actuation_type;
+    
+    AbsEncoder *absEncoder;
+};
+
+
+
 
 MController* smc = NULL;
 
-#include "stdio.h"
+
 
 static char invert_matrix(float** M, float** I, char n);
 //static void MController_config_motor_set(MController* o);
 //static void MController_config_encoder_set(MController* o);
 
 
-//static void send_debug_message(char *message, uint8_t jid, uint16_t par16, uint64_t par64)
+//static void send_debug_message(const char *message, uint8_t jid, uint16_t par16, uint64_t par64)
 //{
 
 //    eOerrmanDescriptor_t errdes = {0};
@@ -1745,7 +1801,7 @@ void MController_update_motor_state_fbk(uint8_t m, void* state)
     Motor_update_state_fbk(smc->motor+m, state);
 }
 
-void MController_invalid_absEncoder_fbk(uint8_t e, ae_errortype_t error_type) //
+void MController_invalid_absEncoder_fbk(uint8_t e, uint8_t error_type) //
 {
     //AbsEncoder_invalid(smc->absEncoder+e, error_type);
     
@@ -1753,7 +1809,7 @@ void MController_invalid_absEncoder_fbk(uint8_t e, ae_errortype_t error_type) //
     
     for (int k=0; k<smc->multi_encs; ++k)
     {
-        AbsEncoder_invalid(enc++, error_type);
+        AbsEncoder_invalid(enc++, static_cast<ae_errortype_t>(error_type));
     }
 }
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.h
@@ -19,62 +19,33 @@
 #ifndef MC_CONTROLLER___
 #define MC_CONTROLLER___
 
-#ifdef WRIST_MK2
-#include "JointSet.h"
-#endif
+// this file Controller.h is the entry point for the usage of this MController module.
+// the module can be used by C modules and also by C++ modules as long as:
+// - we keep the following extern "C" { clause,
+// - we dont add in here any C++ include files
+// We surely can use C++ code inside any other .h and .c files, such as AbsEncoder.[c, h], etc.
+// and we MUST compile the files using C++
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "EoCommon.h"
 
+// to see basic types
+#include "EoCommon.h"
+    
+// to see eOmn_serv_configuration_t etc
+#include "EoManagement.h"    
+
+// to see eOmc_joint_status_t etc
+#include "EoMotionControl.h"    
+    
+// to see CTRL_UNITS
 #include "EOemsControllerCfg.h"
 
-#include "Joint.h"
-#include "Motor.h"
-#include "AbsEncoder.h"
-#include "Pid.h"
-#ifndef WRIST_MK2
-#include "JointSet.h"
-#endif
-typedef struct //MController
-{
-    uint8_t nEncods;
-    uint8_t nJoints;
-    uint8_t nSets;
-    
-    JointSet *jointSet;
-    
-    uint8_t* set_dim;
-    uint8_t* enc_set_dim;
-    
-    uint8_t multi_encs;
-    
-    uint8_t** jos;
-    uint8_t** mos;
-    uint8_t** eos;
-    
-    uint8_t *j2s;
-    uint8_t *m2s;
-    uint8_t *e2s;
-    
-    Motor *motor;
-    Joint *joint;
-    
-    float **Jjm;
-    float **Jmj;
-    
-    float **Sjm;
-    float **Smj;
-    
-    float **Sje;
-    
-    uint8_t part_type;
-    uint8_t actuation_type;
-    
-    AbsEncoder *absEncoder;
-} MController;
+// need to use this opaque struct in order to 
+// remove from the interface any possible .h files, such as Joint.h etc, containing C++ code.
+typedef struct MController_hid MController;
 
 extern MController* MController_new(uint8_t nJoints, uint8_t nEncoders); //
 
@@ -91,7 +62,7 @@ extern void MController_update_motor_state_fbk(uint8_t m, void* state);
 extern void MController_update_joint_torque_fbk(uint8_t j, CTRL_UNITS trq_fbk); //
 extern void MController_update_absEncoder_fbk(uint8_t e, uint32_t* positions); //
 
-extern void MController_invalid_absEncoder_fbk(uint8_t e, ae_errortype_t error_type);
+extern void MController_invalid_absEncoder_fbk(uint8_t e, uint8_t error_type); // use ae_errortype_t or similar type
 
 extern void MController_timeout_absEncoder_fbk(uint8_t e);
 
@@ -144,10 +115,6 @@ extern void MController_update_motor_odometry_fbk_can(int m, void* data);
 
 extern void MController_motor_raise_fault_i2t(int m);
 
-////////////////////////////////////////////////////////////////////////
-
-//VALE: debug function. I'll remove it ASAP
-//void MController_updated_debug_current_info(int j, int32_t avgCurrent, int32_t accum_Ep);
 
 #ifdef __cplusplus
 }       // closing brace for extern "C"

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
@@ -20,20 +20,13 @@
 #ifndef _EOEMSCONTROLLER_CFG_H_
 #define _EOEMSCONTROLLER_CFG_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
         
- // - external dependencies --------------------------------------------------------------------------------------------
+// - external dependencies --------------------------------------------------------------------------------------------
 
-//#include "EoCommon.h"
-//#include "EOMtheEMSapplCfg_cfg.h"
-    
-//#include "EOappEncodersReader.h"
-    
+#include "EoCommon.h"
 #include "EOtheMemoryPool.h"
- 
- // - public #define  --------------------------------------------------------------------------------------------------
+
+// - public #define  --------------------------------------------------------------------------------------------------
 
 
 #if !defined(EOTHESERVICES_customize_handV3_7joints)
@@ -170,9 +163,7 @@ typedef enum {
 
 // - declaration of extern public functions ---------------------------------------------------------------------------
 
- #ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
+
 
 #endif  // include guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -16,17 +16,25 @@
  * Public License foFITNESSr more details
 */
 
-#include "Joint_hid.h"
+#if !defined(__cplusplus)
+    #error this Joint.c file must be compiled in C++
+#endif
+
+// - API
+#include "Joint.h"
+    
+    
+// - dependencies
 
 #include "hal_adc.h"
-
 #include "EOtheCANprotocol.h"
-
 #include "EOtheErrorManager.h"
 #include "EoError.h"
-
 #include "EOtheEntities.h"
-
+   
+// - OPAQUE STRUCT    
+#include "Joint_hid.h"
+    
 static void Joint_set_inner_control_flags(Joint* o);
 static BOOL Joint_set_pos_ref_in_calib(Joint* o, CTRL_UNITS pos_ref, CTRL_UNITS vel_ref);
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.h
@@ -19,9 +19,6 @@
 #ifndef MC_JOINT___
 #define MC_JOINT___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EoCommon.h"
 #include "EOemsControllerCfg.h"
@@ -172,10 +169,7 @@ extern BOOL Joint_set_pos_ref_in_calibType14(Joint* o, CTRL_UNITS pos_ref, CTRL_
 
 //VALE: debug function. I'll remove it ASAP
 //extern void Joint_update_debug_current_info(Joint *o, int32_t avgCurrent, int32_t accum_Ep);
-
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
+ 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -16,10 +16,16 @@
  * Public License foFITNESSr more details
 */
 
+#if !defined(__cplusplus)
+    #error this JointSet.c file must be compiled in C++
+#endif
+
+// - API
+#include "JointSet.h"
+    
+// - dependencies
 #include "EoCommon.h"
-
 #include "EOtheMemoryPool.h"
-
 #include "EOemsControllerCfg.h"
 #include "EOtheErrorManager.h"
 #include "EoError.h"
@@ -32,16 +38,12 @@
 #include "EOthePOS.h"
 #endif
 #include "EOtheEntities.h"
-
 #include "Joint_hid.h"
 #include "Motor.h"
 #include "AbsEncoder.h"
 #include "Pid.h"
-
-
-#include "JointSet.h"
-
 #include "Calibrators.h"
+
 
 static void JointSet_set_inner_control_flags(JointSet* o);
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
@@ -21,10 +21,6 @@
 
 #ifdef WRIST_MK2
 #include "wrist_decoupler.h"
-#else
-#ifdef __cplusplus
-extern "C" {
-#endif
 #endif
 
 #include "EoCommon.h"
@@ -155,10 +151,6 @@ extern void JointSet_send_debug_message(char *message, uint8_t jid, uint16_t par
 extern BOOL JointSet_set_pos_ref(JointSet* o, int j, CTRL_UNITS pos_ref, CTRL_UNITS vel_ref);
 extern void JointSet_get_state(JointSet* o, int j, eOmc_joint_status_t* joint_state);
 extern void JointSet_stop(JointSet* o, int j);
-#else
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
 #endif
  
 #endif  // include-guard

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
@@ -3,9 +3,6 @@
 
 #include "kalman_filter.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
     
 #include "Joint.h"
 
@@ -100,9 +97,6 @@ struct Joint_hid // Joint
 #endif 
 };
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -16,16 +16,21 @@
  * Public License foFITNESSr more details
 */
 
-//#include "stdlib.h"
-//#include <string.h>
+#if !defined(__cplusplus)
+    #error this Motor.c file must be compiled in C++
+#endif
 
+// - API
+#include "Motor.h"
+    
+// - dependencies   
 #include "EoCommon.h"
 #include "iCubCanProto_types.h"
 #include "EoProtocol.h"
 #include "EOtheCANprotocol.h"
 #include "EOtheCANservice.h"
 #include "hal_motor.h"
-#include "Motor.h"
+
 #include "hal_led.h"
 
 #include "EOtheErrorManager.h"
@@ -48,7 +53,7 @@ static void pmc_motor_disable(eObrd_canlocation_t canloc);
 /////////////////////////////////////////////////////////
 // Motor
 
-static void send_debug_message(char *message, uint8_t jid, uint16_t par16, uint64_t par64)
+static void send_debug_message(const char *message, uint8_t jid, uint16_t par16, uint64_t par64)
 {
 
     eOerrmanDescriptor_t errdes = {0};

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -22,9 +22,6 @@
 #ifndef MC_MOTOR_H___
 #define MC_MOTOR_H___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EoCommon.h"
 #include "EoMotionControl.h"
@@ -323,10 +320,7 @@ extern int32_t Motor_get_vel_fbk(Motor* o);
 extern CTRL_UNITS Motor_get_trq_fbk(Motor* o);
 */
 
-
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
+ 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Pid.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Pid.c
@@ -15,9 +15,19 @@
  * MERCHANTABILITY or  FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License foFITNESSr more details
 */
+
+#if !defined(__cplusplus)
+    #error this Pid.c file must be compiled in C++
+#endif
+
+// - API
+#include "Pid.h"  
+
+// - dependencies    
 #include "EOtheErrorManager.h"
 #include "EoError.h"
-static void send_debug_message(char *message, uint8_t jid, uint16_t par16, uint64_t par64)
+    
+static void send_debug_message(const char *message, uint8_t jid, uint16_t par16, uint64_t par64)
 {
     eOerrmanDescriptor_t errdes = {0};
     errdes.code             = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag01);
@@ -29,7 +39,7 @@ static void send_debug_message(char *message, uint8_t jid, uint16_t par16, uint6
     //eo_errman_Info(eo_errman_GetHandle(), message, "", &errdes);
 }
 
-#include "Pid.h"
+
 PID* PID_new(uint8_t n)
 {
     PID *o = NEW(PID, n);

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Pid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Pid.h
@@ -19,9 +19,6 @@
 #ifndef MC_PID_H___
 #define MC_PID_H___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EoCommon.h"
 #include "EoMotionControl.h"
@@ -80,9 +77,6 @@ extern float PID_do_out(PID* o, float En);
 extern float PID_do_friction_comp(PID *o, float vel, float Tr);
 
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.c
@@ -16,7 +16,15 @@
  * Public License foFITNESSr more details
 */
 
+#if !defined(__cplusplus)
+    #error this Trajectory.c file must be compiled in C++
+#endif
+
+// - API
 #include "Trajectory.h"
+
+// - dependencies
+// none
 
 Trajectory* Trajectory_new(uint8_t n) 
 {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.h
@@ -19,9 +19,6 @@
 #ifndef MC_TRAJECTORY_H___
 #define MC_TRAJECTORY_H___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EoCommon.h"
 
@@ -91,10 +88,6 @@ extern float Trajectory_get_target_position(Trajectory* o);
 extern float Trajectory_get_target_velocity(Trajectory* o);
 
 
-
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog.c
@@ -16,11 +16,18 @@
  * Public License foFITNESSr more details
 */
 
-#include "EoCommon.h"
+#if !defined(__cplusplus)
+    #error this Watchdog.c file must be compiled in C++
+#endif
 
+// - API
+#include "WatchDog.h"  
+
+// - dependencies    
+#include "EoCommon.h"
 #include "EOemsControllerCfg.h"
 
-#include "WatchDog.h"
+
 
 void WatchDog_init(WatchDog* o)
 {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog.h
@@ -19,9 +19,6 @@
 #ifndef MC_WATCHDOG___
 #define MC_WATCHDOG___
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "EoCommon.h"
 
@@ -45,9 +42,6 @@ extern void Watchdog_disarm(WatchDog* o);
 extern BOOL WatchDog_check_expired(WatchDog* o);
 
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/EOtheMCamc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/EOtheMCamc.cpp
@@ -134,7 +134,7 @@ static eOresult_t s_eo_motioncontrol_updatePositionFromEncoder(uint8_t index, eO
         if(encoder->errortype != encreader_err_NONE)
         {
 //#warning TODO-AMC-MC: add MController            
-            MController_invalid_absEncoder_fbk(index, (ae_errortype_t)encoder->errortype);
+            MController_invalid_absEncoder_fbk(index, static_cast<uint8_t>(encoder->errortype));
             res = eores_NOK_generic;
         }
         else


### PR DESCRIPTION
The files of the motor control library used by the ETH boards are now compiled in C++ mode.

This library was originally developed to run in a C environment on the ETH boards (`ems` etc).
Over the years, some of its .c files have been added C++ model generated code and so they have been compiled in C++ mode.

Now, we need some other files to contain C++ code, so I have moved all the files into C++ compilation.
To allow a correct compilation on the ETH boards where the functions w/ prefix `MController_*` are ued by both C and C++ modules, I have done a minor change to the .h files. In particular:
- I kept the dual C and C++ linkage only in the file `Controller.h` which contains the public interface: 
  ```C++
  #ifdef __cplusplus
  extern "C" {
  #endif

  // code of `Controller.h` in here

  #ifdef __cplusplus
  }       // closing brace for extern "C"
  #endif 
  ```
- I added in file `Controller.h` an opaque struct for the `MController` which is used only via it pointer. ```
- I removed the C linkage from the other .h files (such as `Joint.h` etc) that are used only in its internal implementation;
- I added in file `Controller.h` an opaque struct for the `MController` which is used only via it pointer.


The files that use the library have been kept unchanged. Only the projects of the `ems`, `mc4plus `and `mc2plus` now compile the files `AbsEncoder.c` etc in C++ mode.

There is no change in code that requires a new version of the binaries or tests.

