### PR TITLE
Use IF instead of WHILE in check motor encoder error

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          24
+#define FW_VERSION_BUILD          25
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
@@ -158,8 +158,8 @@ inline int QEgetPos()
             {
                 QE_RISE_WARNING(index_broken);
                 
-                while (poscnt < 0)              poscnt += QE_RESOLUTION;
-                while (poscnt >= QE_RESOLUTION) poscnt -= QE_RESOLUTION;
+                if (poscnt < 0)              poscnt += QE_RESOLUTION;
+                if (poscnt >= QE_RESOLUTION) poscnt -= QE_RESOLUTION;
                 
                 POSCNT = (unsigned int)poscnt;
             }


### PR DESCRIPTION
Update version to 3.3.25 and change `while` with `if` in checking of motor encoder index broken

Related to icub-firmware-build PR: https://github.com/robotology/icub-firmware-build/pull/134