### PR TITLE
AMC2C bugfix `polepairs` type from size_t to uint8_t

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -28,13 +28,13 @@ namespace embot::app::board::amc2c::info {
     
     constexpr embot::prot::can::applicationInfo applInfo 
     {   
-        embot::prot::can::versionOfAPPLICATION {2, 0, 5},    
+        embot::prot::can::versionOfAPPLICATION {2, 0, 6},    
         embot::prot::can::versionOfCANPROTOCOL {2, 0}    
     };
 
     constexpr embot::app::eth::Date date
     {
-        2023, embot::app::eth::Month::Oct, embot::app::eth::Day::sixteen, 15, 51
+        2023, embot::app::eth::Month::Jan, embot::app::eth::Day::ten, 17, 00
     };
 
     constexpr embot::hw::FLASHpartitionID codePartition 

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.cpp
@@ -551,7 +551,7 @@ void embot::app::board::amc2c::theMBD::Impl::onCurrents_FOC_innerloop(void *owne
     electricalAngleOld = electricalAngle;
     
     // calculate the current joint position
-    size_t polepairs = (0 != AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs) ? AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs : 1;
+    uint8_t polepairs = (0 != AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs) ? AMC_BLDC_Y.ConfigurationParameters_p.motorconfig.pole_pairs : 1;
     position = position + delta / polepairs;
     
     AMC_BLDC_U.SensorsData_p.motorsensors.angle = static_cast<real32_T>(electricalAngle)*0.0054931640625f; // (60 interval angle)


### PR DESCRIPTION
**What's new:**
- fixed the type of `polepairs` in `embot_app_board_amc2c_theMBD.cpp`. 


**Note:**
- Tested on `lego-setup` 


### Further details

As we can see from the image below, after this change we can compute the right value of `AMC_BLDC_U.SensorsData_p.jointpositions.position`.

>[!important]
>This value is currently sent via CAN to the AMC (CM7 core) and used to do "something" within the position motor control. Wrong values of this parameter may generate wrong behavior in motor control.


| before PR (using size_t) | after PR (using uint8_t) |
| :------------: | :-------------: |
| ![image](https://github.com/robotology/icub-firmware/assets/18039045/621dd5e7-c774-4f2a-a214-70a95ffb7a0c) | ![image](https://github.com/robotology/icub-firmware/assets/18039045/15b5162f-3241-4b95-bd9d-910a6838cff1) |


>[!Note]
> Despite this bugfix, we spotted a non-symmetric profile in the velocity changing the sign of the current target.
>Using the Voltage motor control we don't observe this asymmetry
>![image](https://github.com/robotology/icub-firmware/assets/18039045/7c0f39aa-37ab-47c2-9392-a64948e9ef47)
 

cc @simeonedussoni @Nicogene @mfussi66  