### PR TITLE
Fix debug message

### DIFF
--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -98,7 +98,7 @@ static eOresult_t JointSet_do_wait_calibration_6_singleJoint(JointSet *o, int in
     /* When i'm here i sure that:
        - state = calibtype6_st_jntEncResComputed
      */
-    
+    char info[80];
     *calibrationCompleted = FALSE;   
     //get poiter to the joint to calibrate
     Joint* j_ptr = o->joint + o->joints_of_set[indexSet];


### PR DESCRIPTION
This PR introduces a little fix due to the missing of the info variable used in the debug messages in the method `JointSet_do_wait_calibration_6_singleJoint` in `Calibrators.c` , which lead to compilation errors in the code
