### PR TITLE
Update evaluation of final offset for calibratio14 + bugfix

### DIFF
--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -2067,11 +2067,8 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 //1) Fix the offset with the rotation raw
                 int32_t offset_raw = (calibrator->params.type14.offset + calibrator->params.type14.rotation ) % ((int32_t)DEG2ICUB*360);
                 
-                //2) Take offset value of calibation parameter with sign given by invertdirection
-                int32_t offset_fix = (calibrator->params.type14.invertdirection == 1) ? -(offset_raw) : offset_raw;
-                
-                //3) Convert offset to decideg for POS service
-                int32_t offset = ((ICUB2DEG)*(CTRL_UNITS)(offset_fix))*10.0f;
+                //3) Convert offset to decideg for POS service and add "-" sign to offset_raw to correct raw position (always minus sign independently from invertDirection value)
+                int32_t offset = ((ICUB2DEG)*(CTRL_UNITS)((-1)*offset_raw))*10.0f;
                 
                 ////debug code
                 snprintf(info, sizeof(info), "CALIB 14 j%d: or=%d o=%d", e, offset_raw, offset);

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp
@@ -80,7 +80,7 @@ bool embot::app::eth::theEncoderReader::Impl::StartReading()
 bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t position, embot::app::eth::encoder::v1::valueInfo &primary, embot::app::eth::encoder::v1::valueInfo &secondary)
 {
     eOencoderreader_valueInfo_t *e1 = reinterpret_cast<eOencoderreader_valueInfo_t*>(&primary);
-    eOencoderreader_valueInfo_t *e2 = reinterpret_cast<eOencoderreader_valueInfo_t*>(&primary);
+    eOencoderreader_valueInfo_t *e2 = reinterpret_cast<eOencoderreader_valueInfo_t*>(&secondary);
     return eores_OK == eo_encoderreader_Read(eo_encoderreader_GetHandle(), position, e1, e2);
 }
 


### PR DESCRIPTION
This PR just fix a couple of bugs:
- Update evaluation on final offset to be passed by JointSet to POS service so that user set calibration5 param for calibration type 14 as it is printed when port state is read
- Add fix to bug introduced by PR #399 at [lines](https://github.com/marcoaccame/icub-firmware/blob/3a7e203eee8e40ebe333e801208b609f8eb540c4/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp#L82C1-L83C96)  that causes values not to be updated by state and stateExt ports

- New board version will be defined with next PR, which will brings the update for the BAT and EMS4 boards
