### PR TITLE
Use of `embot::app::eth::theEncoderReader` in all ETH boards

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
@@ -40,14 +40,14 @@ namespace embot { namespace app { namespace eth {
             Process::eApplication,
 #if defined(WRIST_MK2)
     #if defined(WRIST_MK2_RIGHT)
-            {101, 6},
+            {101, 7},
     #else
-            {102, 6},
+            {102, 7},
     #endif            
 #else            
-            {103, 6},  
+            {103, 7},  
 #endif            
-            {2023, Month::Jul, Day::twentyfour, 18, 00}
+            {2023, Month::Jul, Day::twentysix, 11, 11}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/proj/appl-01-wrist.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -2536,8 +2536,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -4884,8 +4884,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -7742,8 +7742,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -9376,8 +9376,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -11010,8 +11010,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -1,5 +1,6 @@
 
 /*
+
  * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -1,6 +1,5 @@
 
 /*
-
  * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/proj/amcbldc-application2.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/proj/amcbldc-application2.uvoptx
@@ -1284,7 +1284,7 @@
 
   <Group>
     <GroupName>others::motorhal2</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          70
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          71
 
 //  </h>version
 
@@ -91,11 +91,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          26
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -3146,7 +3146,7 @@
 
   <Group>
     <GroupName>appl-services</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3157,8 +3157,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</PathWithFileName>
-      <FilenameWithoutPath>EOMtheEMSdiagnostic.cpp</FilenameWithoutPath>
+      <PathWithFileName>..\src\eoappservices\EOtheServices.c</PathWithFileName>
+      <FilenameWithoutPath>EOtheServices.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -3169,8 +3169,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\eoappservices\EOtheServices.c</PathWithFileName>
-      <FilenameWithoutPath>EOtheServices.c</FilenameWithoutPath>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</PathWithFileName>
+      <FilenameWithoutPath>EOMtheEMSdiagnostic.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -3249,7 +3249,7 @@
     <File>
       <GroupNumber>13</GroupNumber>
       <FileNumber>83</FileNumber>
-      <FileType>1</FileType>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -3265,18 +3265,6 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\src\eoappservices\EOtheEncoderReader.c</PathWithFileName>
-      <FilenameWithoutPath>EOtheEncoderReader.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>85</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
       <PathWithFileName>..\src\eoappservices\EOtheETHmonitor.c</PathWithFileName>
       <FilenameWithoutPath>EOtheETHmonitor.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
@@ -3284,7 +3272,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3296,7 +3284,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3308,7 +3296,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3320,7 +3308,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3332,7 +3320,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3344,7 +3332,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3356,7 +3344,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3368,7 +3356,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3380,7 +3368,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3392,7 +3380,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3404,7 +3392,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3416,7 +3404,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3428,7 +3416,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3440,7 +3428,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3452,7 +3440,7 @@
     </File>
     <File>
       <GroupNumber>13</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3462,11 +3450,23 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>100</FileNumber>
+      <FileType>1</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</PathWithFileName>
+      <FilenameWithoutPath>EOtheEntities.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
-    <GroupName>eo-motor-controller</GroupName>
-    <tvExp>0</tvExp>
+    <GroupName>embot::app::eth::theEncoderReader</GroupName>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3477,8 +3477,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\mc\Calibrators.c</PathWithFileName>
-      <FilenameWithoutPath>Calibrators.c</FilenameWithoutPath>
+      <PathWithFileName>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_eth_theEncoderReaderLegacy.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -3489,8 +3489,8 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</PathWithFileName>
-      <FilenameWithoutPath>AbsEncoder.c</FilenameWithoutPath>
+      <PathWithFileName>..\src\eoappservices\EOtheEncoderReader.c</PathWithFileName>
+      <FilenameWithoutPath>EOtheEncoderReader.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -3501,14 +3501,58 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</PathWithFileName>
+      <FilenameWithoutPath>EOappEncodersReader.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>motor-controller</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>104</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embobj\plus\mc\Controller.c</PathWithFileName>
       <FilenameWithoutPath>Controller.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>105</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\mc\Calibrators.c</PathWithFileName>
+      <FilenameWithoutPath>Calibrators.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>106</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</PathWithFileName>
+      <FilenameWithoutPath>AbsEncoder.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>107</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3519,8 +3563,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>108</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3531,8 +3575,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>109</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3543,8 +3587,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>110</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3555,8 +3599,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>108</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>111</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3567,8 +3611,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>109</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>112</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3587,8 +3631,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>110</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>113</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3599,8 +3643,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>111</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>114</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3611,8 +3655,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>112</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>115</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3623,8 +3667,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>113</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>116</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3635,8 +3679,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>114</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3647,8 +3691,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>115</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3659,8 +3703,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>116</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3671,8 +3715,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3683,8 +3727,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3695,8 +3739,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3707,8 +3751,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3719,8 +3763,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3731,8 +3775,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3743,8 +3787,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3755,8 +3799,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>127</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3775,8 +3819,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3787,8 +3831,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3799,8 +3843,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3811,8 +3855,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3823,8 +3867,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>132</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3835,8 +3879,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3847,8 +3891,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3859,8 +3903,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>135</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3871,8 +3915,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3883,8 +3927,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3895,8 +3939,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3907,8 +3951,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3919,8 +3963,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3931,8 +3975,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3943,8 +3987,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>142</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3955,8 +3999,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>143</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3970,13 +4014,13 @@
 
   <Group>
     <GroupName>eo-protocol-cfg-callbacks</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>144</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3987,8 +4031,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>145</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3999,8 +4043,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>146</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4011,8 +4055,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4031,8 +4075,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>148</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4043,8 +4087,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>149</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4055,8 +4099,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>150</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4075,8 +4119,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>151</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4087,8 +4131,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>152</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4099,8 +4143,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>153</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4111,8 +4155,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>154</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4123,8 +4167,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>155</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4135,8 +4179,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>156</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4147,46 +4191,14 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>157</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embobj\plus\can\config-can-protocol\EoCANprotBSperiodic.c</PathWithFileName>
       <FilenameWithoutPath>EoCANprotBSperiodic.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-  </Group>
-
-  <Group>
-    <GroupName>eo-board</GroupName>
-    <tvExp>0</tvExp>
-    <tvExpOptDlg>0</tvExpOptDlg>
-    <cbSel>0</cbSel>
-    <RteFlg>0</RteFlg>
-    <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>155</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</PathWithFileName>
-      <FilenameWithoutPath>EOtheEntities.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>156</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</PathWithFileName>
-      <FilenameWithoutPath>EOappEncodersReader.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -4200,7 +4212,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <FileNumber>158</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4212,7 +4224,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>158</FileNumber>
+      <FileNumber>159</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4224,7 +4236,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>159</FileNumber>
+      <FileNumber>160</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4236,7 +4248,7 @@
     </File>
     <File>
       <GroupNumber>21</GroupNumber>
-      <FileNumber>160</FileNumber>
+      <FileNumber>161</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4256,7 +4268,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>161</FileNumber>
+      <FileNumber>162</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4268,7 +4280,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>162</FileNumber>
+      <FileNumber>163</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4280,7 +4292,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>163</FileNumber>
+      <FileNumber>164</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4292,7 +4304,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>164</FileNumber>
+      <FileNumber>165</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4304,7 +4316,7 @@
     </File>
     <File>
       <GroupNumber>22</GroupNumber>
-      <FileNumber>165</FileNumber>
+      <FileNumber>166</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4324,7 +4336,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>166</FileNumber>
+      <FileNumber>167</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -4336,7 +4348,7 @@
     </File>
     <File>
       <GroupNumber>23</GroupNumber>
-      <FileNumber>167</FileNumber>
+      <FileNumber>168</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -812,14 +812,14 @@
           <GroupName>appl-services</GroupName>
           <Files>
             <File>
-              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
-            </File>
-            <File>
               <FileName>EOtheServices.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheServices.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
             </File>
             <File>
               <FileName>EOtheVirtualStrain.c</FileName>
@@ -853,13 +853,8 @@
             </File>
             <File>
               <FileName>EOtheMotionController.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -941,11 +936,41 @@
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
             </File>
+            <File>
+              <FileName>EOtheEntities.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
-          <GroupName>eo-motor-controller</GroupName>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
           <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>motor-controller</GroupName>
+          <Files>
+            <File>
+              <FileName>Controller.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
+            </File>
             <File>
               <FileName>Calibrators.c</FileName>
               <FileType>8</FileType>
@@ -955,11 +980,6 @@
               <FileName>AbsEncoder.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
-            </File>
-            <File>
-              <FileName>Controller.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
             </File>
             <File>
               <FileName>Joint.c</FileName>
@@ -1240,21 +1260,6 @@
               <FileName>EoCANprotBSperiodic.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\can\config-can-protocol\EoCANprotBSperiodic.c</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>eo-board</GroupName>
-          <Files>
-            <File>
-              <FileName>EOtheEntities.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2230,14 +2235,14 @@
           <GroupName>appl-services</GroupName>
           <Files>
             <File>
-              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
-            </File>
-            <File>
               <FileName>EOtheServices.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheServices.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
             </File>
             <File>
               <FileName>EOtheVirtualStrain.c</FileName>
@@ -2271,13 +2276,8 @@
             </File>
             <File>
               <FileName>EOtheMotionController.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -2359,10 +2359,35 @@
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
             </File>
+            <File>
+              <FileName>EOtheEntities.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
-          <GroupName>eo-motor-controller</GroupName>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>motor-controller</GroupName>
           <GroupOption>
             <CommonProperty>
               <UseCPPCompiler>0</UseCPPCompiler>
@@ -2434,6 +2459,11 @@
           </GroupOption>
           <Files>
             <File>
+              <FileName>Controller.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
+            </File>
+            <File>
               <FileName>Calibrators.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Calibrators.c</FilePath>
@@ -2442,11 +2472,6 @@
               <FileName>AbsEncoder.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
-            </File>
-            <File>
-              <FileName>Controller.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
             </File>
             <File>
               <FileName>Joint.c</FileName>
@@ -2727,21 +2752,6 @@
               <FileName>EoCANprotBSperiodic.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\can\config-can-protocol\EoCANprotBSperiodic.c</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>eo-board</GroupName>
-          <Files>
-            <File>
-              <FileName>EOtheEntities.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3768,14 +3778,14 @@
           <GroupName>appl-services</GroupName>
           <Files>
             <File>
-              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
-            </File>
-            <File>
               <FileName>EOtheServices.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheServices.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
             </File>
             <File>
               <FileName>EOtheVirtualStrain.c</FileName>
@@ -3809,13 +3819,8 @@
             </File>
             <File>
               <FileName>EOtheMotionController.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -3948,10 +3953,35 @@
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
             </File>
+            <File>
+              <FileName>EOtheEntities.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
-          <GroupName>eo-motor-controller</GroupName>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>motor-controller</GroupName>
           <GroupOption>
             <CommonProperty>
               <UseCPPCompiler>0</UseCPPCompiler>
@@ -4023,6 +4053,11 @@
           </GroupOption>
           <Files>
             <File>
+              <FileName>Controller.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
+            </File>
+            <File>
               <FileName>Calibrators.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Calibrators.c</FilePath>
@@ -4031,11 +4066,6 @@
               <FileName>AbsEncoder.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
-            </File>
-            <File>
-              <FileName>Controller.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
             </File>
             <File>
               <FileName>Joint.c</FileName>
@@ -4316,21 +4346,6 @@
               <FileName>EoCANprotBSperiodic.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\can\config-can-protocol\EoCANprotBSperiodic.c</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>eo-board</GroupName>
-          <Files>
-            <File>
-              <FileName>EOtheEntities.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -4812,7 +4827,7 @@
               <MiscControls>-DXenableTHESERVICETESTER  -Wno-pragma-pack -Wno-deprecated-register -DUSE_EMS4RD -DUSE_OLD_BUGGY_MODE_TO_SEND_UP_FULLSCALE_WITH_INVERTED_BYTES</MiscControls>
               <Define>DIAGNOSTIC2_enabled DIAGNOSTIC2_receive_from_daemon DIAGNOSTIC2_send_to_yarprobotinterface _no_DIAGNOSTIC2_send_to_daemon</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\libs\midware\eventviewer\api;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\embobj\plus\board\ems001;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\cfg\eoprot-callbacks;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\cfg\eoprot-boards;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\cfg\eoemsappl;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-mapping;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\board;..\..\..\..\mc4plus\appl\v2\src\eoappservices;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embot;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\..\..\mbd\kalman_filter</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\libs\midware\eventviewer\api;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\embobj\plus\board\ems001;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\cfg\eoprot-callbacks;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\cfg\eoprot-boards;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\cfg\eoemsappl;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-mapping;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\board;..\..\..\..\mc4plus\appl\v2\src\eoappservices;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embot;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embot\app\eth</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -5357,14 +5372,14 @@
           <GroupName>appl-services</GroupName>
           <Files>
             <File>
-              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
-            </File>
-            <File>
               <FileName>EOtheServices.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheServices.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOMtheEMSdiagnostic.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\ctrloop\EOMtheEMSdiagnostic.cpp</FilePath>
             </File>
             <File>
               <FileName>EOtheVirtualStrain.c</FileName>
@@ -5398,13 +5413,8 @@
             </File>
             <File>
               <FileName>EOtheMotionController.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -5588,10 +5598,35 @@
               <FileType>8</FileType>
               <FilePath>..\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
             </File>
+            <File>
+              <FileName>EOtheEntities.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
-          <GroupName>eo-motor-controller</GroupName>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>motor-controller</GroupName>
           <GroupOption>
             <CommonProperty>
               <UseCPPCompiler>0</UseCPPCompiler>
@@ -5663,6 +5698,11 @@
           </GroupOption>
           <Files>
             <File>
+              <FileName>Controller.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
+            </File>
+            <File>
               <FileName>Calibrators.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\Calibrators.c</FilePath>
@@ -5671,11 +5711,6 @@
               <FileName>AbsEncoder.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\mc\AbsEncoder.c</FilePath>
-            </File>
-            <File>
-              <FileName>Controller.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\mc\Controller.c</FilePath>
             </File>
             <File>
               <FileName>Joint.c</FileName>
@@ -5956,21 +5991,6 @@
               <FileName>EoCANprotBSperiodic.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embobj\plus\can\config-can-protocol\EoCANprotBSperiodic.c</FilePath>
-            </File>
-          </Files>
-        </Group>
-        <Group>
-          <GroupName>eo-board</GroupName>
-          <Files>
-            <File>
-              <FileName>EOtheEntities.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader_hid.h
@@ -22,9 +22,6 @@
 #ifndef _EOTHEENCODERREADER_HID_H_
 #define _EOTHEENCODERREADER_HID_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 
 // - external dependencies --------------------------------------------------------------------------------------------
@@ -84,9 +81,6 @@ struct EOtheEncoderReader_hid
 // empty section
 
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController_hid.h
@@ -22,9 +22,6 @@
 #ifndef _EOTHEMOTIONCONTROLLER_HID_H_
 #define _EOTHEMOTIONCONTROLLER_HID_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 
 // - external dependencies --------------------------------------------------------------------------------------------
@@ -33,7 +30,7 @@ extern "C" {
 #include "EoProtocol.h"
 
 #include "Controller.h"
-#include "EOtheEncoderReader.h"
+#include "embot_app_eth_theEncoderReader.h"  
 
 #include "EOtheMAIS.h"
 #include "EOthePSC.h"
@@ -74,9 +71,7 @@ typedef struct
     
     // for everything apart mc4can
     EOconstarray*                           jomodescriptors; // points to the jomodescriptor inside EOtheMotionController_hid::service::servconfig etc. 
-    MController*                            thecontroller;
-    EOtheEncoderReader*                     theencoderreader;   
-        
+    MController*                            thecontroller;      
     
     // for mc4plus, mc2plus, mc4plus-mais, mc2pluspsc, mc4plus-faps
     int16_t                                 pwmvalue[hal_motors_number];    // at most i can manage 4 motors
@@ -116,9 +111,6 @@ struct EOtheMotionController_hid
 // empty section
 
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
  
 #endif  // include-guard 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          52
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          53
 //  </h>version
 
 //  <h> build date
@@ -84,11 +84,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          26
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00 
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11 
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvoptx
@@ -1915,18 +1915,6 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</PathWithFileName>
-      <FilenameWithoutPath>EOappEncodersReader.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>12</GroupNumber>
-      <FileNumber>76</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</PathWithFileName>
       <FilenameWithoutPath>EOtheCANdiscovery2.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
@@ -1934,7 +1922,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>77</FileNumber>
+      <FileNumber>76</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1946,7 +1934,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>77</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1958,7 +1946,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>78</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1970,7 +1958,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>79</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1982,7 +1970,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1994,8 +1982,8 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>82</FileNumber>
-      <FileType>1</FileType>
+      <FileNumber>81</FileNumber>
+      <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
@@ -2006,19 +1994,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>83</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</PathWithFileName>
-      <FilenameWithoutPath>EOtheEncoderReader.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>12</GroupNumber>
-      <FileNumber>84</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2030,7 +2006,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2042,7 +2018,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2054,7 +2030,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2066,7 +2042,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2078,7 +2054,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2090,7 +2066,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2102,7 +2078,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2114,7 +2090,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2126,7 +2102,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2138,7 +2114,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2150,7 +2126,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2162,7 +2138,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2174,7 +2150,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2186,7 +2162,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2198,7 +2174,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2210,7 +2186,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2223,14 +2199,58 @@
   </Group>
 
   <Group>
+    <GroupName>embot::app::eth::theEncoderReader</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>99</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_eth_theEncoderReaderLegacy.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>100</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</PathWithFileName>
+      <FilenameWithoutPath>EOtheEncoderReader.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>101</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</PathWithFileName>
+      <FilenameWithoutPath>EOappEncodersReader.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
     <GroupName>eo-motor-controller</GroupName>
     <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>101</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>102</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2241,8 +2261,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>102</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>103</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2253,8 +2273,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>103</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>104</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2265,8 +2285,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>105</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2277,8 +2297,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>106</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2289,8 +2309,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>107</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2301,8 +2321,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>108</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2313,8 +2333,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>108</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>109</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2325,8 +2345,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>109</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>110</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2345,8 +2365,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>110</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>111</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2357,8 +2377,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>111</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>112</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2369,8 +2389,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>112</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>113</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2381,8 +2401,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>113</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>114</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2393,8 +2413,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>114</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>115</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2405,8 +2425,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>115</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>116</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2417,8 +2437,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>116</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2429,8 +2449,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2441,8 +2461,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2453,8 +2473,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2465,8 +2485,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2477,8 +2497,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2489,8 +2509,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2501,8 +2521,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2513,8 +2533,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2528,13 +2548,13 @@
 
   <Group>
     <GroupName>eo-protocol</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2545,8 +2565,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>127</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2557,8 +2577,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2569,8 +2589,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2581,8 +2601,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2593,8 +2613,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2605,8 +2625,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>132</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2617,8 +2637,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2629,8 +2649,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2641,8 +2661,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>135</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2653,8 +2673,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2665,8 +2685,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2677,8 +2697,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2689,8 +2709,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2701,8 +2721,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2713,8 +2733,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2733,8 +2753,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>142</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2745,8 +2765,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>143</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2757,8 +2777,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>144</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2769,8 +2789,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>145</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2784,13 +2804,13 @@
 
   <Group>
     <GroupName>eoprot-can</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>146</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2801,8 +2821,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2813,8 +2833,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>148</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2828,13 +2848,13 @@
 
   <Group>
     <GroupName>eoprot-can-cfg-protocol</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>149</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2845,8 +2865,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>150</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2857,8 +2877,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>151</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2869,8 +2889,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>152</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2881,8 +2901,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>153</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2893,8 +2913,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>154</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2905,8 +2925,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>155</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2925,8 +2945,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>156</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2937,8 +2957,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>157</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2949,8 +2969,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>158</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2961,8 +2981,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>158</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>159</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2981,8 +3001,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>159</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>160</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2993,8 +3013,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>160</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>161</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3005,8 +3025,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>161</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>162</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3017,8 +3037,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>162</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>163</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3029,8 +3049,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>163</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>164</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3049,8 +3069,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>164</FileNumber>
+      <GroupNumber>22</GroupNumber>
+      <FileNumber>165</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -3061,8 +3081,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>165</FileNumber>
+      <GroupNumber>22</GroupNumber>
+      <FileNumber>166</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
@@ -340,7 +340,7 @@
               <MiscControls>-DXenableTHESERVICETESTER -DEOTHESERVICES_disable_thePOS -Wno-pragma-pack -Wno-deprecated-register -DUSE_MC2PLUS -DUSE_OLD_BUGGY_MODE_TO_SEND_UP_FULLSCALE_WITH_INVERTED_BYTES</MiscControls>
               <Define>CER R1_HAND DIAGNOSTIC2_enabled DIAGNOSTIC2_receive_from_daemon DIAGNOSTIC2_send_to_yarprobotinterface _noDIAGNOSTIC2_send_to_daemon</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\libs\highlevel\services\embenv\api;..\cfg\boardcfg;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\mc;..\..\..\..\ems004\appl\v2\cfg\eoprot-callbacks;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\mbd\kalman_filter</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\libs\highlevel\services\embenv\api;..\cfg\boardcfg;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\mc;..\..\..\..\ems004\appl\v2\cfg\eoprot-callbacks;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embot\app\eth</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -810,11 +810,6 @@
               <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
             </File>
             <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
-            </File>
-            <File>
               <FileName>EOtheCANdiscovery2.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</FilePath>
@@ -846,13 +841,8 @@
             </File>
             <File>
               <FileName>EOtheMotionController.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -938,6 +928,26 @@
               <FileName>embot_app_eth_theBATservice.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2185,11 +2195,6 @@
               <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
             </File>
             <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
-            </File>
-            <File>
               <FileName>EOtheCANdiscovery2.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</FilePath>
@@ -2221,13 +2226,8 @@
             </File>
             <File>
               <FileName>EOtheMotionController.c</FileName>
-              <FileType>1</FileType>
+              <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -2313,6 +2313,26 @@
               <FileName>embot_app_eth_theBATservice.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -2699,7 +2719,7 @@
   <LayerInfo>
     <Layers>
       <Layer>
-        <LayName>&lt;Project Info&gt;</LayName>
+        <LayName>mc2plus</LayName>
         <LayTarg>0</LayTarg>
         <LayPrjMark>1</LayPrjMark>
       </Layer>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -86,7 +86,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          73
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          74
 
 //  </h>version
 
@@ -96,11 +96,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          26
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvoptx
@@ -1750,18 +1750,6 @@
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</PathWithFileName>
-      <FilenameWithoutPath>EOappEncodersReader.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>12</GroupNumber>
-      <FileNumber>77</FileNumber>
-      <FileType>1</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</PathWithFileName>
       <FilenameWithoutPath>EOtheCANdiscovery2.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
@@ -1769,7 +1757,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>78</FileNumber>
+      <FileNumber>77</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1781,7 +1769,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>79</FileNumber>
+      <FileNumber>78</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1793,7 +1781,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>80</FileNumber>
+      <FileNumber>79</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1805,7 +1793,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>81</FileNumber>
+      <FileNumber>80</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1817,7 +1805,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>82</FileNumber>
+      <FileNumber>81</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1829,7 +1817,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>83</FileNumber>
+      <FileNumber>82</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1841,19 +1829,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>84</FileNumber>
-      <FileType>8</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</PathWithFileName>
-      <FilenameWithoutPath>EOtheEncoderReader.c</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>12</GroupNumber>
-      <FileNumber>85</FileNumber>
+      <FileNumber>83</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1865,7 +1841,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>86</FileNumber>
+      <FileNumber>84</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1877,7 +1853,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>87</FileNumber>
+      <FileNumber>85</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1889,7 +1865,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>88</FileNumber>
+      <FileNumber>86</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1901,7 +1877,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>89</FileNumber>
+      <FileNumber>87</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1913,7 +1889,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>90</FileNumber>
+      <FileNumber>88</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1925,7 +1901,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>91</FileNumber>
+      <FileNumber>89</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1937,7 +1913,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>92</FileNumber>
+      <FileNumber>90</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1949,7 +1925,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>93</FileNumber>
+      <FileNumber>91</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1961,7 +1937,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>94</FileNumber>
+      <FileNumber>92</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1973,7 +1949,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>95</FileNumber>
+      <FileNumber>93</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1985,7 +1961,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>96</FileNumber>
+      <FileNumber>94</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1997,7 +1973,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>97</FileNumber>
+      <FileNumber>95</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2009,7 +1985,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>98</FileNumber>
+      <FileNumber>96</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2021,7 +1997,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>99</FileNumber>
+      <FileNumber>97</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2033,7 +2009,7 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>100</FileNumber>
+      <FileNumber>98</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2045,13 +2021,57 @@
     </File>
     <File>
       <GroupNumber>12</GroupNumber>
-      <FileNumber>101</FileNumber>
+      <FileNumber>99</FileNumber>
       <FileType>8</FileType>
-      <tvExp>1</tvExp>
+      <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theBATservice.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_app_eth_theBATservice.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>embot::app::eth::theEncoderReader</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>100</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_eth_theEncoderReaderLegacy.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>101</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</PathWithFileName>
+      <FilenameWithoutPath>EOtheEncoderReader.c</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>13</GroupNumber>
+      <FileNumber>102</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</PathWithFileName>
+      <FilenameWithoutPath>EOappEncodersReader.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -2064,8 +2084,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>102</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>103</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2076,8 +2096,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>103</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>104</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2088,8 +2108,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>104</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>105</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2100,8 +2120,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>105</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>106</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2112,8 +2132,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>106</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>107</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2124,8 +2144,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>107</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>108</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2136,8 +2156,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>108</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>109</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2148,8 +2168,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>109</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>110</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2160,8 +2180,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>13</GroupNumber>
-      <FileNumber>110</FileNumber>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>111</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2180,8 +2200,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>111</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>112</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2192,8 +2212,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>112</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>113</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2204,8 +2224,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>113</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>114</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2216,8 +2236,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>114</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>115</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2228,8 +2248,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>115</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>116</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2240,8 +2260,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>116</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>117</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2252,8 +2272,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>117</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>118</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2264,8 +2284,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>118</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>119</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2276,8 +2296,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>119</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>120</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2288,8 +2308,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>120</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>121</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2300,8 +2320,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>121</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>122</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2312,8 +2332,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>122</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>123</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2324,8 +2344,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>123</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>124</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2336,8 +2356,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>124</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>125</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2348,8 +2368,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <GroupNumber>15</GroupNumber>
+      <FileNumber>126</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2368,8 +2388,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>127</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2380,8 +2400,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>128</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2392,8 +2412,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>129</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2404,8 +2424,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>130</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2416,8 +2436,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>130</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>131</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2428,8 +2448,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>131</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>132</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2440,8 +2460,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>132</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>133</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2452,8 +2472,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>133</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>134</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2464,8 +2484,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>134</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>135</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2476,8 +2496,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>135</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>136</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2488,8 +2508,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>136</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>137</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2500,8 +2520,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>137</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>138</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2512,8 +2532,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>138</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>139</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2524,8 +2544,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>139</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>140</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2536,8 +2556,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>140</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>141</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2548,8 +2568,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>15</GroupNumber>
-      <FileNumber>141</FileNumber>
+      <GroupNumber>16</GroupNumber>
+      <FileNumber>142</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2568,8 +2588,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>142</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>143</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2580,8 +2600,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>143</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>144</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2592,8 +2612,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>144</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>145</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2604,8 +2624,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>16</GroupNumber>
-      <FileNumber>145</FileNumber>
+      <GroupNumber>17</GroupNumber>
+      <FileNumber>146</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2624,8 +2644,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>146</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>147</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2636,8 +2656,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>147</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>148</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2648,8 +2668,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>17</GroupNumber>
-      <FileNumber>148</FileNumber>
+      <GroupNumber>18</GroupNumber>
+      <FileNumber>149</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2668,8 +2688,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>149</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>150</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2680,8 +2700,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>150</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>151</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2692,8 +2712,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>151</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>152</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2704,8 +2724,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>152</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>153</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2716,8 +2736,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>153</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>154</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2728,8 +2748,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>154</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>155</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2740,8 +2760,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>18</GroupNumber>
-      <FileNumber>155</FileNumber>
+      <GroupNumber>19</GroupNumber>
+      <FileNumber>156</FileNumber>
       <FileType>1</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2760,8 +2780,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>156</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>157</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2772,8 +2792,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>157</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>158</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2784,8 +2804,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>158</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>159</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2796,8 +2816,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>19</GroupNumber>
-      <FileNumber>159</FileNumber>
+      <GroupNumber>20</GroupNumber>
+      <FileNumber>160</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2816,8 +2836,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>160</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>161</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2828,8 +2848,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>161</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>162</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2840,8 +2860,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>162</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>163</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2852,8 +2872,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>163</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>164</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2864,8 +2884,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>20</GroupNumber>
-      <FileNumber>164</FileNumber>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>165</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2884,8 +2904,8 @@
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
     <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>165</FileNumber>
+      <GroupNumber>22</GroupNumber>
+      <FileNumber>166</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -2896,8 +2916,8 @@
       <bShared>0</bShared>
     </File>
     <File>
-      <GroupNumber>21</GroupNumber>
-      <FileNumber>166</FileNumber>
+      <GroupNumber>22</GroupNumber>
+      <FileNumber>167</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
@@ -814,11 +814,6 @@
               <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
             </File>
             <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
-            </File>
-            <File>
               <FileName>EOtheCANdiscovery2.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</FilePath>
@@ -852,11 +847,6 @@
               <FileName>EOtheMotionController.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -942,6 +932,26 @@
               <FileName>embot_app_eth_theBATservice.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -1651,7 +1661,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DUSE_MC4PLUS -DUSE_OLD_BUGGY_MODE_TO_SEND_UP_FULLSCALE_WITH_INVERTED_BYTES</MiscControls>
               <Define>DIAGNOSTIC2_enabled DIAGNOSTIC2_receive_from_daemon DIAGNOSTIC2_send_to_yarprobotinterface _noDIAGNOSTIC2_send_to_daemon</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\libs\highlevel\services\embenv\api;..\cfg\boardcfg;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\mc;..\..\..\..\ems004\appl\v2\cfg\eoprot-callbacks;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\..\..\mbd\kalman_filter</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\highlevel\abslayer\ipal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\libs\highlevel\services\embenv\api;..\cfg\boardcfg;..\cfg\eoemsappl;..\cfg\abslayer;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\src;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\utils;.;..\src\eoappservices;..\cfg\eoappservices\icub-can-proto;..\cfg\eoappservices\icub-can-net;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\robotconfig\v1\backdoor;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\opcprot;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\ems004\env\cfg;..\..\..\..\..\libs\highlevel\services\embodyrobot;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\embobj\plus\ipnet;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\embobj\plus\can;..\..\..\..\..\embobj\plus\can\config-can-protocol;..\..\..\..\..\embobj\plus\mc;..\..\..\..\ems004\appl\v2\cfg\eoprot-callbacks;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embot\cif;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embot\app\eth</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -2145,11 +2155,6 @@
               <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
             </File>
             <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
-            </File>
-            <File>
               <FileName>EOtheCANdiscovery2.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</FilePath>
@@ -2183,11 +2188,6 @@
               <FileName>EOtheMotionController.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -2273,6 +2273,26 @@
               <FileName>embot_app_eth_theBATservice.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -3545,11 +3565,6 @@
               <FilePath>..\..\..\..\..\embobj\plus\board\EOtheEntities.c</FilePath>
             </File>
             <File>
-              <FileName>EOappEncodersReader.c</FileName>
-              <FileType>1</FileType>
-              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
-            </File>
-            <File>
               <FileName>EOtheCANdiscovery2.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheCANdiscovery2.c</FilePath>
@@ -3583,11 +3598,6 @@
               <FileName>EOtheMotionController.c</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheMotionController.c</FilePath>
-            </File>
-            <File>
-              <FileName>EOtheEncoderReader.c</FileName>
-              <FileType>8</FileType>
-              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
             </File>
             <File>
               <FileName>EOtheETHmonitor.c</FileName>
@@ -3673,6 +3683,26 @@
               <FileName>embot_app_eth_theBATservice.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theBATservice.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>embot::app::eth::theEncoderReader</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_eth_theEncoderReaderLegacy.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\eth\embot_app_eth_theEncoderReaderLegacy.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>EOtheEncoderReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\EOtheEncoderReader.c</FilePath>
+            </File>
+            <File>
+              <FileName>EOappEncodersReader.c</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embobj\plus\board\EOappEncodersReader.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
@@ -27,6 +27,10 @@
 **/
 
 
+#if !defined(__cplusplus)
+    #error this EOappEncodersReader.c file must be compiled in C++
+#endif
+    
 // --------------------------------------------------------------------------------------------------------------------
 // - external dependencies
 // --------------------------------------------------------------------------------------------------------------------
@@ -188,6 +192,7 @@ static EOappEncReader s_eo_theappencreader =
     EO_INIT(.amodiag)
     {
         EO_INIT(.enabled)           eobool_true,
+        EO_INIT(.config)            {0, 0},
         EO_INIT(.minimuminterval)   {(100*1000), (100*1000)},
         EO_INIT(.vals)              { 0, 0 },
         EO_INIT(.regs)              { 0, 0 },
@@ -330,15 +335,29 @@ extern eOresult_t eo_appEncReader_Activate(EOappEncReader *p, EOconstarray *arra
     return(eores_OK);
 }
 
+extern eOresult_t eo_appEncReader_GetEncoderType(EOappEncReader *p, uint8_t jomo, eOmc_encoder_t *primary, eOmc_encoder_t *secondary)
+{
+    if((NULL == p) || (NULL == primary) || (NULL == secondary))
+    {
+        return(eores_NOK_nullpointer);
+    }
+
+    eOappEncReader_jomoconfig_t this_jomoconfig = p->config.jomoconfig[jomo];
+    
+    *primary = (eOmc_encoder_t)this_jomoconfig.encoder1des.type;
+    *secondary = (eOmc_encoder_t)this_jomoconfig.encoder2des.type;
+    
+    return(eores_OK);    
+}
+
 extern eOresult_t eo_appEncReader_UpdatedMaisConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor)
 {
-    eOappEncReader_jomoconfig_t this_jomoconfig = p->config.jomoconfig[jomo];
-
     if(NULL == p)
     {
         return(eores_NOK_nullpointer);
     }
     
+    eOappEncReader_jomoconfig_t this_jomoconfig = p->config.jomoconfig[jomo];    
 
     // check existence for primary encoder
     if((eomc_enc_mais != this_jomoconfig.encoder1des.type) && (eomc_enc_mais != this_jomoconfig.encoder2des.type))

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.h
@@ -22,9 +22,9 @@
 #ifndef _EOAPPENCODERSREADER_H_
 #define _EOAPPENCODERSREADER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+//#ifdef __cplusplus
+//extern "C" {
+//#endif
 
 // - doxy begin -------------------------------------------------------------------------------------------------------
 
@@ -43,9 +43,9 @@ extern "C" {
 
 #include "EoCommon.h"
 #include "EoManagement.h"
-#include "hal_spiencoder.h"
-
+#include "EOconstarray.h"    
 #include "EOtheEncoderReader.h"
+
 
 
 // - public #define  --------------------------------------------------------------------------------------------------
@@ -87,6 +87,7 @@ extern eOresult_t eo_appEncReader_Diagnostics_Enable(EOappEncReader *p, eObool_t
 
 extern eOresult_t eo_appEncReader_Diagnostics_Tick(EOappEncReader *p);
 
+extern eOresult_t eo_appEncReader_GetEncoderType(EOappEncReader *p, uint8_t jomo, eOmc_encoder_t *primary, eOmc_encoder_t *secondary);
 
 extern eOresult_t eo_appEncReader_UpdatedMaisConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor);
 extern eOresult_t eo_appEncReader_UpdatedHallAdcConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor);
@@ -97,9 +98,9 @@ extern eOresult_t eo_appEncReader_UpdatedHallAdcOffset(EOappEncReader *p, uint8_
  **/
  
  
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
+//#ifdef __cplusplus
+//}       // closing brace for extern "C"
+//#endif 
 
 #endif  // include-guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
@@ -23,9 +23,9 @@
 #define _EOAPPENCODERSREADER_HID_H_
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+//#ifdef __cplusplus
+//extern "C" {
+//#endif
     
 // - doxy -------------------------------------------------------------------------------------------------------------
 /* @file       EOappEncodersReader.h
@@ -133,9 +133,9 @@ struct EOappEncReader_hid
 // - declaration of extern hidden functions ---------------------------------------------------------------------------
 // empty-section
 
-#ifdef __cplusplus
-}       // closing brace for extern "C"
-#endif 
+//#ifdef __cplusplus
+//}       // closing brace for extern "C"
+//#endif 
 
 #endif  // include guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -434,18 +434,18 @@ void AbsEncoder_invalid(AbsEncoder* o, ae_errortype_t error_type)
     
     switch (error_type)
     {
-        case ae_err_NOTCONNECTED:
-        case ae_err_NONE:
+        case embot::app::eth::encoder::v1::Error::NOTCONNECTED:
+        case embot::app::eth::encoder::v1::Error::NONE:
             break;
         
         // all other cases are errors: AEA_PARITY, AEA_CHIP, AEA_READING have their tx_error, chip_error, data_error. all others: are data_error. 
-        case ae_err_AEA_PARITY:
+        case embot::app::eth::encoder::v1::Error::AEA_PARITY:
             o->fault_state.bits.tx_error = TRUE;
             break;
-        case ae_err_AEA_CHIP:
+        case embot::app::eth::encoder::v1::Error::AEA_CHIP:
             o->fault_state.bits.chip_error = TRUE;
             break;        
-        case ae_err_AEA_READING:
+        case embot::app::eth::encoder::v1::Error::AEA_READING:
             o->fault_state.bits.data_error = TRUE;
             break;
         

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.h
@@ -24,6 +24,12 @@
 #include "EoMotionControl.h"
 #include "EOemsControllerCfg.h"
 
+#include "embot_app_eth_Encoder.h"
+
+using ae_errortype_t = embot::app::eth::encoder::v1::Error;
+
+
+
 /////////////////////////////////////////////////////////
 // AbsEncoder
 
@@ -133,23 +139,6 @@ extern void AbsEncoder_calibrate_fake(AbsEncoder* o);
  */
 extern void AbsEncoder_update(AbsEncoder* o, uint16_t position);
 
-typedef enum
-{
-    ae_err_NONE                  = 0,
-    ae_err_AEA_READING           = 1,
-    ae_err_AEA_PARITY            = 2,
-    ae_err_AEA_CHIP              = 3,
-//    encreader_err_QENC_GENERIC          = 4,
-//    encreader_err_ABSANALOG_GENERIC     = 5,
-//    encreader_err_MAIS_GENERIC          = 6,
-//    encreader_err_SPICHAINOF2_GENERIC   = 7,
-//    encreader_err_SPICHAINOF3_GENERIC   = 8,
-//    encreader_err_AMO_GENERIC           = 9,
-//    encreader_err_PSC_GENERIC           = 10,  
-//    encreader_err_POS_GENERIC           = 11,    
-    ae_err_GENERIC               = 14,    
-    ae_err_NOTCONNECTED          = 15 /* this error happens when the encoder type is none or encoder is not local, for example it is connected to 2foc board */
-} ae_errortype_t;
 
 extern void AbsEncoder_invalid(AbsEncoder* o, ae_errortype_t error_type);
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -33,7 +33,8 @@
 #warning USE_EMBOT_theServices is defined: removed some code
 // marco.accame: use objects embot::app::eth::theEncoderReader and ... future ones
 #else
-#include "EOappEncodersReader.h"
+//#include "EOtheEncoderReader.h"
+#include "embot_app_eth_theEncoderReader.h"
 #include "EOtheMAIS.h"
 #include "EOthePOS.h"
 #endif
@@ -1720,7 +1721,10 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             if (eo_mais_isAlive(eo_mais_GetHandle()))
             {
                 float computedJntEncoderResolution = (float)(calibrator->params.type6.vmax - calibrator->params.type6.vmin) / (float) (jconfig->userlimits.max  - jconfig->userlimits.min);
-            
+
+#if 1
+                embot::app::eth::theEncoderReader::getInstance().Scale({e, embot::app::eth::encoder::v1::Position::every}, {computedJntEncoderResolution, 0});
+#else
                 eOresult_t res = eo_appEncReader_UpdatedMaisConversionFactors(eo_appEncReader_GetHandle(), e, computedJntEncoderResolution);
                 if(eores_OK != res)
                 {    
@@ -1731,7 +1735,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                     ////debug code ended
                     return;
                 }
-
+#endif 
                 AbsEncoder_config_resolution(o->absEncoder+e, computedJntEncoderResolution);
             
                 //Now I need to re-init absEncoder because I chenged maisConversionFactor, therefore the values returned by EOappEncoreReder are changed.
@@ -1790,6 +1794,10 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             
             int32_t offset = (((float)calibrator->params.type7.vmin)/computedJntEncoderResolution) - jconfig->userlimits.min;
             
+
+#if 1
+            embot::app::eth::theEncoderReader::getInstance().Scale({e, embot::app::eth::encoder::v1::Position::every}, {computedJntEncoderResolution, offset});
+#else            
             eOresult_t res = eo_appEncReader_UpdatedHallAdcOffset(eo_appEncReader_GetHandle(), e, offset);
             if(eores_OK != res)
             {    
@@ -1812,7 +1820,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 ////debug code ended
                 return;
             }
-
+#endif       
             AbsEncoder_config_resolution(o->absEncoder+e, computedJntEncoderResolution);
             
             //Now I need to re init absEncoder because I chenged hallADCConversionFactor, therefore the values returned by EOappEncoreReder are changed.

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Encoder.h
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Encoder.h
@@ -1,0 +1,251 @@
+
+
+/*
+ * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_APP_ETH_ENCODER_H_
+#define __EMBOT_APP_ETH_ENCODER_H_
+
+
+#if 0
+ 
+### The encoder in embot environment
+
+The management of the encoders in the embOBJ environment ....
+
+
+#endif
+
+#include "embot_core.h"
+#include "embot_app_eth_Service.h"
+
+#include "EoCommon.h"
+#include "EoManagement.h"
+#include "EOconstarray.h"
+
+// in here we place types required to manage the encoders in the embot environment.
+
+#if 0
+    In here we place types required to manage the encoders in the embot environment.
+    We use namespaces to manage the evolution of the required functionalities.
+    
+    The `embot::app::eth::encoder::v1` namespace holds a mixture of:
+    - embOBJ types, 
+    - embot types derived by alias of embOBJ ones, and
+    - brand new embot types.
+    All its data structures are meant to mimic the behavior of ETH boards using sensors up to July 2023.
+        
+    The `embot::app::eth::encoder::experimental` namespace is just a tentative example of how to enhance the reading of encoders w/ higher
+    resulution the likes of the AKSIM.
+
+    Future `embot::app::eth::encoder::v2` etc namespaces will introduce the new features
+        
+    From top to down:
+    - the reading service is offered by the PIMPL singleton `embot::app::eth::theEncoderReader` which uses 
+      multiple inheritance from the pure interface classes `embot::app::eth::encoder::v1::IFreader` etc 
+      to expose all the required features (higher encoder resolution, diagnostics, etc).
+    - the internals of the `theEncoderReader` PIMPL singleton are left open to offer the most suitable implementation.
+      So far (July 2023), we have two different implementations:
+      - the one used by `ems`, `mc4plus`, `mc2plus` which relies upon `EOtheEncoderReader`, `EOappEncoderReaader` and `hal` of stm32f407;
+      - the simplified one used by `amc` which directly uses `embot::hw::encoder` to manage just `AEA` encoders
+
+    
+#endif 
+
+namespace embot::app::eth::encoder::v1 {
+       
+    // it tells to which port the encoder is physically attached on the PCB
+    // for now it keep U8 values from eObrd_port_t, eObrd_portmais_t, eObrd_portpsc_t, eObrd_portpos_t, etc (used by icub-main)    
+    using Port = uint8_t;                                               
+        
+    // it tells the type of the encoder. 
+    // for now we use the same values of eOmc_encoder_t (used by icub-main) conveniently placed in here.
+    enum class Type : uint8_t 
+    {   // same as eOmc_encoder_t
+        aea         = eomc_enc_aea,         //  1
+        roie        = eomc_enc_roie,        //  2
+        absanalog   = eomc_enc_absanalog,   //  3, // or HALL_ADC
+        mais        = eomc_enc_mais,        //  4, // MAIS 
+        qenc        = eomc_enc_qenc,        //  5, // or OPTICAL_QUAD
+        hallmotor   = eomc_enc_hallmotor,   //  6, // HALL_MOTOR_SENS    
+        spichainof2 = eomc_enc_spichainof2, //  7,  
+        spichainof3 = eomc_enc_spichainof3, //  8,    
+        amo         = eomc_enc_amo,         //  9, 
+        psc         = eomc_enc_psc,         // 10,
+        pos         = eomc_enc_pos,         // 11,
+        aea3        = eomc_enc_aea3,        // 12,
+        aksim2      = eomc_enc_aksim2,      // 13,
+        mrie        = eomc_enc_mrie,        // 14,
+    
+        none        = eomc_enc_none,        //  0,
+        any         = 254,
+        unknown     = eomc_enc_unknown      //255                
+    };
+    constexpr size_t maxTYPEs {14};    
+    static_assert(maxTYPEs == eomc_encoders_numberof, "v1::maxTYPEs) is not equal to eomc_encoders_numberof");
+    
+    
+    // it tells the logical placement of the encoder, so if the encoder offers measures of the joint or of the motor
+    // we keep values from eOmc_position_t (used by icub-main)
+    enum class Placement : uint8_t { none = 0, atjoint = 1, atmotor = 2 };  
+    constexpr size_t maxPLACEMENTs {3};    
+    
+    // it tells if the encoder is the first or the second of the joint-motor 
+    // Position::one / ::two is associated to ENCODER1 / ENCODER2 of the xml file.
+    // CAVEAT: Position  may be seen as a duplicate of Placement. So far, however we have kept the possibility
+    // to have two encoder for the pair joint-motor, with any placement: even the two of them at the joint.
+    enum class Position : uint8_t { one = 0, two = 1, every = 14, none = 15, primary = one, secondary = two};
+    constexpr size_t maxPOSITIONs {2};  
+  
+    
+    // it tells which are the possible errors in reading encoders. 
+    // so far we just use what was inside the embOBJ encoder reader in enum eOencoderreader_errortype_t, which is now removed. 
+    // CAVEAT: any error beyond 15 cannot be managed by diagnostics messages because it will not fit inside a nibble
+    enum class Error : uint8_t
+    {   // from the old eOencoderreader_errortype_t, now removed
+        NONE                  = 0,
+        AEA_READING           = 1,
+        AEA_PARITY            = 2,
+        AEA_CHIP              = 3,
+        QENC_GENERIC          = 4,
+        ABSANALOG_GENERIC     = 5,
+        MAIS_GENERIC          = 6,
+        SPICHAINOF2_GENERIC   = 7,
+        SPICHAINOF3_GENERIC   = 8,
+        AMO_GENERIC           = 9,
+        PSC_GENERIC           = 10,
+        POS_GENERIC           = 11,
+        GENERIC               = 14,
+        NOTCONNECTED          = 15, /* this error happens when the encoder type is none or encoder is not local, for example it is connected to 2foc board */
+        
+        AKSIM2_INVALID_DATA   = 16,
+        AKSIM2_CLOSE_TO_LIMITS= 17,
+        AKSIM2_CRC_ERROR      = 18,
+        AKSIM2_GENERIC        = 19
+    };   
+    //constexpr size_t maxERRORs {20}; // caveat there is a hole and ...    
+    
+    // it contains the readings of one encoder in multiple components plus its placement and errors.
+    // so far it uses the same complex structure and memory layout of eOencoderreader_valueInfo_t (now removed)
+    struct valueInfo
+    {   // its size is: 4*4+1+1+1 = 19. but it will use 20 bytes
+        static constexpr size_t MAXcomponents {eomc_encoders_maxnumberofcomponents}; // eomc_encoders_maxnumberofcomponents is 4
+        
+        uint32_t value[MAXcomponents] {0};          // typically we use only values[0] unless we have composedof > 1
+        Error errortype {Error::NONE};              // use values of v1::Error
+        uint8_t composedof {0};                     // typically 1, unless we have eomc_enc_spichainof2 / eomc_enc_spichainof3 as in the hand of R1 
+        Placement placement {Placement::none};      // use values from Placement. it tells if at joint or at motor
+    };
+    
+    static_assert(sizeof(valueInfo) == 20, "sizeof(v1::valueInfo) is not 20");
+    
+    // it is used to offer gain and offset to some encoders such as absanalog and mais. 
+    struct Scaler
+    {   // out = input * 1/fabs(scale) - offset
+        float scale {1.0f};
+        int32_t offset {0};    
+    };
+    
+    // it tells that we can manage up to a max number of joint-motor entities
+    static constexpr size_t maxJOMOs {4};  
+    
+    // it defines the coordinates of the encoder with:
+    // - jomo index in range [0, .. , maxJOMOs) 
+    // - position 
+    struct Target
+    {   
+        uint8_t jomo {0};
+        Position pos {Position::one};
+        
+        constexpr Target() = default;
+        constexpr Target(uint8_t j, Position p) : jomo(j), pos(p) {}
+            
+        constexpr bool isvalid() {  return (jomo < maxJOMOs) && (embot::core::tointegral(pos) < maxPOSITIONs); }        
+    };
+    
+    
+    // for use by the ems, mc4plus and mc2plus but also by the amc
+    // it allows to read all the standard resolution encoders used up to july 2023 
+    struct IFreader
+    {
+        struct Config
+        {
+            EOconstarray *carrayofjomodes {nullptr};
+            eOmn_serv_diagn_cfg_t dc {};
+            Config() = default;
+            Config(EOconstarray *cjo, const eOmn_serv_diagn_cfg_t &d) : carrayofjomodes(cjo), dc(d) {}   
+            constexpr bool isvalid() { return carrayofjomodes != nullptr; }
+        };
+        
+        virtual bool Verify(const Config &config, const OnEndOfOperation &onverify, bool activateafterverify) = 0; 
+        virtual bool Activate(const Config &config) = 0;
+        virtual bool Deactivate() = 0;
+        virtual bool SendReport() = 0;
+        virtual bool StartReading() = 0;
+        virtual bool IsReadingAvailable();
+        virtual bool Read(uint8_t jomo, v1::valueInfo &primary, v1::valueInfo &secondary) = 0;   
+        virtual bool Diagnostics_Tick() = 0;
+        virtual Type GetType(const v1::Target &target) = 0;
+        virtual bool Scale(const v1::Target &target, const Scaler &scaler) = 0;
+    protected:
+        virtual ~IFreader() {};    // cannot delete from interface but only from derived object        
+    };          
+   
+} // namespace embot::app::eth::encoder::v1 {
+    
+
+
+namespace embot::app::eth::encoder::experimental {
+        
+    // this is just an example of an experimental interface which can match the needs of the new sensors
+    
+    enum class Error : uint8_t
+    {
+        NONE        = 0,
+        SOME        = 1,
+        OTHER       = 2        
+    };
+    
+    // maybe in the future we want more than two encoders per joint-motor entity
+    enum class Position : uint8_t { one = 0, two = 1, three = 2, four = 3, every = 14, none = 15};
+    constexpr size_t maxPOSITIONs {4};
+    
+    struct Value
+    {   // the value w/ a possible error     
+        int64_t raw {0};                                                    // to accomodate high resolution values
+        embot::app::eth::encoder::experimental::Error error {Error::NONE};      // 
+    };
+    
+    struct Target
+    {   // it tells which joint-motor pair + plus the posotion of the encoder
+        static constexpr size_t maxJOMOs {4};
+        uint8_t jomo {0};
+        Position pos {Position::one};
+        
+        constexpr Target() = default;
+        constexpr Target(uint8_t j, Position p) : jomo(j), pos(p) {}
+            
+        constexpr bool isvalid() {  return (jomo < maxJOMOs) && (embot::core::tointegral(pos) < maxPOSITIONs); }        
+    };
+
+    struct IFreader
+    {
+        virtual bool read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value) = 0;   
+        
+    protected:
+        virtual ~IFreader() {};    // cannot delete from interface but only from derived object        
+    };     
+    
+} // namespace embot::app::eth::encoder::experimental:: {
+
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service.h
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service.h
@@ -24,9 +24,16 @@
 #include <memory>
 
 
-namespace embot { namespace app { namespace eth {
+namespace embot::app::eth {
     
-    typedef eOresult_t (*eOservice_onendofoperation_fun_t) (void* p, eObool_t operationisok);
+    using eOservice_onendofoperation_fun_t = eOresult_t (*) (void* p, eObool_t operationisok);
+    
+    struct OnEndOfOperation
+    {
+        eOservice_onendofoperation_fun_t callback {nullptr};
+        void * param {nullptr};
+        constexpr bool isvalid() { return nullptr != callback; }        
+    };
     
     struct DescriptorCANframe
     {
@@ -126,10 +133,9 @@ namespace embot { namespace app { namespace eth {
             }
         }
     };
+   
 
-    
-
-}}} // namespace embot { namespace app { namespace eth
+} // namespace embot::app::eth
 
 
 #endif  // include-guard

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.h
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.h
@@ -12,51 +12,21 @@
 #define __EMBOT_APP_ETH_THEENCODERREADER_H_
 
 #include "embot_core.h"
-#include "embot_hw_types.h"
-#include "embot_core_binary.h"
 #include "embot_app_eth.h"
-#include "embot_os.h"
-#include "embot_app_eth_Service.h"
+#include "embot_app_eth_Encoder.h"
 
-#include <array>
 
 // embobj dependencies
 #include "EoCommon.h"
 #include "EOconstarray.h"
 #include "EoManagement.h"
 
-typedef enum
-{
-    encreader_err_NONE                  = 0,
-    encreader_err_AEA_READING           = 1,
-    encreader_err_AEA_PARITY            = 2,
-    encreader_err_AEA_CHIP              = 3,
-    encreader_err_QENC_GENERIC          = 4,
-    encreader_err_ABSANALOG_GENERIC     = 5,
-    encreader_err_MAIS_GENERIC          = 6,
-    encreader_err_SPICHAINOF2_GENERIC   = 7,
-    encreader_err_SPICHAINOF3_GENERIC   = 8,
-    encreader_err_AMO_GENERIC           = 9,
-    encreader_err_PSC_GENERIC           = 10,  
-    encreader_err_POS_GENERIC           = 11,    
-    encreader_err_GENERIC               = 14,    
-    encreader_err_NOTCONNECTED          = 15 /* this error happens when the encoder type is none or encoder is not local, for example it is connected to 2foc board */
-} eOencoderreader_errortype_t;
 
-typedef struct
-{
-    uint32_t                                value[eomc_encoders_maxnumberofcomponents];
-    eOencoderreader_errortype_t             errortype;
-    uint8_t                                 composedof;
-    eOmc_position_t                         position;
-} eOencoderreader_valueInfo_t;
 
 namespace embot { namespace app { namespace eth {
       
 #if 0
-    The singleton `theEncoderReader` is responsible to start the reading from one or more SPI encoder(s).
-    Once the data is available ...
-    Finally the position data is converted into icub degrees. 
+    The singleton `theEncoderReader` is responsible to ... 
     
 #endif
     
@@ -65,68 +35,29 @@ namespace embot { namespace app { namespace eth {
      * @brief theEncoderReader class used to read the encoder data from the SPI.
      * 
      */
-    class theEncoderReader
+    class theEncoderReader : public embot::app::eth::encoder::v1::IFreader, embot::app::eth::encoder::experimental::IFreader
     {
     public:
-        /**
-         * @brief Get the Instance object
-         * 
-         * @return theEncoderReader& 
-         */
         static theEncoderReader& getInstance();
                 
-    public:
-        
-        static constexpr size_t max_number_of_jomos { 7 };                          // TODO: verify. Probably unnecessary and wrong.
-        static constexpr size_t max_number_of_encoders { 2 * max_number_of_jomos }; // TODO: verify. Probably unnecessary and wrong.
-        
-        typedef struct
-        {
-            eOmc_encoder_descriptor_t   encoder1des;
-            eOmc_encoder_descriptor_t   encoder2des;
-        } jomoconfig_t;
-        
-        /**
-         * @brief Config struct used to configure the encoder reader.
-         * 
-         */
-        struct Config
-        {
-            uint8_t numofjomos {0};
-            std::array<jomoconfig_t, max_number_of_jomos> jomo_cfg {};
-            constexpr Config() = default;
-//            constexpr Config(const embot::os::Thread::Props &t,
-//                             const embot::app::eth::SocketDescriptor &s,
-//                             const embot::app::eth::SocketAddress &h)
-//                             : thread(t), socket(s), hostaddress(h) {}
-        }; 
-        
-        /**
-         * @brief Initialize the encoder reader.
-         * 
-         * @param config 
-         * @return true if the encoder is initialized correctly, false otherwise.
-         */
-        eOresult_t initialise();
-        
-        eOresult_t Verify(EOconstarray *arrayofjomodes, 
-                          eOservice_onendofoperation_fun_t onverify,
-                          void *arg,        
-                          bool activateafterverify);         
-//        eOresult_t Activate(const eOmn_serv_configuration_t * servcfg);  
-                          
-        eOresult_t activate(EOconstarray *arrayofjomodes, eOmn_serv_diagn_cfg_t dc);
-        
-        eOresult_t deactivate();
-         
-        eOresult_t startReading();
-                          
-        bool isreadingavailable();
-        
-        eOresult_t read(uint8_t position, eOencoderreader_valueInfo_t *valueInfo1, eOencoderreader_valueInfo_t *valueInfo2);
-        
-        bool report();
-        
+
+        bool initialise();
+       
+        // v1::IFreader
+        bool Verify(const Config &config, const OnEndOfOperation &onverify, bool activateafterverify) override;         
+        bool Activate(const Config &config) override;
+        bool Deactivate() override;
+        bool SendReport() override;         
+        bool StartReading() override;                          
+        bool IsReadingAvailable() override;       
+        bool Read(uint8_t jomo, embot::app::eth::encoder::v1::valueInfo &primary, embot::app::eth::encoder::v1::valueInfo &secondary) override;
+        bool Diagnostics_Tick() override;
+        embot::app::eth::encoder::v1::Type GetType(const embot::app::eth::encoder::v1::Target &target) override;
+        bool Scale(const embot::app::eth::encoder::v1::Target &target, const embot::app::eth::encoder::v1::Scaler &scaler) override;
+    
+        // experimental::IFreader
+        bool read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value) override;
+    
     private:
         theEncoderReader(); 
         ~theEncoderReader(); 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp
@@ -1,0 +1,205 @@
+
+/*
+ * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_app_eth_theEncoderReader.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "EOtheEncoderReader.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+
+
+struct embot::app::eth::theEncoderReader::Impl
+{
+    
+    Impl() = default;
+    
+    bool initialise();
+    
+    bool Verify(const Config &config, const OnEndOfOperation &onverify, bool activateafterverify);                            
+    bool Activate(const Config &config);    
+    bool Deactivate();   
+    bool StartReading();    
+    bool Read(uint8_t position, embot::app::eth::encoder::v1::valueInfo &primary, embot::app::eth::encoder::v1::valueInfo &secondary);
+    bool SendReport();                            
+    bool IsReadingAvailable();
+    bool Diagnostics_Tick();
+    embot::app::eth::encoder::v1::Type GetType(const embot::app::eth::encoder::v1::Target &target);
+    bool Scale(const embot::app::eth::encoder::v1::Target &target, const embot::app::eth::encoder::v1::Scaler &scaler);
+    
+    // advanced
+    bool read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value);
+
+};
+
+
+bool embot::app::eth::theEncoderReader::Impl::initialise()
+{
+    eo_encoderreader_Initialise();
+    
+    return true;
+}
+
+bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, const OnEndOfOperation &onverify, bool activateafterverify)
+{ 
+    return eores_OK == eo_encoderreader_Verify(eo_encoderreader_GetHandle(), config.carrayofjomodes, onverify.callback, static_cast<eObool_t>(activateafterverify), config.dc);
+}
+
+
+bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
+{
+    return eores_OK == eo_encoderreader_Activate(eo_encoderreader_GetHandle(), config.carrayofjomodes, config.dc);
+}
+
+bool embot::app::eth::theEncoderReader::Impl::Deactivate()
+{
+    return eores_OK == eo_encoderreader_Deactivate(eo_encoderreader_GetHandle());
+}
+
+bool embot::app::eth::theEncoderReader::Impl::StartReading()
+{
+    return eores_OK == eo_encoderreader_StartReading(eo_encoderreader_GetHandle());
+}
+
+bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t position, embot::app::eth::encoder::v1::valueInfo &primary, embot::app::eth::encoder::v1::valueInfo &secondary)
+{
+    eOencoderreader_valueInfo_t *e1 = reinterpret_cast<eOencoderreader_valueInfo_t*>(&primary);
+    eOencoderreader_valueInfo_t *e2 = reinterpret_cast<eOencoderreader_valueInfo_t*>(&primary);
+    return eores_OK == eo_encoderreader_Read(eo_encoderreader_GetHandle(), position, e1, e2);
+}
+
+bool embot::app::eth::theEncoderReader::Impl::SendReport()
+{
+    return eores_OK == eo_encoderreader_SendReport(eo_encoderreader_GetHandle());
+}
+
+bool embot::app::eth::theEncoderReader::Impl::Diagnostics_Tick()
+{    
+    return eores_OK == eo_encoderreader_Diagnostics_Tick(eo_encoderreader_GetHandle());
+}
+
+bool embot::app::eth::theEncoderReader::Impl::IsReadingAvailable()
+{    
+    return eobool_true == eo_encoderreader_IsReadingAvailable(eo_encoderreader_GetHandle());
+}
+
+embot::app::eth::encoder::v1::Type  embot::app::eth::theEncoderReader::Impl::GetType(const embot::app::eth::encoder::v1::Target &target)
+{
+    eOmc_encoder_t t = eo_encoderreader_GetType(eo_encoderreader_GetHandle(), target.jomo, static_cast<eOencoderreader_Position_t>(embot::core::tointegral(target.pos)));    
+    return static_cast<embot::app::eth::encoder::v1::Type>(t);
+}
+
+bool embot::app::eth::theEncoderReader::Impl::Scale(const embot::app::eth::encoder::v1::Target &target, const embot::app::eth::encoder::v1::Scaler &scaler)
+{
+    // for now only mais and absanalog accept to be scaled ... but in here i dont verify
+    eOencoderreader_Scaler sca {scaler.scale, scaler.offset};
+    return eores_OK == eo_encoderreader_Scale(eo_encoderreader_GetHandle(), target.jomo, static_cast<eOencoderreader_Position_t>(embot::core::tointegral(target.pos)), &sca);
+}
+
+bool embot::app::eth::theEncoderReader::Impl::read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value)
+{
+    value.raw = 0x123456789A;
+    value.error = embot::app::eth::encoder::experimental::Error::NONE;
+    
+    return true;
+}
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - the class
+// --------------------------------------------------------------------------------------------------------------------
+
+embot::app::eth::theEncoderReader& embot::app::eth::theEncoderReader::getInstance()
+{
+    static theEncoderReader* p = new theEncoderReader();
+    return *p;
+}
+
+embot::app::eth::theEncoderReader::theEncoderReader()
+{
+    pImpl = std::make_unique<Impl>();
+}
+
+embot::app::eth::theEncoderReader::~theEncoderReader() { }
+
+bool embot::app::eth::theEncoderReader::initialise()
+{
+    return pImpl->initialise();
+}
+
+bool embot::app::eth::theEncoderReader::Verify(const Config &config, const OnEndOfOperation &onverify, bool activateafterverify)
+{
+    return pImpl->Verify(config, onverify, activateafterverify); 
+}
+
+
+bool embot::app::eth::theEncoderReader::Activate(const Config &config)
+{
+    return pImpl->Activate(config);
+}
+
+bool embot::app::eth::theEncoderReader::Deactivate()
+{
+    return pImpl->Deactivate();
+}
+
+bool embot::app::eth::theEncoderReader::StartReading()
+{
+    return pImpl->StartReading();
+}
+
+bool embot::app::eth::theEncoderReader::Read(uint8_t position, embot::app::eth::encoder::v1::valueInfo &primary, embot::app::eth::encoder::v1::valueInfo &secondary)
+{
+    return pImpl->Read(position, primary, secondary);
+}
+
+bool embot::app::eth::theEncoderReader::SendReport()
+{
+    return pImpl->SendReport();
+}
+
+bool embot::app::eth::theEncoderReader::IsReadingAvailable()
+{
+    return pImpl->IsReadingAvailable();
+}
+
+bool embot::app::eth::theEncoderReader::Diagnostics_Tick()
+{
+    return pImpl->Diagnostics_Tick();
+}
+
+embot::app::eth::encoder::v1::Type  embot::app::eth::theEncoderReader::GetType(const embot::app::eth::encoder::v1::Target &target)
+{
+    return pImpl->GetType(target);
+}
+
+bool embot::app::eth::theEncoderReader::Scale(const embot::app::eth::encoder::v1::Target &target, const embot::app::eth::encoder::v1::Scaler &scaler)
+{
+    return pImpl->Scale(target, scaler);
+}
+
+bool embot::app::eth::theEncoderReader::read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value)
+{
+    return pImpl->read(target, value);
+}
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+


### PR DESCRIPTION
## Description

This PR enables all the ETH boards to use a common interface for the the reading of the encoders used in motion control. 

It ensures:
- easy maintenance / refactoring of the code,
- easy extension towards future more powerful sensors

That is possible because we now use a PIMPL singleton object called `embot::app::eth::theEncoderReader` which is derived from an interface  `embot::app::eth::encoder::v1::IFreader` that offers functionalities as needed by today's encoders.

But it can also be derived from other interfaces to offer easy migration to encoders w/ higher resolution or to add improved diagnostics by keeping the legacy functionalities.



## Details

This PR makes the singleton `embot::app::eth::theEncoderReader` the unique point of usage for acquisition of encoders' information in motion control on ETH boards. 

It is care of the protected implementation (PIMPL) of the singleton to manage the required resources and retrieve the requested encoder values.

```mermaid
erDiagram
"motion control objects" ||..|| "embot::app::eth::theEncoderReader" : use
"embot::app::eth::theEncoderReader" ||..|| "PIMPL" : uses
"PIMPL" ||..|| "HW peripherals" : manages
"PIMPL" ||..|| "CAN located encoders" : manages
```
**Figure**. The object `embot::app::eth::theEncoderReader` and its PIMPL.

For now we use two implementations:

- One dedicated to boards such `ems`, `mc4plus` and `mc2plus` which require the `HAL` of the `stm32f407` chip. This one uses the legacy objects `EOtheEncoderReader` and `EOappEncodersReader` which can stay as they are or can be easily refactored later on.
- One dedicated to the `amc` (but later on also for the `amc2foc`) which can use the `embot::hw` framework.
### The two implementations



``` mermaid
erDiagram

"PIMPL1" ||..|| "EOtheEncoderReader" : uses
"EOtheEncoderReader" ||..|| "EOappEncodersReader" : uses
"EOappEncodersReader" ||..|| "HAL" : uses
"HAL" ||..|| "SPI encoders" : manages
"HAL" ||..|| "MOTOR encoders" : manages
"HAL" ||..|| "ADC encoders" : manages
"EOappEncodersReader" ||..|| "EOtheMAIS" : manages
"EOappEncodersReader" ||..|| "EOthePOS" : manages
"EOappEncodersReader" ||..|| "EOthePSC" : manages
```
**Figure**. Implementation used by `ems`, `mc4plus` and `mc2plus`: all the encoders, both HAL based and CAN located

```mermaid
erDiagram

"PIMPL2" ||..|| "embot::hw::encoder" : uses
"embot::hw::encoder" ||..|| "SPI encoders" : manages
```
**Figure**. Implementation used by `amc`: only AEA encoders so far.

### Evolution of the functionalities

This singleton `embot::app::eth::theEncoderReader` is derived from a given interface, `embot::app::eth::encoder::v1::IFreader`, which ensures the encoder reading functionalities as requested by today's ETH boards: `ems`, `mc4plus`, `mc2plus`, `amc` . 



 ```mermaid
 erDiagram
 
 "embot::app::eth::theEncoderReader" ||..|| "embot::app::eth::encoder::v1::IFreader" : implements
 "embot::app::eth::theEncoderReader" ||..|| "embot::app::eth::encoder::experimental::IFreader" : implements
 "embot::app::eth::encoder::v1::IFreader" ||..|| "today's encoders" : for
 "embot::app::eth::encoder::experimental::IFreader" ||..|| "advanced encoders" : for
 
 ```
**Figure**. The interfaces implemented by `embot::app::eth::theEncoderReader`.


The `embot::app::eth::theEncoderReader` can also implement other interfaces  able to offer future advances services such as high resolution encoders or improved diagnostic mechanisms.

As a mere demonstration of feasibility I have added derivation from an `experimental::IFreader` which can offer 64 bit resolution.



```c++
namespace embot::app::eth::encoder::experimental {
    ...
    struct Value
    {   // the value w/ a possible error     
        int64_t raw {0};  // to accomodate high resolution values
        embot::app::eth::encoder::experimental::Error error {Error::NONE}; 
    };
    ...
```
**Code Listing**. Possible new high resolution value.



```c++
class theEncoderReader : public 
                         embot::app::eth::encoder::v1::IFreader,
                         embot::app::eth::encoder::experimental::IFreader
{
public:
    static theEncoderReader& getInstance();
            
    bool initialise();
   
    // v1::IFreader
    bool Verify(const Config &config, ...) override;   
    ...
    
    // experimental::IFreader
    bool read(const embot::app::eth::encoder::experimental::Target &target,
              embot::app::eth::encoder::experimental::Value &value) override; 
    ...                         
```

**Code Listing**. The `theEncoderReader` is derived from a `v1::IFreader` which give the required services but also from a `experimental::IFreader` which can live alongside to enrich the functionalities.

## Mergeability

Tests OK on a setup dedicated setup w/ an `amc`, a motor and an encoder.
So, I think that we can safely merge.

## Binaries

They are in here:
- https://github.com/robotology/icub-firmware-build/pull/96
