### PR TITLE
Fix/temperature reading

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
- * Author:  Davide Tomé
+ * Author:  Davide Tomï¿½
  * email:   davide.tome@iit.it
 */
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
- * Author:  Davide Tom�
+ * Author:  Davide Tomé
  * email:   davide.tome@iit.it
 */
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/motorhal2/analog.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/motorhal2/analog.c
@@ -368,15 +368,6 @@ uint32_t analogVph3(void)
 }
 
 /*******************************************************************************************************************//**
- * @brief   Measure temp
- * @param   void
- * @return  temp in Celsius degrees
- */
-uint32_t temperature(void)
-{
-	return adc1_Buffer.temp >> 16u;
-}
-/*******************************************************************************************************************//**
  * @brief   Measure IIN current
  * @param   void
  * @return  IIN current in mA [-2500mA .. 2500mA]

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/motorhal2/analog.c
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/motorhal2/analog.c
@@ -368,6 +368,15 @@ uint32_t analogVph3(void)
 }
 
 /*******************************************************************************************************************//**
+ * @brief   Measure temp
+ * @param   void
+ * @return  temp in Celsius degrees
+ */
+uint32_t temperature(void)
+{
+	return adc1_Buffer.temp >> 16u;
+}
+/*******************************************************************************************************************//**
  * @brief   Measure IIN current
  * @param   void
  * @return  IIN current in mA [-2500mA .. 2500mA]

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/tests.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/tests.cpp
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
- * Author:  Davide Tomé
+ * Author:  Davide Tomï¿½
  * email:   davide.tome@iit.it
 */
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/tests.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/tests.cpp
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
- * Author:  Davide Tom�
+ * Author:  Davide Tomé
  * email:   davide.tome@iit.it
 */
 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/2FOC.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/2FOC.h
@@ -60,6 +60,8 @@ volatile extern tI2T I2Tdata;
 volatile extern unsigned char gControlMode;
 volatile extern int gTemperature;
 volatile extern int gTemperatureLimit;
+volatile extern int gTemperatureOverheatingCounter;
+volatile extern BOOL isTemperatureRead;
 volatile extern unsigned int i2cERRORS;
 volatile extern long gQEPosition;
 volatile extern int  gQEVelocity;

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/Faults.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/Faults.h
@@ -41,7 +41,7 @@ typedef union uSysError
 /*b3*/  unsigned CAN_RXIsPasv:1;              /* can IS in RX passive mode */
 /*b4*/  unsigned CAN_IsWarnTX:1;              /* can IS in bus warn in tx (exist only one error for rx and tx, so the bits are used together)*/
 /*b5*/  unsigned CAN_IsWarnRX:1;              /* can IS in bus warn in rx*/
-/*b6*/  unsigned OverHeatingFailure:1;        /* UNUSED: put here for mad in msg */
+/*b6*/  unsigned OverHeatingFailure:1;        /* overheating failure */
 /*b7*/  unsigned unused4:1;                   /* UNUSED: put here for mad in msg */
 
 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
@@ -77,7 +77,7 @@
 // I2T parameters for FILTER implementation
 #define UDEF_I2T_LIMIT 90 // %
 
-#define PWMFREQUENCY  40000
+#define PWMFREQUENCY  20000 ///40000
 
 // Deadtime in seconds (range 1.6 us to 25 ns)
 // DHES accept a greater zero cross distortion in order to keep lower temperature

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          26
+#define FW_VERSION_BUILD          28
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          28
+#define FW_VERSION_BUILD          26
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          25
+#define FW_VERSION_BUILD          26
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/i2cTsens.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/i2cTsens.h
@@ -18,6 +18,8 @@ extern "C" {
     
 int setupI2CTsens(void);
 int readI2CTsens(volatile int* temperature);
+// function used for generating synthetic temperature data useful for testing 
+void generateI2CTsensSynthetic(volatile int* temperature);
 
 #ifdef	__cplusplus
 }

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -161,6 +161,8 @@ volatile static char bDriveEnabled = 0;
 //volatile static char sAlignInProgress = 0;
 volatile int gTemperature = 0;
 volatile int gTemperatureLimit = 0;
+volatile int gTemperatureOverheatingCounter = 0;
+volatile BOOL isTemperatureRead = FALSE;
 volatile unsigned int i2cERRORS = 0;
 
 volatile char sAlignInProgress = 0;
@@ -1198,7 +1200,7 @@ int main(void)
         }
         else
         {
-            gTemperature = -5000;
+            gTemperature = 0;
         }
             
 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -931,11 +931,11 @@ void __attribute__((__interrupt__, no_auto_psv)) _DMA0Interrupt(void)
     Vqfbk = Vq;
 
     // Re-scale Vq, Vd with respect to the PWM resolution and fullscale.
-    if (PWM_50_DUTY_CYC!=1000)
-    {
-        Vq /= 2;
-        Vd /= 2;
-    }
+//    if (PWM_50_DUTY_CYC!=1000)
+//    {
+//        Vq /= 2;
+//        Vd /= 2;
+//    }
 
     //
     ////////////////////////////////////////////////////////////////////////////

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c
@@ -183,8 +183,6 @@ static int s_canIcubProtoParser_parse_pollingMsg(tCanData *rxpayload, unsigned c
             int nom  = ((int)rxpayload->b[2])|(((int)rxpayload->b[3])<<8);
             int peak = ((int)rxpayload->b[4])|(((int)rxpayload->b[5])<<8);
             int ovr  = ((int)rxpayload->b[6])|(((int)rxpayload->b[7])<<8);
-
-            gTemperatureLimit = ovr;
             
             setMaxCurrent(nom, peak, ovr);
 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c
@@ -224,7 +224,7 @@ static int s_canIcubProtoParser_parse_pollingMsg(tCanData *rxpayload, unsigned c
         {
             MotorConfig.fullcalib = TRUE;
             gEncoderConfig.full_calibration = TRUE;
-            gEncoderConfig.offset = 0;
+            //gEncoderConfig.offset = 0;
         }
         else
         {

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
@@ -129,24 +129,29 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
     
     if (!bequiet)
     {
+        /**
         BOOL transmit_addStatus = FALSE;
         if (MotorConfig.has_tsens && isActiveI2CTsens())
         {
-            int Tsend = 100 + canprototransmitter_bid*100;
+            
+            int Tsend = 100 + canprototransmitter_bid*3;
             static int noflood = 0;
 
-            if (++noflood >= Tsend)
+            if (isTemperatureRead)
             {
                 noflood = 0;
                 transmit_addStatus = TRUE;
             }
         }
-        if(transmit_addStatus)
+         * */
+        if(isTemperatureRead)
         {
+            payload.w[0] = 0;
             payload.w[1] = gTemperature;
 
             msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__ADDITIONAL_STATUS );
             ECANSend(msgid, 4, &payload);
+            isTemperatureRead = FALSE;
         }
         else
         {

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/i2cTsens.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/i2cTsens.c
@@ -339,11 +339,15 @@ I2Ctimeout:
 
     __delay32(400);
     
+    config_sensor();
+    
     return I2Cerrcode;
 
 fatal_error:
 
     I2Cdead = TRUE;
+
+    config_sensor();
 
     return I2Cerrcode;
 }

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
@@ -142,7 +142,7 @@ inline int QEgetPos()
     int poscnt = (int)POSCNT;
     
     if (QE_USE_INDEX)
-    {
+    {  
         if (qe_index_found)
         {
             static int poscnt_old = 0;
@@ -165,7 +165,7 @@ inline int QEgetPos()
             }
             
             poscnt_old = poscnt;
-        }
+        }   
     }
     
     return __builtin_divsd(((long)poscnt)<<16,QE_RESOLUTION);

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
@@ -167,7 +167,7 @@ inline int QEgetPos()
             poscnt_old = poscnt;
         }
     }
-
+    
     return __builtin_divsd(((long)poscnt)<<16,QE_RESOLUTION);
 }
 


### PR DESCRIPTION
This PR brings the following changes:
- PWM frequency reduced from 40 kHz to 20 kHz
- Improving of the management of error conditions in the temperature reading: 
    - as described in [the documentation](https://icub-tech-iit.github.io/documentation/temperature_sensors/) different negative temperatures are sent to the user to show different error conditions
    - at each error in the TDB where we are losing the correct configuration of the board we are calling its re-configuration
    - temperature sent over CAN towards the EMS in the moment the reading is done 
    - reading is now at 100 ms
    - if motor stays in overtemperature for more than 10 consecutive seconds we are putting the joint in fault, otherwise we just send warnings
    - if we cannot read from the TDB for more than 10 consecutive seconds we are putting the joint in fault, otherwise we try to reconfigure the sensor
    - the overheating error is removed when the read temperature is just less than the given threshold.
- introduced a method (never called) for generating synthetic temperature data
- now the default value for the stator-rotor offset is not 0x0000 but is 0xFFFF 