### PR TITLE
EoInertials3: refactor in order to make it work also w/ ems and mtb3.

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          79
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          80
 
 //  </h>version
 
@@ -91,11 +91,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
@@ -188,10 +188,6 @@ static eOresult_t s_eo_inertials3_TXstart(EOtheInertials3 *p);
 
 static eOresult_t s_eo_inertials3_TXstop(EOtheInertials3 *p);
 
-static eOresult_t s_eo_inertials2_TXstart(EOtheInertials3 *p);
-
-static eOresult_t s_eo_inertials2_TXstop(EOtheInertials3 *p);
-
 static eObool_t s_eo_inertials3_activestate_can_accept_canframe(void);
 
 static void s_eo_inertials3_build_maps(EOtheInertials3* p, uint32_t enablemask);
@@ -276,15 +272,11 @@ static EOtheInertials3 s_eo_theinertials3 =
     .fifoofinertial3data        = NULL,
     
 //    .fromcan2id)                {NOID08},
-        
-    
-#if 1     
+  
     .canmap_mtb_accel_int      = {0},
     .canmap_mtb_accel_ext      = {0},
     .canmap_mtb_gyros_ext      = {0},
     .canmap_imu                = {0},
-#endif
-    
     .inertial3                  = NULL,
     .id32ofregulars             = NULL,
     .setofboardinfos            = {0},
@@ -1875,126 +1867,12 @@ static void s_eo_inertials3_imu_transmission(EOtheInertials3 *p, eObool_t on, ui
             eObool_t thereisaboard = eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr); 
             eObool_t itisaimuboard = eo_common_hlfword_bitcheck(p->canmap_imu[port], addr);
             if((eobool_true == thereisaboard) && (eobool_true == itisaimuboard))            
-//            if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr))
             {                                             
                 location.addr = addr;
                 eo_canserv_SendCommandToLocation(eo_canserv_GetHandle(), &p->sharedcan.command, location);
             }
         }
     }    
-}
-
-enum { mems_gyro = 0, mems_accel = 1 , mems_numberofthem = 2 };
-
-static eOresult_t s_eo_inertials2_TXstart(EOtheInertials3 *p)
-{ 
-    if(eobool_false == p->configured)
-    {   // dont have a configured service
-        return(eores_OK);
-    }    
-    
-    if((0 == p->canmap_brd_active[0]) && (0 == p->canmap_brd_active[1]) && (0 == p->ethmap_mems_active))
-    {   // no mtb boards or onboard sensors configured
-        return(eores_OK);
-    } 
-    
-    if(0 == p->sensorsconfig.enabled)
-    {   // no mtb boards or local mems enabled
-        return(eores_OK);
-    } 
-    
-    if(eobool_true == eo_common_byte_bitcheck(p->ethmap_mems_active, mems_gyro))
-    {
-        eo_mems_Config(eo_mems_GetHandle(), &p->memsconfig[mems_gyro]);
-        eo_mems_Start(eo_mems_GetHandle());
-    }                        
- 
-    icubCanProto_inertial_config_t canprotoconfig = {0};
-    
-    canprotoconfig.period = p->sensorsconfig.datarate;
-    canprotoconfig.enabledsensors = icubCanProto_inertial_sensorflag_none;
-    
-    p->sharedcan.command.clas = eocanprot_msgclass_pollingAnalogSensor;
-    p->sharedcan.command.type  = ICUBCANPROTO_POL_SK_CMD__ACC_GYRO_SETUP;
-    p->sharedcan.command.value = &canprotoconfig;
-
-    eObrd_canlocation_t location = {0};
-    location.insideindex = eobrd_caninsideindex_none;
-    for(uint8_t port=0; port<2; port++)
-    {
-        location.port = port;
-        for(uint8_t addr=1; addr<15; addr++)
-        {                        
-            if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr))
-            {               
-                canprotoconfig.enabledsensors = icubCanProto_inertial_sensorflag_none;
-                // prepare canprotoconfig.enabledsensors ...
-                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_mtb_accel_int[port], addr))
-                {
-                    canprotoconfig.enabledsensors |= icubCanProto_inertial_sensorflag_internaldigitalaccelerometer;
-                }
-                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_mtb_accel_ext[port], addr))
-                {
-                    canprotoconfig.enabledsensors |= icubCanProto_inertial_sensorflag_externaldigitalaccelerometer;
-                }     
-                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_mtb_gyros_ext[port], addr))
-                {
-                    canprotoconfig.enabledsensors |= icubCanProto_inertial_sensorflag_externaldigitalgyroscope;
-                }                
-                location.addr = addr;
-                eo_canserv_SendCommandToLocation(eo_canserv_GetHandle(), &p->sharedcan.command, location);
-            }
-        }
-    }
-    
-    p->transmissionisactive = eobool_true;
-    s_eo_inertials3_presenceofcanboards_start(p);
-    
-    return(eores_OK);   
-}
-
-
-static eOresult_t s_eo_inertials2_TXstop(EOtheInertials3 *p)
-{
-    if(eobool_false == p->configured)
-    {   // nothing to do because we dont have a configured service 
-        return(eores_OK);
-    }     
-
-    icubCanProto_inertial_config_t canprotoconfig = {0};
-    
-    canprotoconfig.enabledsensors   = icubCanProto_inertial_sensorflag_none;
-    canprotoconfig.period           = p->sensorsconfig.datarate;
-
-    p->sharedcan.command.clas = eocanprot_msgclass_pollingAnalogSensor;
-    p->sharedcan.command.type  = ICUBCANPROTO_POL_SK_CMD__ACC_GYRO_SETUP;
-    p->sharedcan.command.value = &canprotoconfig;
-    
-    
-    eObrd_canlocation_t location = {0};
-    location.insideindex = eobrd_caninsideindex_none;
-    for(uint8_t port=0; port<2; port++)
-    {            
-        location.port = port;
-        for(uint8_t addr=1; addr<15; addr++)
-        {
-            if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr))
-            {
-                location.addr = addr;
-                eo_canserv_SendCommandToLocation(eo_canserv_GetHandle(), &p->sharedcan.command, location);
-            }
-        }
-    }
-    
-    
-    // stop the mems
-    eo_mems_Stop(eo_mems_GetHandle());
-
-
-    p->transmissionisactive = eobool_false;
-    s_eo_inertials3_presenceofcanboards_reset(p);
-               
-    return(eores_OK);
 }
 
 static void s_eo_inertials3_imu_configure(EOtheInertials3 *p)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
@@ -1447,12 +1447,12 @@ static void s_eo_inertials3_build_maps(EOtheInertials3* p, uint32_t enablemask)
     memset(p->frommems2id, NOID08, sizeof(p->frommems2id));
     memset(p->memsparam, 255, sizeof(p->memsparam));    
     
-//    memset(p->fromcan2id, NOID08, sizeof(p->fromcan2id));
+    memset(p->fromcan2id, NOID08, sizeof(p->fromcan2id));
 
 
-//    memset(p->canmap_mtb_accel_int, 0, sizeof(p->canmap_mtb_accel_int));
-//    memset(p->canmap_mtb_accel_ext, 0, sizeof(p->canmap_mtb_accel_ext));
-//    memset(p->canmap_mtb_gyros_ext, 0, sizeof(p->canmap_mtb_gyros_ext));
+    memset(p->canmap_mtb_accel_int, 0, sizeof(p->canmap_mtb_accel_int));
+    memset(p->canmap_mtb_accel_ext, 0, sizeof(p->canmap_mtb_accel_ext));
+    memset(p->canmap_mtb_gyros_ext, 0, sizeof(p->canmap_mtb_gyros_ext));
     p->ethmap_mems_active = 0;
 
     for(uint8_t i=0; i<numofsensors; i++)
@@ -1473,23 +1473,23 @@ static void s_eo_inertials3_build_maps(EOtheInertials3* p, uint32_t enablemask)
 
                 switch(des->typeofsensor)
                 {
-//                    case eoas_inertial_accel_mtb_int:
-//                    {
-//                        p->fromcan2id[des->on.can.port][des->on.can.addr][eoas_inertial_accel_mtb_int-eoas_inertial_accel_mtb_int] = i;
-//                        eo_common_hlfword_bitset(&p->canmap_mtb_accel_int[des->on.can.port], des->on.can.addr);                        
-//                    } break;
+                    case eoas_inertial_accel_mtb_int:
+                    {
+                        p->fromcan2id[des->on.can.port][des->on.can.addr][eoas_inertial_accel_mtb_int-eoas_inertial_accel_mtb_int] = i;
+                        eo_common_hlfword_bitset(&p->canmap_mtb_accel_int[des->on.can.port], des->on.can.addr);                        
+                    } break;
 
-//                    case eoas_inertial_accel_mtb_ext:
-//                    {       
-//                        p->fromcan2id[des->on.can.port][des->on.can.addr][eoas_inertial_accel_mtb_ext-eoas_inertial_accel_mtb_int] = i;
-//                        eo_common_hlfword_bitset(&p->canmap_mtb_accel_ext[des->on.can.port], des->on.can.addr);
-//                    } break;  
+                    case eoas_inertial_accel_mtb_ext:
+                    {       
+                        p->fromcan2id[des->on.can.port][des->on.can.addr][eoas_inertial_accel_mtb_ext-eoas_inertial_accel_mtb_int] = i;
+                        eo_common_hlfword_bitset(&p->canmap_mtb_accel_ext[des->on.can.port], des->on.can.addr);
+                    } break;  
                     
-//                    case eoas_inertial_gyros_mtb_ext:
-//                    {                        
-//                        p->fromcan2id[des->on.can.port][des->on.can.addr][eoas_inertial_gyros_mtb_ext-eoas_inertial_accel_mtb_int] = i;
-//                        eo_common_hlfword_bitset(&p->canmap_mtb_gyros_ext[des->on.can.port], des->on.can.addr);                        
-//                    } break; 
+                    case eoas_inertial_gyros_mtb_ext:
+                    {                        
+                        p->fromcan2id[des->on.can.port][des->on.can.addr][eoas_inertial_gyros_mtb_ext-eoas_inertial_accel_mtb_int] = i;
+                        eo_common_hlfword_bitset(&p->canmap_mtb_gyros_ext[des->on.can.port], des->on.can.addr);                        
+                    } break; 
                     
                     default:
                     {
@@ -1905,18 +1905,18 @@ static eOresult_t s_eo_inertials2_TXstart(EOtheInertials3 *p)
             {               
                 canprotoconfig.enabledsensors = icubCanProto_inertial_sensorflag_none;
                 // prepare canprotoconfig.enabledsensors ...
-                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr))
+                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_mtb_accel_int[port], addr))
                 {
                     canprotoconfig.enabledsensors |= icubCanProto_inertial_sensorflag_internaldigitalaccelerometer;
                 }
-                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr))
+                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_mtb_accel_ext[port], addr))
                 {
                     canprotoconfig.enabledsensors |= icubCanProto_inertial_sensorflag_externaldigitalaccelerometer;
                 }     
-                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_brd_active[port], addr))
+                if(eobool_true == eo_common_hlfword_bitcheck(p->canmap_mtb_gyros_ext[port], addr))
                 {
                     canprotoconfig.enabledsensors |= icubCanProto_inertial_sensorflag_externaldigitalgyroscope;
-                }                  
+                }                
                 location.addr = addr;
                 eo_canserv_SendCommandToLocation(eo_canserv_GetHandle(), &p->sharedcan.command, location);
             }

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
@@ -508,7 +508,7 @@ extern eOresult_t eo_inertials3_Verify(EOtheInertials3 *p, const eOmn_serv_confi
     // now we have a complete array of targets and also numofboards. we do some checks ...
     
     // we check that we have at least one discovery target    
-    if(0 == eo_array_Size(p->sharedcan.discoverytargets))
+    if(eobool_false) //TODO raise error only if is 0 BUT we don't handle ems4 //0 == eo_array_Size(p->sharedcan.discoverytargets))
     {
         p->diagnostics.errorDescriptor.sourcedevice       = eo_errman_sourcedevice_localboard;
         p->diagnostics.errorDescriptor.sourceaddress      = 0;
@@ -996,7 +996,6 @@ extern eOresult_t eo_inertials3_Tick(EOtheInertials3 *p, eObool_t resetstatus)
                  
     return(eores_OK);        
 }
-
 
 
 extern eOresult_t eo_inertials3_Config(EOtheInertials3 *p, eOas_inertial3_config_t* config)

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3.c
@@ -471,6 +471,19 @@ extern eOresult_t eo_inertials3_Verify(EOtheInertials3 *p, const eOmn_serv_confi
     // the number of sensor descriptors
     uint8_t numofsensors = eo_array_Size(p->arrayofsensordescriptors);
     uint16_t overlappedmap[2] = {0};
+    eObool_t thereIsEMSGyro = eobool_false;
+    
+    for(uint8_t s=0; s<numofsensors; s++)
+    {
+        eOas_inertial3_descriptor_t *des = (eOas_inertial3_descriptor_t*) eo_array_At(p->arrayofsensordescriptors, s);
+        if(NULL != des)
+        {
+            if(eobrd_ethtype_ems4 == des->typeofboard) {
+                thereIsEMSGyro = eobool_true;
+            }
+        }            
+    }
+    
     for(uint8_t b=0; b<eoas_inertial3_supportedboards_numberof(); b++)
     {
         eOcandiscovery_target_t trgt = {0};
@@ -503,12 +516,10 @@ extern eOresult_t eo_inertials3_Verify(EOtheInertials3 *p, const eOmn_serv_confi
         }
     }
     
-    #warning TODO: manage teh case of non can boards and only a gyro on the ems
-    
     // now we have a complete array of targets and also numofboards. we do some checks ...
     
-    // we check that we have at least one discovery target    
-    if(eobool_false) //TODO raise error only if is 0 BUT we don't handle ems4 //0 == eo_array_Size(p->sharedcan.discoverytargets))
+    // we check that we have at least one discovery target if we don't have ems gyro active  
+    if((eobool_false == thereIsEMSGyro) && (0 == eo_array_Size(p->sharedcan.discoverytargets)))
     {
         p->diagnostics.errorDescriptor.sourcedevice       = eo_errman_sourcedevice_localboard;
         p->diagnostics.errorDescriptor.sourceaddress      = 0;
@@ -1941,7 +1952,7 @@ static void s_eo_inertials3_mtb3_transmission(EOtheInertials3 *p, eObool_t on, u
     
 //    if(0 == p->sensorsconfig.enabled)
 //    {   // no mtb boards or local mems enabled
-//        return(eores_OK);
+//        return;
 //    } 
                        
  

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3_hid.h
@@ -59,8 +59,6 @@ struct EOtheInertials3_hid
     eOservice_diagnostics_t                 diagnostics;
     eOservice_cantools_t                    sharedcan;
     
-    uint8_t                                 numofmtbs;
-    
     eObool_t                                configured;
     
     uint8_t                                 numofcanboards[eo_inertials3_maxTypesOfBoard];
@@ -88,7 +86,10 @@ struct EOtheInertials3_hid
     uint16_t                                not_heardof_target[2];
     uint16_t                                not_heardof_status[2];
     uint32_t                                not_heardof_counter;
-    eObool_t                                transmissionisactive;
+    eObool_t                                cantransmissionisactive;
+    uint8_t                                 numofsensors;
+    uint8_t                                 numoflocalsensors;
+    uint8_t                                 numofoncansensors;
 }; 
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3_hid.h
@@ -59,14 +59,20 @@ struct EOtheInertials3_hid
     eOservice_diagnostics_t                 diagnostics;
     eOservice_cantools_t                    sharedcan;
     
+    uint8_t                                 numofmtbs;
+    
     eObool_t                                configured;
     
     uint8_t                                 numofcanboards[eo_inertials3_maxTypesOfBoard];
     
     // now the old ones
-    eOas_inertial3_config_t                 sensorsconfig;    
+    eOas_inertial3_config_t                 sensorsconfig;
+    uint16_t                                canmap_mtb_accel_int[2];
+    uint16_t                                canmap_mtb_accel_ext[2];
+    uint16_t                                canmap_mtb_gyros_ext[2];    
     uint16_t                                canmap_brd_active[2];
     uint8_t                                 ethmap_mems_active;
+    uint16_t                                fromcan2id[2][16][3];   // 2 ports, 15 addresses (0->14), 3 kinds on mtb ... use mtb-eoas_inertial_accel_mtb_int
     uint16_t                                frommems2id[inertials3_mems_numberofthem];
     uint8_t                                 memsparam[inertials3_mems_numberofthem];    
     eOmems_sensor_cfg_t                     memsconfig[inertials3_mems_numberofthem];

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3_hid.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheInertials3_hid.h
@@ -69,7 +69,8 @@ struct EOtheInertials3_hid
     eOas_inertial3_config_t                 sensorsconfig;
     uint16_t                                canmap_mtb_accel_int[2];
     uint16_t                                canmap_mtb_accel_ext[2];
-    uint16_t                                canmap_mtb_gyros_ext[2];    
+    uint16_t                                canmap_mtb_gyros_ext[2]; 
+    uint16_t                                canmap_imu[2];    
     uint16_t                                canmap_brd_active[2];
     uint8_t                                 ethmap_mems_active;
     uint16_t                                fromcan2id[2][16][3];   // 2 ports, 15 addresses (0->14), 3 kinds on mtb ... use mtb-eoas_inertial_accel_mtb_int

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          61
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          62
 
 //  </h>version
 
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          16
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          82
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          83
 
 //  </h>version
 
@@ -94,11 +94,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          18
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
@@ -102,8 +102,7 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_GYROSCOPE(eOcan
     //    return(eores_OK);
     //}
     
-    // both can be safely called. because if one services is not active the function will do nothing
-    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_gyros_mtb_ext);    
+    // both can be safely called. because if one services is not active the function will do nothing   
     eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, eoas_inertial3_gyros_mtb_ext);
     
     return(eores_OK);
@@ -118,7 +117,6 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_ACCELEROMETER(e
     //}
     
     // both can be safely called. because if one services is not active the function will do nothing
-    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_accel_mtb_int);
     eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, eoas_inertial3_accel_mtb_int);
     
     return(eores_OK);    

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
@@ -97,10 +97,10 @@ EO_weak extern eObool_t eocanprotINperiodic_redefinable_SkipParsingOf_ANY_PERIOD
 
 extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_GYROSCOPE(eOcanframe_t *frame, eOcanport_t port)
 {
-    if(eobool_true == eocanprotINperiodic_redefinable_SkipParsingOf_ANY_PERIODIC_INERTIAL_MSG(frame, port))
-    {
-        return(eores_OK);
-    }
+    //if(eobool_true == eocanprotINperiodic_redefinable_SkipParsingOf_ANY_PERIODIC_INERTIAL_MSG(frame, port))
+    //{
+    //    return(eores_OK);
+    //}
     
     // both can be safely called. because if one services is not active the function will do nothing
     eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_gyros_mtb_ext);    
@@ -112,10 +112,10 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_GYROSCOPE(eOcan
 extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_ACCELEROMETER(eOcanframe_t *frame, eOcanport_t port)
 {
     
-    if(eobool_true == eocanprotINperiodic_redefinable_SkipParsingOf_ANY_PERIODIC_INERTIAL_MSG(frame, port))
-    {
-        return(eores_OK);
-    }
+    //if(eobool_true == eocanprotINperiodic_redefinable_SkipParsingOf_ANY_PERIODIC_INERTIAL_MSG(frame, port))
+    //{
+    //    return(eores_OK);
+    //}
     
     // both can be safely called. because if one services is not active the function will do nothing
     eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_accel_mtb_int);

--- a/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/can/config-can-protocol/EoCANprotISperiodic.c
@@ -102,7 +102,9 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_GYROSCOPE(eOcan
         return(eores_OK);
     }
     
-    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_gyros_mtb_ext);
+    // both can be safely called. because if one services is not active the function will do nothing
+    eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_gyros_mtb_ext);    
+    eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, eoas_inertial3_gyros_mtb_ext);
     
     return(eores_OK);
 }
@@ -115,7 +117,9 @@ extern eOresult_t eocanprotINperiodic_parser_PER_IS_MSG__DIGITAL_ACCELEROMETER(e
         return(eores_OK);
     }
     
+    // both can be safely called. because if one services is not active the function will do nothing
     eo_inertials2_AcceptCANframe(eo_inertials2_GetHandle(), frame, port, eoas_inertial_accel_mtb_int);
+    eo_inertials3_AcceptCANframe(eo_inertials3_GetHandle(), frame, port, eoas_inertial3_accel_mtb_int);
     
     return(eores_OK);    
 }


### PR DESCRIPTION
This PR integrates in `EoInertials3` the functionalities of `EoInertials2`. In this way `EoInertials3` can be runned for retreiving the imu data both from legacy boards such as `ems` `mtb3` AND `rfe`, `mtb4`, `strain2`.

It requires:
- https://github.com/robotology/icub-main/pull/894