### PR TITLE
fix aea3 spi config + minor cleanup

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {1, 7},
-            {2023, Month::Nov, Day::twentynine, 14, 38}
+            {1, 8},
+            {2023, Month::Dec, Day::fourteen, 18, 45}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_MA730.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_MA730.h
@@ -88,7 +88,7 @@ namespace embot { namespace hw { namespace chip {
         { 
             embot::hw::spi::Prescaler::sixtyfour, 
             embot::hw::spi::DataSize::eight, 
-            embot::hw::spi::Mode::two,
+            embot::hw::spi::Mode::one,
             { {embot::hw::gpio::Pull::pullup, embot::hw::gpio::Pull::nopull,      // | miso | mosi |
                embot::hw::gpio::Pull::pulldown, embot::hw::gpio::Pull::pullup} }  // | sclk | sel  |
         };


### PR DESCRIPTION
**What's new**
- Fix spi configuration for chipMA730 (aka aea3). Now it compliant with the datasheet
- minor cleanup in aea3 encoder readings (see also https://github.com/robotology/icub-firmware/pull/420)


**Note**
- Tested on lego-setup with AMC board and `aea3`