### PR TITLE
Update fw to v1.3.1 and display variable:

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
@@ -13,13 +13,6 @@
 #ifndef BAT_B_H
 #define BAT_B_H
 
-// TEST VARIABLES
-extern uint32_t test_faults_final_time;
-extern uint32_t test_faults_counter_motor;
-extern uint32_t test_faults_waiting_motor;
-extern uint32_t test_faults_counter_board;
-extern uint32_t test_faults_waiting_board;
-
 extern char Firmware_vers;
 extern char Revision_vers;
 extern char Build_number;

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
@@ -13,6 +13,13 @@
 #ifndef BAT_B_H
 #define BAT_B_H
 
+// TEST VARIABLES
+extern uint32_t test_faults_final_time;
+extern uint32_t test_faults_counter_motor;
+extern uint32_t test_faults_waiting_motor;
+extern uint32_t test_faults_counter_board;
+extern uint32_t test_faults_waiting_board;
+
 extern char Firmware_vers;
 extern char Revision_vers;
 extern char Build_number;
@@ -43,6 +50,7 @@ extern uint16_t timer_delay_motor;
 extern uint16_t timer_delay_board_max;
 extern uint16_t timer_delay_motor_max;
 extern uint16_t timer_delay_dcdc_max;
+
 
 extern uint32_t blink_ds;
 extern uint8_t toggle_1s;
@@ -85,6 +93,13 @@ extern uint8_t DCDC_ctrl;
 extern uint8_t DCDC_status;
 extern uint8_t HSM_PG;
 extern uint8_t HSM_F;
+
+extern uint8_t HSM_HW_F;
+extern uint8_t HSM_SW_F;
+
+extern int32_t Current_board_in_fault;
+extern int32_t Current_HSM_in_fault;
+extern int32_t Current_motor_in_fault;
 
 extern uint16_t timeout;
 extern uint16_t time_delay;

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/Display_uOLED.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/Display_uOLED.h
@@ -17,7 +17,7 @@
 void Display_uOLED_128_G2(void);
 void Display_uOLED_init(void);
 
-extern uint16_t uOLED_Parameters[14];
+extern uint16_t uOLED_Parameters[18];
 extern uint16_t Display_qualifier;
 
 

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/global_var.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/global_var.h
@@ -12,6 +12,13 @@
 #ifndef __GLOBAL_VAR_H
 #define __GLOBAL_VAR_H
 
+// TEST VARS
+extern uint32_t test_faults_final_time;
+extern uint32_t test_faults_counter_motor;
+extern uint32_t test_faults_waiting_motor;
+extern uint32_t test_faults_counter_board;
+extern uint32_t test_faults_waiting_board;
+
 // ----------------------------------------------------------------------------
 // Firmware Version
 // ----------------------------------------------------------------------------
@@ -73,6 +80,13 @@ extern uint8_t V12motor;
 extern uint8_t V12motor_F;
 extern uint8_t HSM_broken;
 extern uint8_t HSM;
+extern uint8_t HSM_HW_F;
+extern uint8_t HSM_SW_F;
+
+extern int32_t Current_board_in_fault;
+extern int32_t Current_HSM_in_fault;
+extern int32_t Current_motor_in_fault;
+
 extern uint8_t DCrestart;
 
 extern uint8_t V12board_bdc;

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -9,14 +9,6 @@
 #include "stm32l4xx_hal.h"
 #include "BAT_B.h"
 
-//TEST VARS
-uint32_t test_faults_final_time = 60000;
-uint32_t test_faults_counter_motor = 20000;
-uint32_t test_faults_waiting_motor = 2000;
-uint32_t test_faults_counter_board = 20000;
-uint32_t test_faults_waiting_board = 2000;
-
-
 char Firmware_vers = 1;
 char Revision_vers = 3;
 char Build_number  = 1;

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -9,9 +9,17 @@
 #include "stm32l4xx_hal.h"
 #include "BAT_B.h"
 
+//TEST VARS
+uint32_t test_faults_final_time = 60000;
+uint32_t test_faults_counter_motor = 20000;
+uint32_t test_faults_waiting_motor = 2000;
+uint32_t test_faults_counter_board = 20000;
+uint32_t test_faults_waiting_board = 2000;
+
+
 char Firmware_vers = 1;
 char Revision_vers = 3;
-char Build_number  = 0;
+char Build_number  = 1;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis
 uint32_t vhyst=0;    // voltage hysteresis
@@ -46,7 +54,7 @@ uint8_t toggle_100ms = 0;
 
 uint16_t I_V12board_MAX      = 10000;    // threshold in mA
 uint16_t I_V12motor_MAX      = 10000;    // threshold in mA
-uint16_t I_HSM_MAX           = 36000;    // threshold in mA
+uint16_t I_HSM_MAX           = 38000;    // threshold in mA
 uint16_t timer_fault_board   = 0;
 uint16_t timer_fault_motors  = 0;
 uint16_t timer_fault_HSM     = 0;
@@ -63,6 +71,15 @@ uint8_t HSM           = 0;		// HSM control
 uint8_t HSM_PG        = 0;
 uint8_t HSM_F         = 0;
 uint8_t DCrestart     = 0;
+
+//HSM Hw-Sw Fault flags
+uint8_t HSM_HW_F         = 0;
+uint8_t HSM_SW_F         = 0;
+
+// Instantaneous Currents at fault to be sent to UART
+int32_t Current_board_in_fault = 0;
+int32_t Current_HSM_in_fault = 0;
+int32_t Current_motor_in_fault = 0;
 
 uint8_t V12board_bdc  = 1;    // +++++++++++++++++++++++++++++++++++++++++++++ da cambiare logica ++++++++++++++++++
 uint8_t V12motor_bdc  = 1;    // +++++++++++++++++++++++++++++++++++++++++++++ da cambiare logica ++++++++++++++++++

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/Display_uOLED.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/Display_uOLED.c
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------------------------------------------------------
 // Display_uOLED_128_G2
 // -----------------------------------------------------------------------------------------------------------------------------
-uint16_t uOLED_Parameters[14] = {0};
+uint16_t uOLED_Parameters[18] = {0};
 uint16_t Display_qualifier = 0x01;
 
 
@@ -43,6 +43,11 @@ void Display_uOLED_128_G2(){
   
   uOLED_Parameters[12] = (100*HSM_PG) + (10*V12motor) + (V12board);
   uOLED_Parameters[13] = (100*HSM_F) + (10*V12motor_F) + (V12board_F);
+  uOLED_Parameters[14] = (DCDC_status_B << 8) | DCDC_status_A;
+  
+  uOLED_Parameters[15] = Current_board_in_fault;
+  uOLED_Parameters[16] = Current_motor_in_fault;
+  uOLED_Parameters[17] = Current_HSM_in_fault;
   
   HAL_UART_Transmit_DMA(&huart1, (uint8_t*)uOLED_Parameters, sizeof(uOLED_Parameters));
 }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -688,17 +688,6 @@ BOOL AbsEncoder_is_ok(AbsEncoder* o)
 
 BOOL AbsEncoder_is_calibrated(AbsEncoder* o)
 {
-
-    eOerrmanDescriptor_t errdes = {0};
-    char message[150];
-    snprintf(message, sizeof(message), "enc_off=o->offset=%d enc_zero=%d",o->offset, o->zero );
-    errdes.code             = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag02);
-    errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-    errdes.sourceaddress    = 0;
-    errdes.par16            = 0;
-    errdes.par64            = 0;
-    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_debug, message, NULL, &errdes);
-    
     return !o->state.bits.not_calibrated;
 }
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -118,12 +118,6 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
             
             AbsEncoder_calibrate_absolute(e_ptr, 0, jCalib6Data_ptr->computedZero);
             
-//            // debug code
-//            char info[80];
-//            snprintf(info, sizeof(info), "AbsEnc calib: mcp:%d cz:%d co:%d eps:%d", m_ptr->pos_fbk, m_ptr->hardstop_calibdata.zero, m_ptr->pos_calib_offset, e_ptr->position_sure);
-//            JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
-//            // debug code ended
-            
             jCalib6Data_ptr->state = calibtype6_st_absEncoderCalibrated;
             
         }
@@ -134,12 +128,6 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
             //if the current position (computed with calib param of abs encoder) is out of limits range, I'll put joint in fault
             //the limit range is very big. this check should save us from wrong calib params.
             int32_t curr_pos = AbsEncoder_position(e_ptr);
-					
-            // debug code
-            char info[80];
-            snprintf(info, sizeof(info), "Encoder pos:%d and zero:%d", curr_pos, e_ptr->zero);
-            JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
-            // debug code ended
 
             if((curr_pos > j_ptr->pos_max+CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD) || (curr_pos < j_ptr->pos_min-CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD))
             {
@@ -183,12 +171,6 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
     
                 return(eores_NOK_generic);
             }
-            
-            // debug code
-            memset(&info[0], 0, sizeof(info));
-            snprintf(info, sizeof(info), "init traj: cpos=%.2f target=%.2f lim:%.2f %.2f", j_ptr->pos_fbk, j_ptr->running_calibration.data.type6.targetpos, j_ptr->pos_max, j_ptr->pos_min);
-            JointSet_send_debug_message(info, j_ptr->ID, 0, 0);
-            // debug code ended
 
             jCalib6Data_ptr->state = calibtype6_st_trajectoryStarted;
         }    
@@ -301,9 +283,6 @@ static eOresult_t JointSet_do_wait_calibration_7_singleJoint(Joint *j, Motor* m,
             {
                 *calibrationCompleted = TRUE;
                 jCalib7data_ptr->state = calibtype7_st_finished;
-//                char info[80];
-//                sprintf(info,"calib7:completed!");
-//                JointSet_send_debug_message(info, j->ID);
             }
          }    
         break;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -208,18 +208,6 @@ void Joint_config(Joint* o, uint8_t ID, eOmc_joint_config_t* config)
             // Initialize Kalman Filter for the joint
             o->kalman_filter.initialize();
     }
-    
-//    eOerrmanDescriptor_t errdes = {0};
-//    char message[150];
-//    
-//    snprintf(message, sizeof(message), "CFG HW LIMITS: max=%.2f, min=%.2f",o->pos_min_hard, o->pos_max_hard);
-
-//    errdes.code             = eoerror_code_get(eoerror_category_Debug, eoerror_value_DEB_tag01);
-//    errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-//    errdes.sourceaddress    = o->ID;
-//    errdes.par16            = 0;
-//    errdes.par64            = 0;
-//    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_debug, message, NULL, &errdes);
 }
 
 void Joint_destroy(Joint* o)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1590,11 +1590,6 @@ static void JointSet_do_wait_calibration(JointSet* o)
             break;
     }
     
-    //Debug code
-    // char message[150];
-    // snprintf(message, sizeof(message), "JointSet_do_wait_calibration: is_calib=%d.",o->is_calibrated );
-    // JointSet_send_debug_message(message, 0, 0, 0);
-    
     if (!o->is_calibrated) return;
     
     for (int es=0; es<E; ++es)
@@ -1651,10 +1646,6 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
         
         case eomc_calibration_type5_hard_stops:
         {
-//            //Debug code
-//            char message[150];
-//            snprintf(message, sizeof(message), "calib cmd rec: pwm%d cz%d", calibrator->params.type5.pwmlimit, calibrator->params.type5.calibrationZero);
-//            JointSet_send_debug_message(message, e);
             o->calibration_timeout = 0;
             BOOL ret = Motor_calibrate_moving2Hardstop(o->motor+e, calibrator->params.type5.pwmlimit, (calibrator->params.type5.final_pos - calibrator->params.type5.calibrationZero));
             
@@ -1699,14 +1690,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 JointSet_send_debug_message(info, e, 0, 0);
                 ////debug code ended
                 return;
-            }
-            
-            //debug code
-            char info[70];
-            snprintf(info, sizeof(info), "vmax=%d,vim=%d",calibrator->params.type6.vmax, calibrator->params.type6.vmin);
-            JointSet_send_debug_message(info, e, 0, 0);
-            ////debug code ended
-                
+            } 
             //if I'm here I can perform calib type 6.
             
             // 2) set state
@@ -1752,12 +1736,6 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             {
                 o->joint[e].running_calibration.data.type6.targetpos = target_pos;
                 o->joint[e].running_calibration.data.type6.computedZero = 0;
-                
-                //debug code
-                snprintf(info, sizeof(info), "targetPos=%.1f",o->joint[e].running_calibration.data.type6.targetpos);
-                JointSet_send_debug_message(info, e, 0, 0);
-                //debug code ended
-                
             }
             else
             {
@@ -2072,18 +2050,8 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 //3) Convert offset to decideg for POS service and add "-" sign to offset_raw to correct raw position (always minus sign independently from invertDirection value)
                 int32_t offset = ((ICUB2DEG)*(CTRL_UNITS)((-1)*offset_raw))*10.0f;
                 
-                ////debug code
-                snprintf(info, sizeof(info), "CALIB 14 j%d: or=%d o=%d", e, offset_raw, offset);
-                JointSet_send_debug_message(info, e, 0, 0);
-                ////debug code ended
-                
                 //4) Add the rotation
                 eOmc_calib14_ROT_t rotation = eomc_int2calib14_ROT(calibrator->params.type14.rotation);
-                
-                ////debug code
-                snprintf(info, sizeof(info), "Rot from:%d to:%u and iv:%u", calibrator->params.type14.rotation, rotation, calibrator->params.type14.invertdirection);
-                JointSet_send_debug_message(info, e, 0, 0);
-                ////debug code ended
                 
                 if(rotation == eOmc_calib14_ROT_unknown || rotation == eOmc_calib14_ROT_none)
                 {
@@ -2095,11 +2063,6 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                     return;
                 }
                 eoas_pos_ROT_t posrotation = JointSet_calib14_ROT2pos_ROT(rotation);
-                
-                ////debug code
-                snprintf(info, sizeof(info), "CALIB 14 j %d: rot_raw=%d rot_enum=%u ", e, calibrator->params.type14.rotation, posrotation);
-                JointSet_send_debug_message(info, e, 0, 0);
-                ////debug code ended
                 
                 if (eo_pos_Calibrate(eo_pos_GetHandle(), e, posrotation, calibrator->params.type14.invertdirection, offset) != eores_OK)
                 {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -438,12 +438,6 @@ BOOL Motor_calibrate_moving2Hardstop(Motor* o, int32_t pwm, int32_t zero) //
 
     o->hardstop_calibdata.last_pos = o->pos_fbk;
     
-    //debug code
-    char message[150];
-    snprintf(message, sizeof(message), "Pos lp:%d, pos fbk:%d, zero:%d", o->hardstop_calibdata.last_pos, o->pos_fbk, zero);
-    send_debug_message(message, o->ID, 0, 0);
-    //ends here
-    
     o->hardstop_calibdata.zero = zero;
     //Motor_set_run(o);
     return TRUE;


### PR DESCRIPTION
add HSM hw/fw faults flag to status_B
move sending of CAN frames from 1ms to 100ms timer if fault before next 100ms trigger sending of CAN frames in that moment if fault happens save and send to display that currents and voltages Update battery fw for sending status to display, plus triggering fault screens correctly