### PR TITLE
amc2c – introduce changes to fix debugging + enable SWO trace features

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
@@ -75,7 +75,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -119,18 +119,23 @@
       <TargetDriverDllRegistry>
         <SetRegEntry>
           <Number>0</Number>
+          <Key>ULP2CM3</Key>
+          <Name>-UP0948199 -O206 -S8 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO65554 -TC200000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+        </SetRegEntry>
+        <SetRegEntry>
+          <Number>0</Number>
           <Key>UL2CM3</Key>
           <Name>UL2CM3(-S0 -C0 -P0 )  -FN1 -FC8000 -FD10000000 -FF0STM32H7x_2048 -FL0200000 -FS08000000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>ST-LINKIII-KEIL_SWO</Key>
-          <Name>-U002E00303137510A39383538 -O206 -SF10000 -C0 -A3 -I0 -HNlocalhost -HP7184 -P1 -N00("") -D00(00000000) -L00(0) -TO131091 -TC200000000 -TT10000000 -TP21 -TDS8010 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM) -WA0 -WE0 -WVCE4 -WS2710 -WM0 -WP2</Name>
+          <Name>-U005700373137510539383538 -O462 -SF24000 -C0 -A3 -I0 -HNlocalhost -HP7184 -P1 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO19 -TC200000000 -TT400000000 -TP21 -TDS8021 -TDT0 -TDC1F -TIE80000000 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z20 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z14 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -148,106 +153,37 @@
           <Name>(105=-1,-1,-1,-1,0)</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>123</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>135288800</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>C:\ace\!mar\icub-firmware\emBODY\eBcode\arch-arm\board\amc2c\application\src\main-basic.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\h7disco\../src/main-basic.cpp\123</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>115</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>C:\ace\!mar\icub-firmware\emBODY\eBcode\arch-arm\board\amc2c\application\src\main-basic.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>113</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>C:\ace\!mar\icub-firmware\emBODY\eBcode\arch-arm\board\amc2c\application\src\main-basic.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>osthread</ItemText>
+          <ItemText>signalled</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>tmr</ItemText>
+          <ItemText>TXreceivedback</ItemText>
         </Ww>
         <Ww>
           <count>2</count>
           <WinNumber>1</WinNumber>
-          <ItemText>_internals.cfg-&gt;isr_queue,0x10</ItemText>
+          <ItemText>tde.str</ItemText>
         </Ww>
         <Ww>
           <count>3</count>
           <WinNumber>1</WinNumber>
-          <ItemText>errormsg</ItemText>
+          <ItemText>tout,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>4</count>
           <WinNumber>1</WinNumber>
-          <ItemText>errormsg</ItemText>
+          <ItemText>replyinfo</ItemText>
         </Ww>
         <Ww>
           <count>5</count>
           <WinNumber>1</WinNumber>
-          <ItemText>errormsg</ItemText>
-        </Ww>
-        <Ww>
-          <count>6</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>pImpl</ItemText>
-        </Ww>
-        <Ww>
-          <count>7</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>largestack</ItemText>
-        </Ww>
-        <Ww>
-          <count>8</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>frame</ItemText>
-        </Ww>
-        <Ww>
-          <count>9</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>hfdcan</ItemText>
+          <ItemText>dd</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -261,7 +197,7 @@
         <Mm>
           <WinNumber>1</WinNumber>
           <SubType>0</SubType>
-          <ItemText>0x20003134</ItemText>
+          <ItemText>0x5C004000</ItemText>
           <AccSizeX>0</AccSizeX>
         </Mm>
       </MemoryWindow1>
@@ -270,7 +206,7 @@
       </Tracepoint>
       <DebugFlag>
         <trace>0</trace>
-        <periodic>0</periodic>
+        <periodic>1</periodic>
         <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
@@ -288,8 +224,8 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
-        <StkLoc>0</StkLoc>
+        <aSer4>1</aSer4>
+        <StkLoc>1</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
         <uProt>0</uProt>
@@ -307,8 +243,14 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
-        <Enable>1</Enable>
+        <Enable>0</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
@@ -371,7 +313,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -416,7 +358,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP0948199 -O206 -S8 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO65554 -TC200000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP0948199 -O206 -S8 -C0 -P00000003 -N00("") -D00(00000000) -L00(0) -TO32787 -TC200000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -595,7 +537,7 @@
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
       <DebugDescription>
-        <Enable>1</Enable>
+        <Enable>0</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
@@ -833,7 +775,7 @@
 
   <Group>
     <GroupName>embot::app::board::amc2c</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvoptx
@@ -75,7 +75,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -313,7 +313,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -358,7 +358,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP0948199 -O206 -S8 -C0 -P00000003 -N00("") -D00(00000000) -L00(0) -TO32787 -TC200000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP0948193 -O462 -S12 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO32787 -TC200000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8001 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -373,7 +373,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z20 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z23 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -391,72 +391,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>324</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>135300074</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amc2c\../../../../embot/hw/embot_hw_icc_ltr.cpp\324</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>116</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>135300918</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amc2c\../../../../embot/hw/embot_hw_icc_ltr.cpp\116</Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>318</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>135300048</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\embot\hw\embot_hw_icc_ltr.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amc2c\../../../../embot/hw/embot_hw_icc_ltr.cpp\318</Expression>
-        </Bp>
-        <Bp>
-          <Number>3</Number>
-          <Type>0</Type>
-          <LineNumber>58</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>135304336</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\embot\hw\embot_hw_icc_printer.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amc2c\../../../../embot/hw/embot_hw_icc_printer.cpp\58</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -500,7 +435,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>1</periodic>
-        <aLwin>0</aLwin>
+        <aLwin>1</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -517,7 +452,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>1</aSer4>
+        <aSer4>0</aSer4>
         <StkLoc>1</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -536,6 +471,12 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
         <Enable>0</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
@@ -831,7 +772,7 @@
 
   <Group>
     <GroupName>theMBD</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvprojx
@@ -10,14 +10,14 @@
       <TargetName>appl-can-stlink</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -314,7 +314,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>5</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -340,7 +340,7 @@
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMC2C STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\hw;..\..\..\..\embot\os;..\..\..\..\embot\app;..\..\..\..\embot\app;..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\embot\prot\can;..\..\..\amcbldc\code;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\bsp;..\..\code</IncludePath>
+              <IncludePath>..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\embot\hw;..\..\..\..\embot\os;..\..\..\..\embot\app;..\..\..\..\embot\app;..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\embot\prot\can;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\bsp;..\..\..\..\embot\app\eth;..\..\..\..\embot\app\bldc;..\src\app-board-amc2c;..\..\..\amcbldc\application\src\model-based-design\sharedutils;..\..\..\amcbldc\application\src\model-based-design\can-decoder;..\..\..\amcbldc\application\src\model-based-design\can-encoder;..\..\..\amcbldc\application\src\model-based-design\supervisor-rx;..\..\..\amcbldc\application\src\model-based-design\supervisor-tx;..\..\..\amcbldc\application\src\model-based-design\control-outer;..\..\..\amcbldc\application\src\model-based-design\control-foc;..\..\..\amcbldc\application\src\model-based-design\estimator;..\..\..\amcbldc\application\src\model-based-design\amc-bldc;..\..\..\amcbldc\application\src\model-based-design\filter-current;..\..\..\amcbldc\application\src\model-based-design\thermal-model;..\..\..\..\libs\lowlevel\cmsis\dsp\v160\Include;..\..\bsp\motorhal</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -403,11 +403,113 @@
               <FileName>embot_app_board_amc2c_mbd.demo.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\app-board-amc2c\embot_app_board_amc2c_mbd.demo.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>2</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>1</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_app_board_amc2c_test.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\src\app-board-amc2c\embot_app_board_amc2c_test.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_app_board_amc2c_theCANagentCORE.cpp</FileName>
@@ -1102,14 +1204,14 @@
       <TargetName>appl-can-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -2302,8 +2404,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-can.uvprojx
@@ -10,13 +10,13 @@
       <TargetName>appl-can-stlink</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1204,13 +1204,13 @@
       <TargetName>appl-can-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6180000::V6.18::ARMCLANG</pCCUsed>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1508,7 +1508,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>2</Optim>
+            <Optim>5</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -2404,7 +2404,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theCANagentCORE.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theCANagentCORE.cpp
@@ -55,7 +55,7 @@ struct embot::app::board::amc2c::theCANagentCORE::Impl
         std::uint8_t        tobefilled[3];  // to make the size of struct ... multiple of 8.
     };         
         
-    StoredInfo _storedinfo = {0};  
+    StoredInfo _storedinfo = {};  
     
     embot::prot::can::applicationInfo _applicationinfo {};
 
@@ -82,7 +82,7 @@ bool embot::app::board::amc2c::theCANagentCORE::Impl::initialise(const Config &c
     _storedinfo.applicationVbuild = _config.applicationinfo.version.build;
     _storedinfo.protocolVmajor = _config.applicationinfo.protocol.major;
     _storedinfo.protocolVminor = _config.applicationinfo.protocol.minor;
-    _storedinfo.protocolVmajor = _config.applicationinfo.protocol.major;
+  
     std::memmove(_storedinfo.info32, _config.boardinfo, sizeof(_storedinfo.info32)); 
     
     _board = static_cast<embot::prot::can::Board>(_storedinfo.boardtype);

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c.cpp
@@ -185,10 +185,10 @@ namespace embot { namespace hw { namespace testpoint {
     #if   defined(STM32HAL_BOARD_AMC2C)
 
     
-    constexpr PROP tp1 = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::A, embot::hw::GPIO::PIN::five}  };
-    constexpr PROP tp2 = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::A, embot::hw::GPIO::PIN::eight}  };
-    constexpr PROP tp3 = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::zero}  };
-    constexpr PROP tp4 = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::thirteen}}; 
+    constexpr PROP tp1 = { .on = embot::hw::gpio::State::SET, .off = embot::hw::gpio::State::RESET, .gpio = {embot::hw::GPIO::PORT::A, embot::hw::GPIO::PIN::five}  };
+    constexpr PROP tp2 = { .on = embot::hw::gpio::State::SET, .off = embot::hw::gpio::State::RESET, .gpio = {embot::hw::GPIO::PORT::A, embot::hw::GPIO::PIN::eight}  };
+    constexpr PROP tp3 = { .on = embot::hw::gpio::State::SET, .off = embot::hw::gpio::State::RESET, .gpio = {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::zero}  };
+    constexpr PROP tp4 = { .on = embot::hw::gpio::State::SET, .off = embot::hw::gpio::State::RESET, .gpio = {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::thirteen}}; 
     
     constexpr BSP thebsp {
         // maskofsupported

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_motor_bsp_amc2c.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_motor_bsp_amc2c.cpp
@@ -385,7 +385,7 @@ namespace embot::hw::motor::bsp::amc2c {
         hTIM1.Instance = TIM1;
         hTIM1.Init.Prescaler = 0;
         hTIM1.Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED1;
-        hTIM1.Init.Period = 1024;
+        hTIM1.Init.Period = 1219;
         hTIM1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
         hTIM1.Init.RepetitionCounter = 0;
         hTIM1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
@@ -440,7 +440,7 @@ namespace embot::hw::motor::bsp::amc2c {
         Error_Handler();
         }
         sConfigOC.OCMode = TIM_OCMODE_PWM2;
-        sConfigOC.Pulse = 752;
+        sConfigOC.Pulse = 895; // was 752, changed due to different clock source from amc-bldc
         if (HAL_TIM_PWM_ConfigChannel(&hTIM1, &sConfigOC, TIM_CHANNEL_6) != HAL_OK)
         {
         Error_Handler();
@@ -1260,8 +1260,8 @@ namespace embot::hw::motor::bsp::amc2c {
             HAL_NVIC_SetPriority(TIM1_BRK_IRQn, 5, 0);
             HAL_NVIC_EnableIRQ(TIM1_BRK_IRQn);
 #endif            
-            HAL_NVIC_SetPriority(TIM1_UP_IRQn, 5, 0);
-            HAL_NVIC_EnableIRQ(TIM1_UP_IRQn);
+//            HAL_NVIC_SetPriority(TIM1_UP_IRQn, 5, 0);
+//            HAL_NVIC_EnableIRQ(TIM1_UP_IRQn);
             HAL_NVIC_SetPriority(TIM1_TRG_COM_IRQn, 5, 0);
             HAL_NVIC_EnableIRQ(TIM1_TRG_COM_IRQn);
             HAL_NVIC_SetPriority(TIM1_CC_IRQn, 5, 0);
@@ -1331,7 +1331,7 @@ namespace embot::hw::motor::bsp::amc2c {
 #else            
             HAL_NVIC_DisableIRQ(TIM1_BRK_IRQn);
 #endif            
-            HAL_NVIC_DisableIRQ(TIM1_UP_IRQn);
+//            HAL_NVIC_DisableIRQ(TIM1_UP_IRQn);
             HAL_NVIC_DisableIRQ(TIM1_TRG_COM_IRQn);
             HAL_NVIC_DisableIRQ(TIM1_CC_IRQn);
             /* USER CODE BEGIN TIM1_MspDeInit 1 */

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/motorhal.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/motorhal.cpp
@@ -33,6 +33,8 @@
 // - all the rest
 // --------------------------------------------------------------------------------------------------------------------
 
+volatile int32_t RAW = 0;
+volatile int32_t CURRENT = 0;
 
 namespace embot::hw::motor::adc {
     
@@ -45,7 +47,12 @@ struct Converter
     static int32_t raw2current(int32_t r)
     {
         int32_t c = (r/1000) * 7872;
-        return c;
+        
+        RAW = r;
+        RAW = RAW;
+        CURRENT = c;
+        CURRENT = CURRENT;
+        return CURRENT;
     }
     
     static int32_t current2raw(int32_t c)

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/motorhal.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/motorhal.cpp
@@ -39,22 +39,19 @@ namespace embot::hw::motor::adc {
 
 #define hadc1 (embot::hw::motor::bsp::amc2c::hADC1)
 #define hadc2 (embot::hw::motor::bsp::amc2c::hADC2)
-    
-    
 
 struct Converter
 {
     static int32_t raw2current(int32_t r)
     {
-        // return CIN_GAIN * vref_mV * r >> 16u;
-        return r;       
+        int32_t c = (r/1000) * 7872;
+        return c;
     }
     
     static int32_t current2raw(int32_t c)
     {
-        // int32_t tmp = (curr << 16) / (CIN_GAIN * vref_mV);
-        // return tmp;
-        return c;       
+        int32_t r = (c*7872) / 1000;
+        return r;
     }    
     
     constexpr Converter() = default;
@@ -237,7 +234,7 @@ bool deinit()
 {
     bool r = true;    
     // AdcMotDeInit() unchanged is OK 
-    AdcMotDeInit();
+    // AdcMotDeInit();
     // i also clear the callback
     set({});    
     return r;    
@@ -406,7 +403,7 @@ struct hall_Table
 
     static constexpr uint16_t hallAngleTable[] =
     {
-        /* ABC  (°)  */
+        /* ABC  (?)  */
         /* LLL ERROR */ static_cast<uint16_t>(0),
         /* LLH  240  */ static_cast<uint16_t>(240.0 * Deg2iCub), /* 43690 */
         /* LHL  120  */ static_cast<uint16_t>(120.0 * Deg2iCub), /* 21845 */
@@ -661,9 +658,9 @@ extern void set(uint16_t u, uint16_t v, uint16_t w)
         u = v = w = 0;
     }
 
-    _pwm_internals.pwmcomparevalue_protect(true);    
+//    _pwm_internals.pwmcomparevalue_protect(true);    
     PwmPhaseSet(u, v, w);
-    _pwm_internals.pwmcomparevalue_protect(false);
+//    _pwm_internals.pwmcomparevalue_protect(false);
     
 //    if(true == _pwm_internals.calibrating)
 //    {        

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/pwm.c
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/pwm.c
@@ -63,6 +63,8 @@ extern TIM_HandleTypeDef htim1;
 #define USE_BREAK_INPUT     0
 #endif
 
+// marco.accame: between [0, 1023], where original value is in [0, 64k) and use nearest integer
+// using (p+32)/64
 /* This macro reduce a PWM unsigned value to the value to be loaded in TIM1_CCRx registers */
 #define PWM_COMPARE_VALUE(Pwm)  ((((unsigned)(Pwm))>=0xFFC0U)?0x03FFU:((Pwm+0x0020U)>>6u))
 
@@ -88,13 +90,13 @@ static volatile uint16_t PwmComparePhaseW = 0;
  * @param   phtim   Not used
  * @return  void
  */
-static void PwmUpdateEvent_cb(TIM_HandleTypeDef *phtim)
-{
-    /* Update the compare registers of the PWM counter */
-    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, PwmComparePhaseU);
-    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, PwmComparePhaseV);
-    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, PwmComparePhaseW);
-}
+//static void PwmUpdateEvent_cb(TIM_HandleTypeDef *phtim)
+//{
+//    /* Update the compare registers of the PWM counter */
+//    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, PwmComparePhaseU);
+//    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, PwmComparePhaseV);
+//    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, PwmComparePhaseW);
+//}
 
 #if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
 #else
@@ -128,15 +130,20 @@ static void PwmBreakEvent_cb(TIM_HandleTypeDef *phtim)
 void PwmPhaseSet(uint16_t u, uint16_t v, uint16_t w)
 {
     /* Reduce PWM values in counter units */
-    u = PWM_COMPARE_VALUE(u);
-    v = PWM_COMPARE_VALUE(v);
-    w = PWM_COMPARE_VALUE(w);
+//    u = PWM_COMPARE_VALUE(u);
+//    v = PWM_COMPARE_VALUE(v);
+//    w = PWM_COMPARE_VALUE(w);
+
+
     /* Must be interrupt-safe */
-    taskDISABLE_INTERRUPTS();
-    PwmComparePhaseU = u;
-    PwmComparePhaseV = v;
-    PwmComparePhaseW = w;
-    taskENABLE_INTERRUPTS();
+//    taskDISABLE_INTERRUPTS();
+    PwmComparePhaseU = (u<1024) ? (u) : (1023);
+    PwmComparePhaseV = (v<1024) ? (v) : (1023);
+    PwmComparePhaseW = (w<1024) ? (w) : (1023);
+//    taskENABLE_INTERRUPTS();
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, PwmComparePhaseU);
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, PwmComparePhaseV);
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, PwmComparePhaseW);    
 }
 
 
@@ -232,9 +239,9 @@ HAL_StatusTypeDef PwmInit(void)
 {
     /* Stop any operation in progress */
 #if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
-    __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE);
+//    __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE);
 #else    
-    __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE|TIM_IT_BREAK);
+    __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_BREAK);
 #endif    
     HAL_TIM_PWM_Stop_IT(&htim1, TIM_CHANNEL_1);
     HAL_TIM_PWM_Stop_IT(&htim1, TIM_CHANNEL_2);
@@ -259,7 +266,8 @@ HAL_StatusTypeDef PwmInit(void)
     __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_3, PwmComparePhaseW = 0);
    
     /* Register the TIM1 callback functions and start the PWM generator */
-    if ((HAL_OK == HAL_TIM_RegisterCallback(&htim1, HAL_TIM_PERIOD_ELAPSED_CB_ID, PwmUpdateEvent_cb)) &&
+    if (
+//        (HAL_OK == HAL_TIM_RegisterCallback(&htim1, HAL_TIM_PERIOD_ELAPSED_CB_ID, PwmUpdateEvent_cb)) &&
 #if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
 #else    
         (HAL_OK == HAL_TIM_RegisterCallback(&htim1, HAL_TIM_BREAK2_CB_ID, PwmBreakEvent_cb)) &&
@@ -278,7 +286,7 @@ HAL_StatusTypeDef PwmInit(void)
 //#if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
 //        __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_UPDATE);
 //#else        
-        __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_UPDATE|TIM_IT_BREAK); 
+        __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_BREAK); 
 //#endif         
         return HAL_OK;
     }
@@ -300,9 +308,9 @@ void PwmDeInit(void)
     PwmReset(ENABLE);
     PwmSleep(ENABLE);
 #if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
-     __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE);
+//     __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE);
 #else    
-    __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE|TIM_IT_BREAK);
+    __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_BREAK);
 #endif    
     HAL_TIM_Base_Stop(&htim1);
     HAL_TIM_PWM_Stop_IT(&htim1, TIM_CHANNEL_1);

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/pwm.c
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/pwm.c
@@ -137,9 +137,9 @@ void PwmPhaseSet(uint16_t u, uint16_t v, uint16_t w)
 
     /* Must be interrupt-safe */
 //    taskDISABLE_INTERRUPTS();
-    PwmComparePhaseU = (u<1024) ? (u) : (1023);
-    PwmComparePhaseV = (v<1024) ? (v) : (1023);
-    PwmComparePhaseW = (w<1024) ? (w) : (1023);
+    PwmComparePhaseU = (u<1219) ? (u) : (1219);
+    PwmComparePhaseV = (v<1219) ? (v) : (1219);
+    PwmComparePhaseW = (w<1219) ? (w) : (1219);
 //    taskENABLE_INTERRUPTS();
     __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, PwmComparePhaseU);
     __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_2, PwmComparePhaseV);

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.uvprojx
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32H743ZITx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) IROM2(0x08100000,0x00100000) XRAM(0x30000000,0x00048000) XRAM2(0x38000000,0x00010000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -2510,8 +2510,8 @@
         <TargetCommonOption>
           <Device>STM32H743ZITx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) IROM2(0x08100000,0x00100000) XRAM(0x30000000,0x00048000) XRAM2(0x38000000,0x00010000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -5106,8 +5106,8 @@
         <TargetCommonOption>
           <Device>STM32H745XIHx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -7702,8 +7702,8 @@
         <TargetCommonOption>
           <Device>STM32H745XIHx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -10367,8 +10367,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -13629,8 +13629,8 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.0.0</PackID>
-          <PackURL>http://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -13927,7 +13927,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>5</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>


### PR DESCRIPTION
**What's new:**

- update projects to work with both `st-link` and `ulinkpro` debuggers enabling trace, logic analyzer and event viewer 
- add testpoint `tp1` and `tp2` inside 1ms tick and FocInnerLoop respectively
- fix test point `set` and `reset` (now `set` means HIGH and `reset` means LOW)
- adjust the conversion value for Va, Vb, Vc to set the PWM values according to the micro HW config
- remove cb for TIM1 to avoid wasting CPU time

cc @davidetome 