### PR TITLE
Fix/battery version

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvoptx
@@ -75,7 +75,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -230,7 +230,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvoptx
@@ -22,7 +22,7 @@
   </DaveTm>
 
   <Target>
-    <TargetName>BAT_B_iCub3</TargetName>
+    <TargetName>BAT_B_Generic</TargetName>
     <ToolsetNumber>0x4</ToolsetNumber>
     <ToolsetName>ARM-ADS</ToolsetName>
     <TargetOption>

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvprojx
@@ -49,7 +49,7 @@
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
           <OutputDirectory>BAT Rev B\</OutputDirectory>
-          <OutputName>BAT_B</OutputName>
+          <OutputName>BAT Rev B</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>1</CreateHexFile>
@@ -134,7 +134,7 @@
             <RunIndependent>0</RunIndependent>
             <UpdateFlashBeforeDebugging>1</UpdateFlashBeforeDebugging>
             <Capability>1</Capability>
-            <DriverSelection>4096</DriverSelection>
+            <DriverSelection>4100</DriverSelection>
           </Flash1>
           <bUseTDR>1</bUseTDR>
           <Flash2>BIN\UL2CM3.DLL</Flash2>

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/MDK-ARM/BAT_Rev_B.uvprojx
@@ -7,7 +7,7 @@
 
   <Targets>
     <Target>
-      <TargetName>BAT_B_iCub3</TargetName>
+      <TargetName>BAT_B_Generic</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
       <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
@@ -49,7 +49,7 @@
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
           <OutputDirectory>BAT Rev B\</OutputDirectory>
-          <OutputName>BAT Rev B</OutputName>
+          <OutputName>BAT_B</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>1</CreateHexFile>
@@ -134,7 +134,7 @@
             <RunIndependent>0</RunIndependent>
             <UpdateFlashBeforeDebugging>1</UpdateFlashBeforeDebugging>
             <Capability>1</Capability>
-            <DriverSelection>4100</DriverSelection>
+            <DriverSelection>4096</DriverSelection>
           </Flash1>
           <bUseTDR>1</bUseTDR>
           <Flash2>BIN\UL2CM3.DLL</Flash2>
@@ -338,7 +338,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls></MiscControls>
-              <Define>BAT_B_iCub3, USE_HAL_DRIVER,STM32L476xx</Define>
+              <Define>BAT_B_Generic, USE_HAL_DRIVER,STM32L476xx</Define>
               <Undefine></Undefine>
               <IncludePath>../Inc;                                           ../Drivers/STM32L4xx_HAL_Driver/Inc;                                           ../Drivers/STM32L4xx_HAL_Driver/Inc/Legacy;                                           ../Drivers/CMSIS/Device/ST/STM32L4xx/Include;                                           ../Drivers/CMSIS/Include</IncludePath>
             </VariousControls>
@@ -1224,8 +1224,8 @@
       <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM" Cversion="5.6.0" condition="ARMv6_7_8-M Device">
         <package name="CMSIS" schemaVersion="1.7.7" url="http://www.keil.com/pack/" vendor="ARM" version="5.9.0"/>
         <targetInfos>
+          <targetInfo name="BAT_B_Generic"/>
           <targetInfo name="BAT_B_R1"/>
-          <targetInfo name="BAT_B_iCub3"/>
         </targetInfos>
       </component>
     </components>
@@ -1235,7 +1235,7 @@
   <LayerInfo>
     <Layers>
       <Layer>
-        <LayName>&lt;Project Info&gt;</LayName>
+        <LayName>BAT_Rev_B</LayName>
         <LayTarg>0</LayTarg>
         <LayPrjMark>1</LayPrjMark>
       </Layer>

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -103,7 +103,7 @@ uint16_t Battery_high=4200*7;   // 7s5p battery
 uint16_t Battery_low=3300*7;    // 7s5p battery
 #endif 
 
-#ifdef BAT_B_iCub3
+#ifdef BAT_B_Generic
 uint32_t VTH[7]={32000, 34000, 36000, 38000, 40000, 42000, 44000};   // threshold in mV iCub 2.5 Battery
 uint16_t Battery_high=4200*10;   // 10s3p battery
 uint16_t Battery_low=3300*10;    // 10s3p battery

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/main.c
@@ -297,7 +297,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim){
   if(htim->Instance==TIM15){        // timer 10ms
     displayCharge();
     checkHSM();
-    #ifdef BAT_B_iCub3
+    #ifdef BAT_B_Generic
       FAULT_CHECK();
     #endif
   }
@@ -757,9 +757,9 @@ void FAULT_CHECK(void){
 
 
 // -----------------------------------------------------------------------------------------------------------------------------
-// Finite state machine - DCDC power management - Target BAT_B_iCub3
+// Finite state machine - DCDC power management - Target BAT_B_Generic
 // -----------------------------------------------------------------------------------------------------------------------------
-#ifdef BAT_B_iCub3
+#ifdef BAT_B_Generic
 void dcdc_management(void){
 	
   // ----- EVENTS -------------------------------------------------- //


### PR DESCRIPTION
This PR brings small change:
- Fix naming convention for BAT project so that now we have the possibility to built 2 executable:
    - a generic one called bat.hex that can work on both iCub (all versions provided with BAT) and ergoCub
    - a different version that can work only on R1 robot

