### PR TITLE
Wrist stuck at startup bug fixed

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {1, 11},
-            {2024, Month::Jan, Day::twentythree, 11, 00}
+            {1, 12},
+            {2024, Month::Feb, Day::twelve, 11, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -918,7 +918,17 @@ void JointSet_do_pwm_control(JointSet* o)
             }
             else
             {
-                o->control_mode = eomc_controlmode_notConfigured;
+                if ( o->wristMK2.warmup)
+                {
+                    o->control_mode = eomc_controlmode_notConfigured;
+                }
+                
+                o->wristMK2.watchdog = 10000;
+                
+                Trajectory_start2end(o->wristMK2.prk_trajectory,   (o->joint[0]).pos_fbk, ZERO, DEG2ICUB*30.0f);
+                Trajectory_start2end(o->wristMK2.prk_trajectory+1, (o->joint[1]).pos_fbk, ZERO, DEG2ICUB*30.0f);
+                Trajectory_start2end(o->wristMK2.prk_trajectory+2, (o->joint[2]).pos_fbk, ZERO, DEG2ICUB*30.0f);
+                
                 static char msg[] = "*** CAN'T EXIT SINGULARITY ***";
                 JointSet_send_debug_message(msg, 0, 0, 0);
             }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
@@ -43,7 +43,9 @@ enum wrist_mk_version_t {WRIST_MK_VER_2_0 = 20,  WRIST_MK_VER_2_1 = 21};
 typedef struct //wristMk2_t
 {
     BOOL is_parking;
-    BOOL warmup;
+    int warmup;
+    
+    int watchdog;
     
     wrist_mk_version_t mk_version;
     BOOL is_right_wrist;
@@ -51,14 +53,18 @@ typedef struct //wristMk2_t
     wrist_decoupler wristDecoupler;
     
     Trajectory ypr_trajectory[3];
+    Trajectory prk_trajectory[3];
     
     CTRL_UNITS ypr_pos_ref[3];
     CTRL_UNITS ypr_vel_ref[3];
     CTRL_UNITS ypr_acc_ref[3];
     CTRL_UNITS ypr_pos_fbk[3];
     
+    CTRL_UNITS prk_pos_ref[3];
+    CTRL_UNITS prk_vel_ref[3];
+    CTRL_UNITS prk_acc_ref[3];
+    
     CTRL_UNITS last_valid_pos[3];
-    CTRL_UNITS park_target[3];
 
 } wristMK2_t;
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
@@ -43,7 +43,7 @@ enum wrist_mk_version_t {WRIST_MK_VER_2_0 = 20,  WRIST_MK_VER_2_1 = 21};
 typedef struct //wristMk2_t
 {
     BOOL is_parking;
-    BOOL must_park;
+    BOOL warmup;
     
     wrist_mk_version_t mk_version;
     BOOL is_right_wrist;
@@ -57,7 +57,8 @@ typedef struct //wristMk2_t
     CTRL_UNITS ypr_acc_ref[3];
     CTRL_UNITS ypr_pos_fbk[3];
     
-    //CTRL_UNITS arm_pos_off[3];
+    CTRL_UNITS last_valid_pos[3];
+    CTRL_UNITS park_target[3];
 
 } wristMK2_t;
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.c
@@ -200,6 +200,12 @@ void Trajectory_stop(Trajectory *o, int32_t pos)
     Trajectory_set_pos_raw(o, pos);
 }
 
+void Trajectory_start2end(Trajectory *o, int32_t start, float end, float velAvg)
+{
+    Trajectory_set_pos_raw(o, start);
+    Trajectory_set_pos_end(o, end, velAvg);
+}
+
 void Trajectory_velocity_stop(Trajectory *o)
 {
     o->bVelocityMove = FALSE;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.h
@@ -72,6 +72,8 @@ extern void Trajectory_set_vel_end(Trajectory *o, float v1, float avg_acc);
 extern void Trajectory_set_pos_raw(Trajectory *o, float p0);
 extern void Trajectory_set_vel_raw(Trajectory *o, float v0);
 
+extern void Trajectory_start2end(Trajectory *o, int32_t start, float end, float velAvg);
+
 extern int8_t Trajectory_do_step(Trajectory *o, float *p, float *v, float *a);
 
 extern void Trajectory_init(Trajectory *o, int32_t p0, int32_t v0, int32_t a0);


### PR DESCRIPTION
The build related to this PR is here: https://github.com/robotology/icub-firmware-build/pull/138

This PR fixes the following problem: if the wrist can't reach the position set by the calibrator after the absolute encoder calibration, the joint isn't able to move any more also if it results running in position mode.

The probelm was caused by the Idle mode forced by the go-to-home failure after calibration. In fact, when put in running mode the wrist remains in go-to-safe-position, but the Idle transition has canceled its trajectory, so it can't move to its target.

Solution adopted in this PR:

The joints aren't set in `position mode` any more when they are parking, but parking makes use of its own parking trajectory generators instead.

The joint results in `calibrating` mode to the yarprobotinterface until it has completed the first parking, so that the yarprobotinterface waits before sending the position move command.

The parking mode is monitored for timeout.