### PR TITLE
Set joints to NOT_CONFIGURED at YRI closure using MotionController Deactivate() API

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/examples/appl-01/cfg/theApplication_config.h
@@ -40,14 +40,14 @@ namespace embot { namespace app { namespace eth {
             Process::eApplication,
 #if defined(WRIST_MK2)
     #if defined(WRIST_MK2_RIGHT)
-            {101, 9},
+            {101, 10},
     #else
-            {102, 9},
+            {102, 10},
     #endif            
 #else            
-            {103, 9},  
+            {103, 10},  
 #endif            
-            {2023, Month::Sep, Day::seven, 14, 00}
+            {2023, Month::Sep, Day::eight, 17, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          73
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          74
 
 //  </h>version
 
@@ -91,9 +91,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          8
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -1581,9 +1581,9 @@ extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p)
     
     if(eobool_false == p->service.started)
     {   // it is already stopped
+    
         return(eores_OK);
     }
-    
     
     if(eo_motcon_mode_mc4 == p->service.servconfig.type)
     {
@@ -1594,7 +1594,8 @@ extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p)
     }
     else //foc, mc4plus, mc4plusmais, and others which use the MControler
     {
-         MController_go_idle();
+        MController_go_idle();
+        MController_deinit();
     }
       
     p->service.started = eobool_false;
@@ -1605,7 +1606,6 @@ extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p)
     //eo_motioncontrol_SetRegulars(p, NULL, NULL);
     
     // eo_errman_Trace(eo_errman_GetHandle(), "eo_motioncontrol_Stop()", s_eobj_ownname);
-    
     return(eores_OK);    
 }
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          55
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          56
 //  </h>version
 
 //  <h> build date
@@ -84,9 +84,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          8
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00 
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          76
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          77
 
 //  </h>version
 
@@ -94,9 +94,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        9
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          8
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
@@ -1801,7 +1801,6 @@ void MController_set_interaction_mode(uint8_t j, eOmc_interactionmode_t interact
     JointSet_set_interaction_mode(smc->jointSet+smc->j2s[j], interaction_mode);
 } 
 
-
 // --------------------------------------------------------------------------------------------------------------------
 // - definition of static functions 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -311,7 +311,7 @@ BOOL Joint_set_control_mode(Joint* o, eOmc_controlmode_command_t control_mode)
 {
     if (o->control_mode == ((eOmc_controlmode_t)control_mode)) return TRUE;
     
-    if (o->control_mode == eomc_controlmode_notConfigured) return FALSE;
+    if (o->control_mode == eomc_controlmode_notConfigured) return FALSE;  
         
     if (o->control_mode == eomc_controlmode_calib) return FALSE;    
     

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -616,6 +616,7 @@ BOOL JointSet_set_control_mode(JointSet* o, eOmc_controlmode_command_t control_m
     {
     case eomc_controlmode_cmd_force_idle:
     case eomc_controlmode_cmd_idle:
+    {
         for (int k=0; k<N; ++k)
         { 
             Motor_motion_reset(o->motor+o->motors_of_set[k]);
@@ -624,7 +625,8 @@ BOOL JointSet_set_control_mode(JointSet* o, eOmc_controlmode_command_t control_m
             Motor_set_idle(o->motor+o->motors_of_set[k]);
             Joint_set_control_mode(o->joint+o->joints_of_set[k], control_mode_cmd);
         }
-        break;
+    }
+    break;
 #ifdef WRIST_MK2    
     case eomc_controlmode_cmd_mixed:
     case eomc_controlmode_cmd_velocity_pos:


### PR DESCRIPTION
In order to solve problems of joints going in hw limit fault at yarprobotinterface restart now joints are set to NOT_CONFIGURED control mode at YRI closure, therefore at restart they can re-calibrate effectively as shown ad explained in [this issue](https://github.com/icub-tech-iit/project-ergocub/issues/124#)