### PR TITLE
Correct disabling of led toggling at 100ms wrongly removed in previous fw

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -11,7 +11,7 @@
 
 char Firmware_vers = 1;
 char Revision_vers = 3;
-char Build_number  = 1;
+char Build_number  = 2;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis
 uint32_t vhyst=0;    // voltage hysteresis

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
@@ -302,6 +302,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim){
     #endif
   }
   if(htim->Instance==TIM16){        // timer 100ms
+    toggle_100ms = toggle_100ms^1;
     CANBUS();
   }
   if(htim->Instance==TIM17){        // timer 1s


### PR DESCRIPTION
Re-enabled a line for the LED toggling. 