### PR TITLE
amc bugfix reading aea3 bitshift

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_MA730.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_MA730.cpp
@@ -173,11 +173,9 @@ bool embot::hw::chip::MA730::Impl::read(Data &data, embot::core::relTime timeout
     
     if(resOK == embot::hw::spi::read(_config.spi, da, timeout))
     {
-        // TODO: verify
-        // AEA3 offers 14 bit of resolution
+        // AEA3 offers 14 bit of resolution (0-16383)
         // in this way we are reading 16 bits (1 bit dummy + 14 bit valid + 1 bit zero padded). The dummy bit has been masked.
-        data.position = (((_databuffer[0] & 0x7F) << 8 )| _databuffer[1]);
-       
+        data.position = ((_databuffer[0] & 0x7F) << 7) | (_databuffer[1] >> 1);
         data.status.ok = true;
         r = true;
     }
@@ -193,7 +191,7 @@ void embot::hw::chip::MA730::Impl::onCompletion(void *p)
     embot::hw::chip::MA730::Impl *pimpl = reinterpret_cast<embot::hw::chip::MA730::Impl*>(p);
     if(nullptr != pimpl->_tmpdata)
     {
-       pimpl->_tmpdata->position = (((pimpl->_databuffer[0] & 0x7F) << 8 )| pimpl->_databuffer[1]); // to be verified ....
+       pimpl->_tmpdata->position = ((pimpl->_databuffer[0] & 0x7F) << 7) | (pimpl->_databuffer[1] >> 1);
        pimpl->_tmpdata->status.ok = true;
     }
     pimpl->_tmponcompletion.execute();


### PR DESCRIPTION
**What's new**

- Fix the bitshift reading of chip_MA730 (aka AEA3) on the `AMC` board

### Brief description of the reading

We know that the chip_MA730 has a resolution of 14 bits, so it can count values from 0 to 16383.
We also know that in order to perform a reading we have to send 2 bytes to the clock source.
Finally, from the Datasheet, we know that the first bit of the Byte read is a dummy bit and the last bit of the second Byte is a zero-padded bit.
Let's see how to read the case of maximum value in summary:

#### Step 0 (initial conditions)
|  | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| Buffer[0] | [dummy] | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| Buffer[1] | 1 | 1 | 1 | 1 | 1 | 1 | 1 | [zero padded] |

|  | 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| position | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - | - |


#### Step 1 (clip the first byte by removing the dummy bit (mask it with 0x7F) and shift it to the left by 7 positions)
|  | 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| position | - | 0 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |


#### Step 2 (read the second Byte by shifting it first by 1 position to the right )
|  | 15 | 14 | 13 | 12 | 11 | 10 | 9 | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| position | - | 0 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |

In the last step position contains our final 14-bit value ---> 16383.

cc @valegagge @ale-git 