### PR TITLE
Now the joints can run based only to motor encoder - without AMO sensors - and calibrate in hard stop.

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,          
-            {1, 3},        
-            {2023, Month::Oct, Day::twentyfour, 15, 21}
+            {1, 4},        
+            {2023, Month::Nov, Day::thirteen, 10, 53}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          77
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          78
 
 //  </h>version
 
@@ -89,9 +89,9 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -91,11 +91,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          20
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          53
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          5 
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          53 
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          59
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          60
 
 //  </h>version
 
@@ -83,13 +83,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          34 
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          5 
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -94,11 +94,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          58
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          53
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          80
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          81
 
 //  </h>version
 
@@ -92,13 +92,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2023
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          33
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          58
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
@@ -24,27 +24,27 @@
 
 typedef struct // TripodCalib
 {
-    int32_t pwm;
-    int32_t zero;
-    int32_t max_delta;
-    int32_t start_pos[3];
+    int32_t pwm;          // [2FOC PWM units] (-32000 : +32000) = (-100% : +100%)
+    int32_t zero;         // [millimiters]
+    int32_t max_delta;    // [millimeters]
+    int32_t start_pos[3]; // [millimeters]
     
 } TripodCalib;
 
 typedef struct // CableCalib
 {
-    int32_t pwm;
-    int32_t delta;
-    int32_t target;
-    int32_t cable_range;
+    int32_t pwm;          // [MC2+ PWM units] (-3360 : +3360) = (-100% : +100%)
+    int32_t delta;        // [icubdegrees]
+    int32_t target;       // [icubdegrees]
+    int32_t cable_range;  // [icubdegrees]
 } CableCalib;
 
 typedef struct // HardStopCalib
 {
-    int32_t pwm;
-    int32_t zero;
-    int32_t space_thr;
-    int32_t time_thr;
+	  int32_t pwm;       // [2FOC PWM units] (-32000 : +32000) = (-100% : +100%)
+    int32_t zero;      // [icubdegrees]
+    int32_t space_thr; // [icubdegrees]  // placeholder if we want to make them configurable
+    int32_t time_thr;  // [milliseconds] // placeholder if we want to make them configurable
 } HardStopCalib;
 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
@@ -43,8 +43,8 @@ typedef struct // HardStopCalib
 {
 	  int32_t pwm;       // [2FOC PWM units] (-32000 : +32000) = (-100% : +100%)
     int32_t zero;      // [icubdegrees]
-    int32_t space_thr; // [icubdegrees]  // placeholder if we want to make them configurable
-    int32_t time_thr;  // [milliseconds] // placeholder if we want to make them configurable
+    int32_t space_thr; // [icubdegrees]  
+    int32_t time_thr;  // [milliseconds]
 } HardStopCalib;
 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
@@ -39,6 +39,14 @@ typedef struct // CableCalib
     int32_t cable_range;
 } CableCalib;
 
+typedef struct // HardStopCalib
+{
+    int32_t pwm;
+    int32_t zero;
+    int32_t space_thr;
+    int32_t time_thr;
+} HardStopCalib;
+
 
  
 #endif  // include-guard

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -602,7 +602,7 @@ BOOL JointSet_do_wait_calibration_10(JointSet* o)
         {
             Motor_set_pwm_ref(o->motor+m, o->motor[m].calib_pwm);
             
-            if (Motor_is_still(o->motor+m, 12000, 1000))
+            if (Motor_is_still(o->motor+m, o->hard_stop_calib.space_thr, o->hard_stop_calib.time_thr))
             {
                 o->motor[m].pos_calib_offset += o->motor[m].pos_fbk - o->hard_stop_calib.zero;        
                 o->motor[m].pos_fbk = o->hard_stop_calib.zero;
@@ -630,7 +630,7 @@ BOOL JointSet_do_wait_calibration_10(JointSet* o)
             {
                 Motor_set_pwm_ref(o->motor+m, o->motor[m].calib_pwm);
         
-                if (AbsEncoder_is_still(encoder, 12000, 1000))
+                if (AbsEncoder_is_still(encoder, o->hard_stop_calib.space_thr, o->hard_stop_calib.time_thr))
                 {
                     AbsEncoder_calibrate_in_hard_stop(encoder);
                 }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1871,15 +1871,15 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 AbsEncoder_calibrate_fake(o->absEncoder+e);
                 o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
                 o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
-                o->hard_stop_calib.space_thr = 120;
-                o->hard_stop_calib.space_thr = 500;
+                o->hard_stop_calib.space_thr = 12000; // placeholder if we want to make them configurable
+                o->hard_stop_calib.time_thr = 1000;   // placeholder if we want to make them configurable
             }
             else
             {
                 o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
                 o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
-                o->hard_stop_calib.space_thr = 12000;
-                o->hard_stop_calib.space_thr = 1000;
+                o->hard_stop_calib.space_thr = 12000; // placeholder if we want to make them configurable
+                o->hard_stop_calib.time_thr = 1000;   // placeholder if we want to make them configurable
                 AbsEncoder_still_check_reset(o->absEncoder+e);
                 AbsEncoder_start_hard_stop_calibrate(o->absEncoder+e, calibrator->params.type10.calibrationZero);
             }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1861,14 +1861,28 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             o->calibration_timeout = 0;
             
             Joint_set_hardware_limit(o->joint+e);
-            
+
             Motor_calibrate_withOffset(o->motor+e, 0);
             Motor_set_run(o->motor+e, eomc_ctrl_out_type_pwm);
             o->motor[e].calib_pwm = calibrator->params.type10.pwmlimit;
             
-            AbsEncoder_still_check_reset(o->absEncoder+e);
-            AbsEncoder_start_hard_stop_calibrate(o->absEncoder+e, calibrator->params.type10.calibrationZero);
-            
+            if (AbsEncoder_is_fake(o->absEncoder+e))
+            {
+                AbsEncoder_calibrate_fake(o->absEncoder+e);
+                o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
+                o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
+                o->hard_stop_calib.space_thr = 120;
+                o->hard_stop_calib.space_thr = 500;
+            }
+            else
+            {
+                o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
+                o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
+                o->hard_stop_calib.space_thr = 12000;
+                o->hard_stop_calib.space_thr = 1000;
+                AbsEncoder_still_check_reset(o->absEncoder+e);
+                AbsEncoder_start_hard_stop_calibrate(o->absEncoder+e, calibrator->params.type10.calibrationZero);
+            }
         }
         break;
         

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1871,15 +1871,15 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 AbsEncoder_calibrate_fake(o->absEncoder+e);
                 o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
                 o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
-                o->hard_stop_calib.space_thr = 12000; // placeholder if we want to make them configurable
-                o->hard_stop_calib.time_thr = 1000;   // placeholder if we want to make them configurable
+                o->hard_stop_calib.space_thr = 12000; // we can make them configurable (probably not needed)
+                o->hard_stop_calib.time_thr = 1000;   // we can make them configurable (probably not needed)
             }
             else
             {
                 o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
                 o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
-                o->hard_stop_calib.space_thr = 12000; // placeholder if we want to make them configurable
-                o->hard_stop_calib.time_thr = 1000;   // placeholder if we want to make them configurable
+                o->hard_stop_calib.space_thr = 12000; // we can make them configurable (probably not needed)
+                o->hard_stop_calib.time_thr = 1000;   // we can make them configurable (probably not needed)
                 AbsEncoder_still_check_reset(o->absEncoder+e);
                 AbsEncoder_start_hard_stop_calibrate(o->absEncoder+e, calibrator->params.type10.calibrationZero);
             }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
@@ -123,6 +123,8 @@ typedef struct // JointSet
     #endif
 
     TripodCalib tripod_calib;
+    HardStopCalib hard_stop_calib;
+
 } JointSet;
 
 extern JointSet* JointSet_new(uint8_t n); //

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -74,6 +74,30 @@ static void Motor_config_MC4p(uint8_t motor, eOmc_motor_config_t* config)
 }
 */
 
+BOOL Motor_is_still(Motor* o, int32_t space_window, int32_t time_window)
+{
+    o->partial_space += o->pos_raw_fbk - o->pos_raw_fbk_old;
+    o->pos_raw_fbk_old = o->pos_raw_fbk;
+    
+    BOOL still = FALSE;
+    
+    if (++o->partial_timer > time_window)
+    {        
+        still = abs(o->partial_space) < space_window;
+        
+        o->partial_timer = 0;
+        o->partial_space = 0;
+    }
+    
+    return still;
+}
+
+void Motor_still_check_reset(Motor* o)
+{
+    o->partial_timer = 0;
+    o->partial_space = 0;
+}
+
 static void Motor_hardStopCalbData_reset(Motor* o)
 {
     memset(&o->hardstop_calibdata, 0, sizeof(HardStopCalibData));

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -45,6 +45,9 @@ extern void Motor_init(Motor* o);  //
 extern void Motor_config(Motor* o, uint8_t ID, eOmc_motor_config_t* config); //
 extern void Motor_destroy(Motor* o); //
 
+extern BOOL Motor_is_still(Motor* o, int32_t space_window, int32_t time_window);
+extern void Motor_still_check_reset(Motor* o);
+
 extern void Motor_config_encoder(Motor* o, int32_t resolution);
 extern void Motor_config_max_currents(Motor* o, eOmc_current_limits_params_t* current_params);
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
@@ -142,6 +142,9 @@ struct Motor_hid
 
     CTRL_UNITS GEARBOX;
 
+    uint32_t partial_timer;
+    int32_t  partial_space;
+
     BOOL HAS_TEMP_SENSOR;
     int16_t temperature_max;
     int16_t temperature_fbk;
@@ -154,6 +157,7 @@ struct Motor_hid
     
     int32_t pos_raw_cal_fbk;
     int32_t pos_raw_fbk;
+    int32_t pos_raw_fbk_old;
     int32_t vel_raw_fbk;
     
     int32_t pos_calib_offset;


### PR DESCRIPTION
At present, robots like iCub 3 and ErgoCub can use AMO sensors in incremental mode with hard stop calibration.
This new version allows the same robots to run without AMO sensors at all, only relying on motor encoders.

Build PR https://github.com/robotology/icub-firmware-build/pull/112