### PR TITLE
Fix the control mode management in case of wrist decoupler

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {1, 9},
-            {2024, Month::Jan, Day::eight, 18, 00}
+            {1, 10},
+            {2024, Month::Jan, Day::seventeen, 17, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -2241,7 +2241,18 @@ void JointSet_stop(JointSet* o, int j) //use only in WRIST_MK2 case
 extern void JointSet_get_state(JointSet* o, int j, eOmc_joint_status_t* joint_state) //use only in WRIST_MK2 case
 {
     joint_state->core.modes.interactionmodestatus    = o->interaction_mode;
-    joint_state->core.modes.controlmodestatus        = o->control_mode;
+    
+    /*NOTE: 
+    in WRIST_MK2 case the jointset.controlmode values the control mode imposed by the user, 
+    while the control_mode of each joint belonging tothe set values "position_direct" always. 
+    In the case the jointset.controlmode is harwarefault, we need to return the exact state of each joint 
+    in order to inform the user which is the joint with the fault*/
+    if(o->control_mode == eomc_controlmode_hwFault)
+        joint_state->core.modes.controlmodestatus = o->joint[o->joints_of_set[j]].control_mode;
+    else
+        joint_state->core.modes.controlmodestatus = o->control_mode; 
+    
+    
     joint_state->core.modes.ismotiondone             = Trajectory_is_done(&(o->wristMK2.ypr_trajectory[j]));
     joint_state->core.measures.meas_position         = o->wristMK2.ypr_pos_fbk[j];           
     joint_state->core.measures.meas_velocity         = ZERO;        


### PR DESCRIPTION
During the tests on the wrist of ergoCub, we noticed that the joints belonging to the joint set had the same control mode (HW-fault). With this PR, in case of error, each joint has its own control mode, so, for example, if an overcurrent occurs on one joint then it will be in hw-fault, while the others are in idle.

We already test this PR on the wrist setup successfully.
