### PR TITLE
Add handling of status messages for BAT and BMS in EMS baord

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/protocol/can/EoCANprotBSperiodic_amc.c
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/protocol/can/EoCANprotBSperiodic_amc.c
@@ -72,18 +72,20 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 //#include "embot_core.h"
-extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS(eOcanframe_t *frame, eOcanport_t port)
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__INFO(eOcanframe_t *frame, eOcanport_t port)
 {
-//    embot::app::eth::theBATservice::canFrameDescriptor cfd 
-//    { 
-//        port, 
-//        frame, 
-//        embot::app::eth::theBATservice::canFrameDescriptor::Type::unspecified
-//    };
-//    embot::app::eth::theBATservice::getInstance().AcceptCANframe(cfd);
     return(eores_OK);
 }
 
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BMS(eOcanframe_t *frame, eOcanport_t port)
+{
+    return(eores_OK);
+}
+
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BAT(eOcanframe_t *frame, eOcanport_t port)
+{
+    return(eores_OK);
+}
 
 extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__ALLTHEOTHERS(eOcanframe_t *frame, eOcanport_t port)
 {

--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
@@ -40,14 +40,14 @@ namespace embot { namespace app { namespace eth {
             Process::eApplication,
 #if defined(WRIST_MK2)
     #if defined(WRIST_MK2_RIGHT)
-            {101, 8},
+            {101, 9},
     #else
-            {102, 8},
+            {102, 9},
     #endif            
 #else            
-            {103, 8},  
+            {103, 9},  
 #endif            
-            {2023, Month::Jul, Day::thirthyone, 11, 30}
+            {2023, Month::Sep, Day::seven, 14, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
@@ -13,8 +13,6 @@
 #ifndef BAT_B_H
 #define BAT_B_H
 
-void dcdc_management(void);
-
 extern char Firmware_vers;
 extern char Revision_vers;
 extern char Build_number;
@@ -84,6 +82,7 @@ extern uint8_t timerFSM_motors;
 extern uint8_t DCDC_status_A;
 extern uint8_t DCDC_status_B;
 extern uint8_t DCDC_ctrl;
+extern uint8_t DCDC_status;
 extern uint8_t HSM_PG;
 extern uint8_t HSM_F;
 

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/can_utility.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/can_utility.h
@@ -29,4 +29,10 @@ extern uint8_t               TxData_620[8];
 extern uint8_t               RxData_620[8];
 extern uint32_t              TxMailbox_620;
 
+extern CAN_TxHeaderTypeDef   TxHeader_629;
+extern CAN_RxHeaderTypeDef   RxHeader_629;
+extern uint8_t               TxData_629[8];
+extern uint8_t               RxData_629[8];
+extern uint32_t              TxMailbox_629;
+
 #endif

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/global_var.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/global_var.h
@@ -91,6 +91,7 @@ extern uint8_t timerFSM_motors;
 extern uint8_t DCDC_status_A;
 extern uint8_t DCDC_status_B;
 extern uint8_t DCDC_ctrl;
+extern uint8_t DCDC_status;
 extern uint8_t HSM_PG;
 extern uint8_t HSM_F;
 

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvoptx
@@ -10,7 +10,7 @@
     <aExt>*.s*; *.src; *.a*</aExt>
     <oExt>*.obj; *.o</oExt>
     <lExt>*.lib</lExt>
-    <tExt>*.txt; *.h; *.inc</tExt>
+    <tExt>*.txt; *.h; *.inc; *.md</tExt>
     <pExt>*.plm</pExt>
     <CppX>*.cpp</CppX>
     <nMigrate>0</nMigrate>
@@ -28,7 +28,7 @@
     <TargetOption>
       <CLKADS>8000000</CLKADS>
       <OPTTT>
-        <gFlags>0</gFlags>
+        <gFlags>1</gFlags>
         <BeepAtEnd>1</BeepAtEnd>
         <RunSim>0</RunSim>
         <RunTarget>1</RunTarget>
@@ -75,9 +75,9 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
-      <CpuCode>0</CpuCode>
+      <CpuCode>18</CpuCode>
       <DebugOpt>
         <uSim>0</uSim>
         <uTrg>1</uTrg>
@@ -183,7 +183,7 @@
     <TargetOption>
       <CLKADS>8000000</CLKADS>
       <OPTTT>
-        <gFlags>0</gFlags>
+        <gFlags>1</gFlags>
         <BeepAtEnd>1</BeepAtEnd>
         <RunSim>0</RunSim>
         <RunTarget>1</RunTarget>
@@ -230,9 +230,9 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
-      <CpuCode>0</CpuCode>
+      <CpuCode>18</CpuCode>
       <DebugOpt>
         <uSim>0</uSim>
         <uTrg>1</uTrg>

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvprojx
@@ -10,14 +10,14 @@
       <TargetName>BAT_B_iCub3</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060422::V5.06 update 4 (build 422)::ARMCC</pCCUsed>
-      <uAC6>0</uAC6>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32L476VETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.3.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.6.1</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000-0x20017FFF) IRAM2(0x10000000-0x10007FFF) IROM(0x8000000-0x807FFFF) CLOCK(8000000) FPU2 CPUTYPE("Cortex-M4")</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -186,6 +186,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -313,7 +314,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -322,14 +323,14 @@
             <PlainCh>0</PlainCh>
             <Ropi>0</Ropi>
             <Rwpi>0</Rwpi>
-            <wLevel>2</wLevel>
+            <wLevel>3</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>1</v6Lang>
-            <v6LangP>1</v6LangP>
+            <v6Lang>3</v6Lang>
+            <v6LangP>5</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
             <v6Lto>0</v6Lto>
@@ -614,14 +615,14 @@
       <TargetName>BAT_B_R1</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>5060750::V5.06 update 6 (build 750)::ARMCC</pCCUsed>
-      <uAC6>0</uAC6>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32L476VETx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.3.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.6.1</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000-0x20017FFF) IRAM2(0x10000000-0x10007FFF) IROM(0x8000000-0x807FFFF) CLOCK(8000000) FPU2 CPUTYPE("Cortex-M4")</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -790,6 +791,7 @@
             <RvdsVP>2</RvdsVP>
             <RvdsMve>0</RvdsMve>
             <RvdsCdeCp>0</RvdsCdeCp>
+            <nBranchProt>0</nBranchProt>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -917,7 +919,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -926,14 +928,14 @@
             <PlainCh>0</PlainCh>
             <Ropi>0</Ropi>
             <Rwpi>0</Rwpi>
-            <wLevel>2</wLevel>
+            <wLevel>3</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
-            <v6Lang>1</v6Lang>
-            <v6LangP>1</v6LangP>
+            <v6Lang>3</v6Lang>
+            <v6LangP>5</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
             <v6Lto>0</v6Lto>
@@ -1219,8 +1221,8 @@
   <RTE>
     <apis/>
     <components>
-      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="4.3.0" condition="CMSIS Core">
-        <package name="CMSIS" schemaVersion="1.3" url="http://www.keil.com/pack/" vendor="ARM" version="4.5.0"/>
+      <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
+        <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
         <targetInfos>
           <targetInfo name="BAT_B_R1"/>
           <targetInfo name="BAT_B_iCub3"/>
@@ -1234,11 +1236,6 @@
     <Layers>
       <Layer>
         <LayName>&lt;Project Info&gt;</LayName>
-        <LayDesc></LayDesc>
-        <LayUrl></LayUrl>
-        <LayKeys></LayKeys>
-        <LayCat></LayCat>
-        <LayLic></LayLic>
         <LayTarg>0</LayTarg>
         <LayPrjMark>1</LayPrjMark>
       </Layer>

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -10,8 +10,8 @@
 #include "BAT_B.h"
 
 char Firmware_vers = 1;
-char Revision_vers = 2;
-char Build_number  = 1;
+char Revision_vers = 3;
+char Build_number  = 0;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis
 uint32_t vhyst=0;    // voltage hysteresis
@@ -60,6 +60,8 @@ uint8_t V12motor      = 0;		// DCDC motor control
 uint8_t V12motor_F    = 0;		// fault
 uint8_t HSM_broken    = 0;		// HSM transistors broken
 uint8_t HSM           = 0;		// HSM control
+uint8_t HSM_PG        = 0;
+uint8_t HSM_F         = 0;
 uint8_t DCrestart     = 0;
 
 uint8_t V12board_bdc  = 1;    // +++++++++++++++++++++++++++++++++++++++++++++ da cambiare logica ++++++++++++++++++
@@ -78,8 +80,6 @@ uint8_t timerFSM_motors = 0;
 uint8_t DCDC_status_A = 0;
 uint8_t DCDC_status_B = 0;
 uint8_t DCDC_ctrl     = 0;
-uint8_t HSM_PG        = 0;
-uint8_t HSM_F         = 0;
 
 uint16_t timeout    = 0;
 uint16_t time_delay = 500;

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/can_utility.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/can_utility.c
@@ -27,12 +27,19 @@ uint32_t              TxMailbox;
 // then there'll be a getInstance() sort of method for retrieving the struct
 // following the signleton usage in OOP
 // this will help to make code cleaner and avoid duplications
-// Instantiate data for info regarding status of battery pack
+// Instantiate data regarding info of battery pack
 CAN_TxHeaderTypeDef   TxHeader_620;
 CAN_RxHeaderTypeDef   RxHeader_620;
 uint8_t               TxData_620[8];
 uint8_t               RxData_620[8];
 uint32_t              TxMailbox_620;
+
+// Instantiate data regarding status of battery pack
+CAN_TxHeaderTypeDef   TxHeader_629;
+CAN_RxHeaderTypeDef   RxHeader_629;
+uint8_t               TxData_629[8];
+uint8_t               RxData_629[8];
+uint32_t              TxMailbox_629;
 
 // -----------------------------------------------------------------------------------------------------------------------------
 // CAN configuration
@@ -95,6 +102,14 @@ void CAN_Config(void)
   TxHeader_620.IDE = CAN_ID_STD;
   TxHeader_620.DLC = 8;
   TxHeader_620.TransmitGlobalTime = DISABLE;
+  
+    /*##-6- Configure Status Battery Pack Transmission process #####################################*/ 
+  TxHeader_629.StdId = 0x629;
+  TxHeader_629.ExtId = 0x01;
+  TxHeader_629.RTR = CAN_RTR_DATA;
+  TxHeader_629.IDE = CAN_ID_STD;
+  TxHeader_629.DLC = 8;
+  TxHeader_629.TransmitGlobalTime = DISABLE;
   
 }
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          72
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          73
 
 //  </h>version
 
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          31
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          30
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.h
@@ -44,6 +44,9 @@ public:
 
   struct canFrameDescriptor {
     enum class Type : uint8_t {
+      info,
+      status_bms,
+      status_bat,
       unspecified,
     };
     eOcanport_t port{eOcanport1};
@@ -86,8 +89,7 @@ public:
   static constexpr eOas_battery_status_t defaultBATstatus{
       .timedvalue = {.age = 0,
                      .temperature = 0,
-                     .status = 0,
-                     .filler = 0,
+                     //.status = 0,
                      .voltage = 0,
                      .current = 0,
                      .charge = 0}};
@@ -97,7 +99,7 @@ public:
   };
 
   const theServiceTester::Config &servicetesterconfig() const;
-
+  
 private:
   // this one is called inside process() when the tag is
   // eoprot_tag_as_bat_config (or by theServiceTester)

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,20 +75,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          54
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          55
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          31
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          30 
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00 
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          75
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          76
 
 //  </h>version
 
@@ -92,13 +92,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          31
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          30
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol.c
@@ -1182,7 +1182,7 @@ const eOcanprot_functions_t s_eo_canprot_functions_periodicBattery[] =
 {
     {   // 000      ICUBCANPROTO_PER_BS_MSG__STATUS
         EO_INIT(.former) NULL,
-        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__STATUS
+        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__INFO
     },
     {   // 001      
         EO_INIT(.former) NULL,
@@ -1190,7 +1190,7 @@ const eOcanprot_functions_t s_eo_canprot_functions_periodicBattery[] =
     }, 
     {   // 002      
         EO_INIT(.former) NULL,
-        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__ALLTHEOTHERS,
+        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__ALLTHEOTHERS
     },
     {   // 003      
         EO_INIT(.former) NULL,
@@ -1214,11 +1214,11 @@ const eOcanprot_functions_t s_eo_canprot_functions_periodicBattery[] =
     },
     {   // 008      
         EO_INIT(.former) NULL,
-        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__ALLTHEOTHERS
+        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BMS
     },
     {   // 009      
         EO_INIT(.former) NULL,
-        EO_INIT(.parser) NULL
+        EO_INIT(.parser) eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BAT
     },
     {   // 010      
         EO_INIT(.former) NULL,
@@ -1431,7 +1431,7 @@ static eOresult_t s_eo_canprot_parse0length(eOcanframe_t *frame, eOcanport_t por
 
 
 static eObool_t s_eo_canprot_filter_sourceaddress(eOcanframe_t *frame)
-{    
+{        
     if(0 == EOCANPROT_FRAME_GET_SOURCE(frame))
     {
         return(eobool_true);

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol.h
@@ -48,11 +48,11 @@ extern "C" {
 
 // - public #define  --------------------------------------------------------------------------------------------------
 
-// we mange teh following: 
+// we manage the following: 
 // - class: it is eOcanprot_msgclass_t
 // - source: it is the can address which sent the frame [0, 14]
 // - destination: it is the can address where to send the frame [0, 14]
-// - type: it is either the MSG or the CMD whcih describes the message (ICUBCANPROTO_PER_MC_MSG__POSITION, ICUBCANPROTO_POL_MC_CMD__SET_INTERACTION_MODE, etc.).
+// - type: it is either the MSG or the CMD which describes the message (ICUBCANPROTO_PER_MC_MSG__POSITION, ICUBCANPROTO_POL_MC_CMD__SET_INTERACTION_MODE, etc.).
 // - idcan: it is the ID of the CAN frame
 // - internal index: it is either 0 or 1 and is used in mc to specify a joint/motor
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol_functions.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANprotocol_functions.h
@@ -355,7 +355,9 @@ extern eOresult_t eocanprotMCperiodic_former_PER_MC_MSG__EMSTO2FOC_DESIRED_CURRE
 
 // - battery: periodic
 
-extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS(eOcanframe_t *frame, eOcanport_t port);
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__INFO(eOcanframe_t *frame, eOcanport_t port);
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BMS(eOcanframe_t *frame, eOcanport_t port);
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BAT(eOcanframe_t *frame, eOcanport_t port);
 
 
 extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__ALLTHEOTHERS(eOcanframe_t *frame, eOcanport_t port);

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANservice.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/EOtheCANservice.c
@@ -298,7 +298,7 @@ extern eOresult_t eo_canserv_TXwaituntildone(EOtheCANservice *p, eOcanport_t por
             errdes.code                 = eoerror_code_get(eoerror_category_System, eoerror_value_SYS_canservices_txbusfailure);
             errdes.par16                = 0x0001;
             errdes.par16                |= ((uint16_t)sizeoftxfifo << 8);
-            errdes.par64                = 0; // dont knw what to send up           
+            errdes.par64                = 0; // dont know what to send up           
             errdes.sourcedevice         = (eOcanport1 == port) ? (eo_errman_sourcedevice_canbus1) : (eo_errman_sourcedevice_canbus2);
             errdes.sourceaddress        = 0;                                   
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);    

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotBSperiodic.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotBSperiodic.c
@@ -72,18 +72,41 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 #include "embot_core.h"
-extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS(eOcanframe_t *frame, eOcanport_t port)
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__INFO(eOcanframe_t *frame, eOcanport_t port)
 {
     embot::app::eth::theBATservice::canFrameDescriptor cfd 
     { 
         port, 
         frame, 
-        embot::app::eth::theBATservice::canFrameDescriptor::Type::unspecified
+        embot::app::eth::theBATservice::canFrameDescriptor::Type::info
     };
     embot::app::eth::theBATservice::getInstance().AcceptCANframe(cfd);
     return(eores_OK);
 }
 
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BMS(eOcanframe_t *frame, eOcanport_t port)
+{
+    embot::app::eth::theBATservice::canFrameDescriptor cfd 
+    { 
+        port, 
+        frame, 
+        embot::app::eth::theBATservice::canFrameDescriptor::Type::status_bms
+    };
+    embot::app::eth::theBATservice::getInstance().AcceptCANframe(cfd);
+    return(eores_OK);
+}
+
+extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__STATUS_BAT(eOcanframe_t *frame, eOcanport_t port)
+{
+    embot::app::eth::theBATservice::canFrameDescriptor cfd 
+    { 
+        port, 
+        frame, 
+        embot::app::eth::theBATservice::canFrameDescriptor::Type::status_bat
+    };
+    embot::app::eth::theBATservice::getInstance().AcceptCANframe(cfd);
+    return(eores_OK);
+}
 
 extern eOresult_t eocanprotINperiodic_parser_PER_BS_MSG__ALLTHEOTHERS(eOcanframe_t *frame, eOcanport_t port)
 {


### PR DESCRIPTION
This PR introduces the following changes:
- Add data regarding CAN message with StdId `0x629` used in BAT code for sending data regarding status of the board
- Define CAN messages for sending to EMS board from BAT the status info and wrap in **#ifdef** clause the message not parsed by EMS board but used by custom application
- Define in EMS fw parsing for BMS and BAT status and define related protocol methods in map `s_eo_canprot_functions_periodicBattery` and CAN_protocol_BS callbacks, which are left commented for AMC board
- Update versions for fw which will be pushed to icub-firmware-build