### PR TITLE
hal2.h - add missing header

### DIFF
--- a/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/hal2/api/hal2.h
+++ b/emBODY/eBcode/arch-arm/libs/highlevel/abslayer/hal2/api/hal2.h
@@ -1,0 +1,25 @@
+
+/*
+ * Copyright (C) 2023 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __HAL2_H_
+#define __HAL2_H_
+
+// it just wraps the usual hal interface
+
+#include "hal.h"
+#include "hal_motor.h"
+#include "hal_adc.h"
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+
+


### PR DESCRIPTION
As per the title, this PR adds a missing header included by test projects

cc @marcoaccame @Nicogene 