### PR TITLE
AMC V1.13 with improved wrist Mk2 direct kinematics solver

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {1, 12},
-            {2024, Month::Feb, Day::twelve, 11, 00}
+            {1, 13},
+            {2024, Month::Feb, Day::fifteen, 11, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.h
@@ -42,6 +42,10 @@ enum wrist_mk_version_t {WRIST_MK_VER_2_0 = 20,  WRIST_MK_VER_2_1 = 21};
 /* The struct wristMk2_t contains all the data related to the wrist MK2*/
 typedef struct //wristMk2_t
 {
+	// The warmup flag is == 2 at startup and makes the wrist start a first parking move.
+    // warmup == 1 means first parking in progress, and warmup == 0 means first parking done.
+    // Thanks to the new direct kinematics solver all the parking procedures will be likely removed
+    // after some time of use of the robot without problems because no more necessary.
     BOOL is_parking;
     int warmup;
     

--- a/emBODY/eBcode/arch-arm/mbd/wrist_decoupler/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/mbd/wrist_decoupler/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'wrist_decoupler'.
 //
-// Model version                  : 7.13
-// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Tue Jul 25 11:18:40 2023
+// Model version                  : 8.5
+// Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
+// C/C++ source code generated on : Wed Feb 14 13:47:53 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/wrist_decoupler/wrist_decoupler.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/wrist_decoupler/wrist_decoupler.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'wrist_decoupler'.
 //
-// Model version                  : 7.13
-// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Tue Jul 25 11:18:40 2023
+// Model version                  : 8.5
+// Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
+// C/C++ source code generated on : Wed Feb 14 13:47:53 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -22,8 +22,8 @@
 #include "rtwtypes.h"
 #include <cmath>
 #include <cstring>
-#include <cfloat>
 #include <stddef.h>
+#include <cfloat>
 #define NumBitsPerChar                 8U
 
 extern real_T rt_remd_snf(real_T u0, real_T u1);
@@ -606,42 +606,123 @@ void wrist_decoupler::sind(real_T x[3])
 }
 
 // Function for MATLAB Function: '<S1>/motors2ypr'
-real_T wrist_decoupler::maximum(const real_T x[3])
+void wrist_decoupler::cosd_f(real_T *x)
 {
-  real_T ex;
-  int32_T idx;
-  int32_T k;
-  if (!rtIsNaN(x[0])) {
-    idx = 1;
+  real_T absx;
+  real_T b_x;
+  int8_T n;
+  if (rtIsInf(*x) || rtIsNaN(*x)) {
+    *x = (rtNaN);
   } else {
-    boolean_T exitg1;
-    idx = 0;
-    k = 2;
-    exitg1 = false;
-    while ((!exitg1) && (k < 4)) {
-      if (!rtIsNaN(x[k - 1])) {
-        idx = k;
-        exitg1 = true;
+    b_x = rt_remd_snf(*x, 360.0);
+    absx = std::abs(b_x);
+    if (absx > 180.0) {
+      if (b_x > 0.0) {
+        b_x -= 360.0;
       } else {
-        k++;
+        b_x += 360.0;
       }
+
+      absx = std::abs(b_x);
+    }
+
+    if (absx <= 45.0) {
+      b_x *= 0.017453292519943295;
+      n = 0;
+    } else if (absx <= 135.0) {
+      if (b_x > 0.0) {
+        b_x = (b_x - 90.0) * 0.017453292519943295;
+        n = 1;
+      } else {
+        b_x = (b_x + 90.0) * 0.017453292519943295;
+        n = -1;
+      }
+    } else if (b_x > 0.0) {
+      b_x = (b_x - 180.0) * 0.017453292519943295;
+      n = 2;
+    } else {
+      b_x = (b_x + 180.0) * 0.017453292519943295;
+      n = -2;
+    }
+
+    switch (n) {
+     case 0:
+      *x = std::cos(b_x);
+      break;
+
+     case 1:
+      *x = -std::sin(b_x);
+      break;
+
+     case -1:
+      *x = std::sin(b_x);
+      break;
+
+     default:
+      *x = -std::cos(b_x);
+      break;
     }
   }
+}
 
-  if (idx == 0) {
-    ex = x[0];
+// Function for MATLAB Function: '<S1>/motors2ypr'
+void wrist_decoupler::sind_c(real_T *x)
+{
+  real_T absx;
+  real_T b_x;
+  int8_T n;
+  if (rtIsInf(*x) || rtIsNaN(*x)) {
+    *x = (rtNaN);
   } else {
-    ex = x[idx - 1];
-    for (k = idx + 1; k < 4; k++) {
-      real_T x_0;
-      x_0 = x[k - 1];
-      if (ex < x_0) {
-        ex = x_0;
+    b_x = rt_remd_snf(*x, 360.0);
+    absx = std::abs(b_x);
+    if (absx > 180.0) {
+      if (b_x > 0.0) {
+        b_x -= 360.0;
+      } else {
+        b_x += 360.0;
       }
+
+      absx = std::abs(b_x);
+    }
+
+    if (absx <= 45.0) {
+      b_x *= 0.017453292519943295;
+      n = 0;
+    } else if (absx <= 135.0) {
+      if (b_x > 0.0) {
+        b_x = (b_x - 90.0) * 0.017453292519943295;
+        n = 1;
+      } else {
+        b_x = (b_x + 90.0) * 0.017453292519943295;
+        n = -1;
+      }
+    } else if (b_x > 0.0) {
+      b_x = (b_x - 180.0) * 0.017453292519943295;
+      n = 2;
+    } else {
+      b_x = (b_x + 180.0) * 0.017453292519943295;
+      n = -2;
+    }
+
+    switch (n) {
+     case 0:
+      *x = std::sin(b_x);
+      break;
+
+     case 1:
+      *x = std::cos(b_x);
+      break;
+
+     case -1:
+      *x = -std::cos(b_x);
+      break;
+
+     default:
+      *x = -std::sin(b_x);
+      break;
     }
   }
-
-  return ex;
 }
 
 // Function for MATLAB Function: '<S1>/motors2ypr'
@@ -675,6 +756,45 @@ real_T wrist_decoupler::minimum(const real_T x[3])
       real_T x_0;
       x_0 = x[k - 1];
       if (ex > x_0) {
+        ex = x_0;
+      }
+    }
+  }
+
+  return ex;
+}
+
+// Function for MATLAB Function: '<S1>/motors2ypr'
+real_T wrist_decoupler::maximum(const real_T x[3])
+{
+  real_T ex;
+  int32_T idx;
+  int32_T k;
+  if (!rtIsNaN(x[0])) {
+    idx = 1;
+  } else {
+    boolean_T exitg1;
+    idx = 0;
+    k = 2;
+    exitg1 = false;
+    while ((!exitg1) && (k < 4)) {
+      if (!rtIsNaN(x[k - 1])) {
+        idx = k;
+        exitg1 = true;
+      } else {
+        k++;
+      }
+    }
+  }
+
+  if (idx == 0) {
+    ex = x[0];
+  } else {
+    ex = x[idx - 1];
+    for (k = idx + 1; k < 4; k++) {
+      real_T x_0;
+      x_0 = x[k - 1];
+      if (ex < x_0) {
         ex = x_0;
       }
     }
@@ -797,46 +917,102 @@ real_T wrist_decoupler::det(const real_T x[9])
   return y;
 }
 
+// Function for MATLAB Function: '<S1>/motors2ypr'
+void wrist_decoupler::mldivide(const real_T A[9], const real_T B_0[3], real_T Y
+  [3])
+{
+  real_T b_A[9];
+  real_T a21;
+  real_T maxval;
+  int32_T r1;
+  int32_T r2;
+  int32_T r3;
+  std::memcpy(&b_A[0], &A[0], 9U * sizeof(real_T));
+  r1 = 0;
+  r2 = 1;
+  r3 = 2;
+  maxval = std::abs(A[0]);
+  a21 = std::abs(A[1]);
+  if (a21 > maxval) {
+    maxval = a21;
+    r1 = 1;
+    r2 = 0;
+  }
+
+  if (std::abs(A[2]) > maxval) {
+    r1 = 2;
+    r2 = 1;
+    r3 = 0;
+  }
+
+  b_A[r2] = A[r2] / A[r1];
+  b_A[r3] /= b_A[r1];
+  b_A[r2 + 3] -= b_A[r1 + 3] * b_A[r2];
+  b_A[r3 + 3] -= b_A[r1 + 3] * b_A[r3];
+  b_A[r2 + 6] -= b_A[r1 + 6] * b_A[r2];
+  b_A[r3 + 6] -= b_A[r1 + 6] * b_A[r3];
+  if (std::abs(b_A[r3 + 3]) > std::abs(b_A[r2 + 3])) {
+    int32_T rtemp;
+    rtemp = r2;
+    r2 = r3;
+    r3 = rtemp;
+  }
+
+  b_A[r3 + 3] /= b_A[r2 + 3];
+  b_A[r3 + 6] -= b_A[r3 + 3] * b_A[r2 + 6];
+  Y[1] = B_0[r2] - B_0[r1] * b_A[r2];
+  Y[2] = (B_0[r3] - B_0[r1] * b_A[r3]) - b_A[r3 + 3] * Y[1];
+  Y[2] /= b_A[r3 + 6];
+  Y[0] = B_0[r1] - b_A[r1 + 6] * Y[2];
+  Y[1] -= b_A[r2 + 6] * Y[2];
+  Y[1] /= b_A[r2 + 3];
+  Y[0] -= b_A[r1 + 3] * Y[1];
+  Y[0] /= b_A[r1];
+}
+
 // Model step function
 void wrist_decoupler::step()
 {
+  quaternion Told;
   real_T up[12];
   real_T P_0[9];
   real_T b[9];
   real_T ya_0[9];
-  real_T xa[3];
   real_T xb[3];
   real_T ya[3];
   real_T yb[3];
   real_T absx;
   real_T b_n;
-  real_T maxval;
+  real_T b_n_tmp;
+  real_T b_yc;
   real_T rtb_Gain_o_idx_0;
   real_T rtb_Gain_o_idx_1;
   real_T rtb_Gain_o_idx_2;
-  real_T rtb_Product1;
-  real_T rtb_attitude_idx_0;
+  real_T rtb_Product1_tmp;
+  real_T rtb_Product2_tmp;
   real_T st;
+  real_T step_0;
   real_T theta;
-  real_T tmp;
-  real_T tmp_0;
   real_T up_tmp;
   real_T up_tmp_0;
   real_T up_tmp_1;
   real_T up_tmp_2;
   real_T up_tmp_3;
   real_T up_tmp_4;
+  real_T xa_idx_1;
+  real_T xa_idx_2;
   real_T yc_idx_2;
+  int32_T P_tmp;
   int32_T cycles;
   int32_T exitg1;
   int32_T idx;
-  int32_T r1;
-  int32_T r2;
-  int32_T r3;
-  int32_T rtemp;
+  int32_T k;
+  int32_T singularity;
   int8_T n;
   boolean_T exitg2;
-  boolean_T guard1 = false;
+  boolean_T first_try;
+  boolean_T guard1;
+  boolean_T guard11;
 
   // Outputs for Atomic SubSystem: '<Root>/wrist_decoupler'
   // MATLAB Function: '<S1>/motors2ypr' incorporates:
@@ -845,63 +1021,98 @@ void wrist_decoupler::step()
   //   Inport: '<Root>/theta_diff'
   //   Inport: '<Root>/theta_off'
 
-  rtb_Gain_o_idx_0 = rtU.theta_diff[0];
-  rtb_Gain_o_idx_1 = rtU.theta_diff[1];
-  rtb_Gain_o_idx_2 = rtU.theta_diff[2];
+  // :  theta_diff = Wrap180(theta_diff);
+  // :  y = x;
+  // :  for i=1:3
+  // :  while y(i) >= 180.0
+  for (rtb_Gain_o_idx_0 = rtU.theta_diff[0]; rtb_Gain_o_idx_0 >= 180.0;
+       rtb_Gain_o_idx_0 -= 360.0) {
+    // :  y(i) = y(i) - 360.0;
+  }
 
-  // :  if isempty(singularity_reg)
-  if (!rtDW.singularity_reg_not_empty) {
+  // :  while y(i) < -180.0
+  while (rtb_Gain_o_idx_0 < -180.0) {
+    // :  y(i) = y(i) + 360.0;
+    rtb_Gain_o_idx_0 += 360.0;
+  }
+
+  // :  while y(i) >= 180.0
+  for (rtb_Gain_o_idx_1 = rtU.theta_diff[1]; rtb_Gain_o_idx_1 >= 180.0;
+       rtb_Gain_o_idx_1 -= 360.0) {
+    // :  y(i) = y(i) - 360.0;
+  }
+
+  // :  while y(i) < -180.0
+  while (rtb_Gain_o_idx_1 < -180.0) {
+    // :  y(i) = y(i) + 360.0;
+    rtb_Gain_o_idx_1 += 360.0;
+  }
+
+  // :  while y(i) >= 180.0
+  for (rtb_Gain_o_idx_2 = rtU.theta_diff[2]; rtb_Gain_o_idx_2 >= 180.0;
+       rtb_Gain_o_idx_2 -= 360.0) {
+    // :  y(i) = y(i) - 360.0;
+  }
+
+  // :  while y(i) < -180.0
+  while (rtb_Gain_o_idx_2 < -180.0) {
+    // :  y(i) = y(i) + 360.0;
+    rtb_Gain_o_idx_2 += 360.0;
+  }
+
+  // :  if isempty(Q)
+  if (!rtDW.Q_not_empty) {
     // :  Pz = -tand(arm_bend)*[1; 1; 1];
     if (rtIsInf(rtU.arm_bend) || rtIsNaN(rtU.arm_bend)) {
-      maxval = (rtNaN);
+      step_0 = (rtNaN);
     } else {
-      maxval = rt_remd_snf(rtU.arm_bend, 360.0);
-      absx = std::abs(maxval);
+      step_0 = rt_remd_snf(rtU.arm_bend, 360.0);
+      absx = std::abs(step_0);
       if (absx > 180.0) {
-        if (maxval > 0.0) {
-          maxval -= 360.0;
+        if (step_0 > 0.0) {
+          step_0 -= 360.0;
         } else {
-          maxval += 360.0;
+          step_0 += 360.0;
         }
 
-        absx = std::abs(maxval);
+        absx = std::abs(step_0);
       }
 
       if (absx <= 45.0) {
-        maxval *= 0.017453292519943295;
+        step_0 *= 0.017453292519943295;
         n = 0;
       } else if (absx <= 135.0) {
-        if (maxval > 0.0) {
-          maxval = (maxval - 90.0) * 0.017453292519943295;
+        if (step_0 > 0.0) {
+          step_0 = (step_0 - 90.0) * 0.017453292519943295;
           n = 1;
         } else {
-          maxval = (maxval + 90.0) * 0.017453292519943295;
+          step_0 = (step_0 + 90.0) * 0.017453292519943295;
           n = -1;
         }
-      } else if (maxval > 0.0) {
-        maxval = (maxval - 180.0) * 0.017453292519943295;
+      } else if (step_0 > 0.0) {
+        step_0 = (step_0 - 180.0) * 0.017453292519943295;
         n = 2;
       } else {
-        maxval = (maxval + 180.0) * 0.017453292519943295;
+        step_0 = (step_0 + 180.0) * 0.017453292519943295;
         n = -2;
       }
 
-      maxval = std::tan(maxval);
+      step_0 = std::tan(step_0);
       if ((n == 1) || (n == -1)) {
-        absx = 1.0 / maxval;
-        maxval = -(1.0 / maxval);
-        if (rtIsInf(maxval) && (n == 1)) {
-          maxval = absx;
+        absx = 1.0 / step_0;
+        step_0 = -(1.0 / step_0);
+        if (rtIsInf(step_0) && (n == 1)) {
+          step_0 = absx;
         }
       }
     }
 
     // :  P = [cosd(theta_off) sind(theta_off) Pz];
-    rtDW.Pz_b[0] = -maxval;
+    rtDW.Pz_i[0] = -step_0;
     yb[0] = rtU.theta_off[0];
-    rtDW.Pz_b[1] = -maxval;
+    rtDW.Pz_i[1] = -step_0;
     yb[1] = rtU.theta_off[1];
-    rtDW.Pz_b[2] = -maxval;
+    rtDW.Pz_i[2] = -step_0;
     yb[2] = rtU.theta_off[2];
     cosd(yb);
     ya[0] = rtU.theta_off[0];
@@ -924,518 +1135,558 @@ void wrist_decoupler::step()
     ya[1] = rtU.plat_off[1];
     ya[2] = rtU.plat_off[2];
     sind(ya);
-    rtDW.Q_p[0] = yb[0];
-    rtDW.Q_p[3] = ya[0];
-    rtDW.Q_p[6] = 0.0;
-    rtDW.Q_p[1] = yb[1];
-    rtDW.Q_p[4] = ya[1];
-    rtDW.Q_p[7] = 0.0;
-    rtDW.Q_p[2] = yb[2];
-    rtDW.Q_p[5] = ya[2];
-    rtDW.Q_p[8] = 0.0;
+    rtDW.Q_a[0] = yb[0];
+    rtDW.Q_a[3] = ya[0];
+    rtDW.Q_a[6] = 0.0;
+    rtDW.Q_a[1] = yb[1];
+    rtDW.Q_a[4] = ya[1];
+    rtDW.Q_a[7] = 0.0;
+    rtDW.Q_a[2] = yb[2];
+    rtDW.Q_a[5] = ya[2];
+    rtDW.Q_a[8] = 0.0;
+    rtDW.Q_not_empty = true;
 
     // :  PQ = [P(1,:)*Q(1,:)' P(2,:)*Q(2,:)' P(3,:)*Q(3,:)'];
-    rtDW.PQ_f[0] = (P_0[0] * rtDW.Q_p[0] + P_0[3] * rtDW.Q_p[3]) + rtDW.Pz_b[0] *
+    rtDW.PQ_c[0] = (P_0[0] * rtDW.Q_a[0] + P_0[3] * rtDW.Q_a[3]) + rtDW.Pz_i[0] *
       0.0;
-    rtDW.PQ_f[1] = (P_0[1] * rtDW.Q_p[1] + P_0[4] * rtDW.Q_p[4]) + rtDW.Pz_b[1] *
+    rtDW.PQ_c[1] = (P_0[1] * rtDW.Q_a[1] + P_0[4] * rtDW.Q_a[4]) + rtDW.Pz_i[1] *
       0.0;
-    rtDW.PQ_f[2] = (P_0[2] * rtDW.Q_p[2] + P_0[5] * rtDW.Q_p[5]) + rtDW.Pz_b[2] *
+    rtDW.PQ_c[2] = (P_0[2] * rtDW.Q_a[2] + P_0[5] * rtDW.Q_a[5]) + rtDW.Pz_i[2] *
       0.0;
 
+    // :  hyaw = 0.1666*(theta_diff(1)+theta_diff(2)+theta_diff(3));
+    absx = ((rtb_Gain_o_idx_0 + rtb_Gain_o_idx_1) + rtb_Gain_o_idx_2) * 0.1666;
+
+    // :  T = quaternion(cosd(hyaw),0,0,sind(0.5*hyaw));
+    rtDW.T.a = absx;
+    cosd_f(&rtDW.T.a);
+    rtDW.T.b = 0.0;
+    rtDW.T.c = 0.0;
+    rtDW.T.d = 0.5 * absx;
+    sind_c(&rtDW.T.d);
+
+    // :  attitude_ok = compact(T);
+    rtDW.attitude_ok[0] = rtDW.T.a;
+    rtDW.attitude_ok[1] = rtDW.T.b;
+    rtDW.attitude_ok[2] = rtDW.T.c;
+    rtDW.attitude_ok[3] = rtDW.T.d;
+  }
+
+  // :  Told = T;
+  Told = rtDW.T;
+
+  // :  singularity = 0;
+  singularity = 0;
+
+  // :  step = 0.01;
+  step_0 = 0.01;
+
+  // :  first_try = true;
+  first_try = true;
+
+  // :  for cycles=1:40
+  cycles = 1;
+  idx = 0;
+  guard1 = false;
+  do {
+    exitg1 = 0;
+    if (idx < 40) {
+      cycles = idx + 1;
+
+      // :  q = rotatepoint(T,Q);
+      b_n_tmp = std::sqrt(((rtDW.T.a * rtDW.T.a + rtDW.T.b * rtDW.T.b) +
+                           rtDW.T.c * rtDW.T.c) + rtDW.T.d * rtDW.T.d);
+      yc_idx_2 = rtDW.T.a / b_n_tmp;
+      rtb_Product1_tmp = rtDW.T.b / b_n_tmp;
+      rtb_Product2_tmp = rtDW.T.c / b_n_tmp;
+      b_n_tmp = rtDW.T.d / b_n_tmp;
+      up[0] = 0.0;
+      up[1] = 0.0;
+      up[2] = 0.0;
+      std::memcpy(&up[3], &rtDW.Q_a[0], 9U * sizeof(real_T));
+      yb[0] = ((yc_idx_2 * up[0] - rtb_Product1_tmp * up[3]) - rtb_Product2_tmp *
+               up[6]) - b_n_tmp * up[9];
+      ya[0] = ((yc_idx_2 * up[3] + rtb_Product1_tmp * up[0]) + rtb_Product2_tmp *
+               up[9]) - b_n_tmp * up[6];
+      xb[0] = ((yc_idx_2 * up[6] - rtb_Product1_tmp * up[9]) + rtb_Product2_tmp *
+               up[0]) + b_n_tmp * up[3];
+      absx = ((yc_idx_2 * up[9] + rtb_Product1_tmp * up[6]) - rtb_Product2_tmp *
+              up[3]) + b_n_tmp * up[0];
+      yb[1] = ((yc_idx_2 * up[1] - rtb_Product1_tmp * up[4]) - rtb_Product2_tmp *
+               up[7]) - b_n_tmp * up[10];
+      ya[1] = ((yc_idx_2 * up[4] + rtb_Product1_tmp * up[1]) + rtb_Product2_tmp *
+               up[10]) - b_n_tmp * up[7];
+      xb[1] = ((yc_idx_2 * up[7] - rtb_Product1_tmp * up[10]) + rtb_Product2_tmp
+               * up[1]) + b_n_tmp * up[4];
+      xa_idx_1 = ((yc_idx_2 * up[10] + rtb_Product1_tmp * up[7]) -
+                  rtb_Product2_tmp * up[4]) + b_n_tmp * up[1];
+      yb[2] = ((yc_idx_2 * up[2] - rtb_Product1_tmp * up[5]) - rtb_Product2_tmp *
+               up[8]) - b_n_tmp * up[11];
+      ya[2] = ((yc_idx_2 * up[5] + rtb_Product1_tmp * up[2]) + rtb_Product2_tmp *
+               up[11]) - b_n_tmp * up[8];
+      xb[2] = ((yc_idx_2 * up[8] - rtb_Product1_tmp * up[11]) + rtb_Product2_tmp
+               * up[2]) + b_n_tmp * up[5];
+      xa_idx_2 = ((yc_idx_2 * up[11] + rtb_Product1_tmp * up[8]) -
+                  rtb_Product2_tmp * up[5]) + b_n_tmp * up[2];
+      up_tmp = ((yb[0] * -rtb_Product1_tmp + ya[0] * yc_idx_2) + xb[0] *
+                -b_n_tmp) - absx * -rtb_Product2_tmp;
+      up_tmp_0 = ((yb[0] * -rtb_Product2_tmp - ya[0] * -b_n_tmp) + xb[0] *
+                  yc_idx_2) + absx * -rtb_Product1_tmp;
+      up_tmp_1 = ((yb[0] * -b_n_tmp + ya[0] * -rtb_Product2_tmp) - xb[0] *
+                  -rtb_Product1_tmp) + absx * yc_idx_2;
+      up[0] = ((yb[0] * yc_idx_2 - ya[0] * -rtb_Product1_tmp) - xb[0] *
+               -rtb_Product2_tmp) - absx * -b_n_tmp;
+      up[3] = up_tmp;
+      up[6] = up_tmp_0;
+      up[9] = up_tmp_1;
+      up_tmp_2 = ((yb[1] * -rtb_Product1_tmp + ya[1] * yc_idx_2) + xb[1] *
+                  -b_n_tmp) - xa_idx_1 * -rtb_Product2_tmp;
+      up_tmp_3 = ((yb[1] * -rtb_Product2_tmp - ya[1] * -b_n_tmp) + xb[1] *
+                  yc_idx_2) + xa_idx_1 * -rtb_Product1_tmp;
+      up_tmp_4 = ((yb[1] * -b_n_tmp + ya[1] * -rtb_Product2_tmp) - xb[1] *
+                  -rtb_Product1_tmp) + xa_idx_1 * yc_idx_2;
+      up[1] = ((yb[1] * yc_idx_2 - ya[1] * -rtb_Product1_tmp) - xb[1] *
+               -rtb_Product2_tmp) - xa_idx_1 * -b_n_tmp;
+      up[4] = up_tmp_2;
+      up[7] = up_tmp_3;
+      up[10] = up_tmp_4;
+      b_n = ((yb[2] * -rtb_Product1_tmp + ya[2] * yc_idx_2) + xb[2] * -b_n_tmp)
+        - xa_idx_2 * -rtb_Product2_tmp;
+      b_yc = ((yb[2] * -rtb_Product2_tmp - ya[2] * -b_n_tmp) + xb[2] * yc_idx_2)
+        + xa_idx_2 * -rtb_Product1_tmp;
+      theta = ((yb[2] * -b_n_tmp + ya[2] * -rtb_Product2_tmp) - xb[2] *
+               -rtb_Product1_tmp) + xa_idx_2 * yc_idx_2;
+      up[2] = ((yb[2] * yc_idx_2 - ya[2] * -rtb_Product1_tmp) - xb[2] *
+               -rtb_Product2_tmp) - xa_idx_2 * -b_n_tmp;
+      up[5] = b_n;
+      up[8] = b_yc;
+      up[11] = theta;
+      for (k = 0; k < 3; k++) {
+        P_tmp = (k + 1) * 3;
+        P_0[3 * k] = up[P_tmp];
+        P_0[3 * k + 1] = up[P_tmp + 1];
+        P_0[3 * k + 2] = up[P_tmp + 2];
+      }
+
+      // :  m = [sqrt(q(1,1)^2+q(1,2)^2) sqrt(q(2,1)^2+q(2,2)^2) sqrt(q(3,1)^2+q(3,2)^2)]; 
+      absx = std::sqrt(P_0[0] * P_0[0] + P_0[3] * P_0[3]);
+      xa_idx_1 = std::sqrt(P_0[1] * P_0[1] + P_0[4] * P_0[4]);
+      xa_idx_2 = std::sqrt(P_0[2] * P_0[2] + P_0[5] * P_0[5]);
+
+      // :  if min(abs(m)) == 0
+      xb[0] = absx;
+      xb[1] = xa_idx_1;
+      xb[2] = xa_idx_2;
+      guard11 = false;
+      if (minimum(xb) == 0.0) {
+        // :  if step > 0.001
+        if (step_0 > 0.001) {
+          // :  step = 0.5*step;
+          step_0 *= 0.5;
+
+          // :  T = Told;
+          rtDW.T = Told;
+          guard11 = true;
+        } else if (first_try) {
+          // :  elseif first_try
+          // :  first_try = false;
+          first_try = false;
+
+          // :  step = 0.01;
+          step_0 = 0.01;
+
+          // :  hyaw = 0.1666*(theta_diff(1)+theta_diff(2)+theta_diff(3));
+          absx = ((rtb_Gain_o_idx_0 + rtb_Gain_o_idx_1) + rtb_Gain_o_idx_2) *
+            0.1666;
+
+          // :  T = quaternion(cosd(hyaw),0,0,sind(0.5*hyaw));
+          rtDW.T.a = absx;
+          cosd_f(&rtDW.T.a);
+          rtDW.T.b = 0.0;
+          rtDW.T.c = 0.0;
+          rtDW.T.d = 0.5 * absx;
+          sind_c(&rtDW.T.d);
+          guard11 = true;
+        } else {
+          guard1 = true;
+          exitg1 = 1;
+        }
+      } else {
+        // :  arg = [(PQ(1)-Pz(1)*q(1,3))/m(1); (PQ(2)-Pz(2)*q(2,3))/m(2); (PQ(3)-Pz(3)*q(3,3))/m(3)]; 
+        yb[0] = (rtDW.PQ_c[0] - rtDW.Pz_i[0] * up_tmp_1) / absx;
+        yb[1] = (rtDW.PQ_c[1] - rtDW.Pz_i[1] * up_tmp_4) / xa_idx_1;
+        yb[2] = (rtDW.PQ_c[2] - rtDW.Pz_i[2] * theta) / xa_idx_2;
+
+        // :  if max(abs(arg)) > 1.0
+        xb[0] = std::abs(yb[0]);
+        xb[1] = std::abs(yb[1]);
+        xb[2] = std::abs(yb[2]);
+        if (maximum(xb) > 1.0) {
+          // :  if step > 0.001
+          if (step_0 > 0.001) {
+            // :  step = 0.5*step;
+            step_0 *= 0.5;
+
+            // :  T = Told;
+            rtDW.T = Told;
+            guard11 = true;
+          } else if (first_try) {
+            // :  elseif first_try
+            // :  first_try = false;
+            first_try = false;
+
+            // :  step = 0.01;
+            step_0 = 0.01;
+
+            // :  hyaw = 0.1666*(theta_diff(1)+theta_diff(2)+theta_diff(3));
+            absx = ((rtb_Gain_o_idx_0 + rtb_Gain_o_idx_1) + rtb_Gain_o_idx_2) *
+              0.1666;
+
+            // :  T = quaternion(cosd(hyaw),0,0,sind(0.5*hyaw));
+            rtDW.T.a = absx;
+            cosd_f(&rtDW.T.a);
+            rtDW.T.b = 0.0;
+            rtDW.T.c = 0.0;
+            rtDW.T.d = 0.5 * absx;
+            sind_c(&rtDW.T.d);
+            guard11 = true;
+          } else {
+            guard1 = true;
+            exitg1 = 1;
+          }
+        } else {
+          // :  theta = atan2d(q(:,2),q(:,1))+[90; 90; 90;]-asind(arg);
+          // :  theta_err = Wrap180(theta_diff+theta_off-theta);
+          // :  y = x;
+          // :  for i=1:3
+          // :  if max(abs(theta_err)) < 0.1
+          st = (57.295779513082323 * rt_atan2d_snf(P_0[3], P_0[0]) + 90.0) -
+            57.295779513082323 * std::asin(yb[0]);
+          ya[0] = st;
+
+          // :  while y(i) >= 180.0
+          for (absx = (rtb_Gain_o_idx_0 + rtU.theta_off[0]) - st; absx >= 180.0;
+               absx -= 360.0) {
+            // :  y(i) = y(i) - 360.0;
+          }
+
+          // :  while y(i) < -180.0
+          while (absx < -180.0) {
+            // :  y(i) = y(i) + 360.0;
+            absx += 360.0;
+          }
+
+          xb[0] = std::abs(absx);
+          st = (57.295779513082323 * rt_atan2d_snf(P_0[4], P_0[1]) + 90.0) -
+            57.295779513082323 * std::asin(yb[1]);
+          ya[1] = st;
+
+          // :  while y(i) >= 180.0
+          for (xa_idx_1 = (rtb_Gain_o_idx_1 + rtU.theta_off[1]) - st; xa_idx_1 >=
+               180.0; xa_idx_1 -= 360.0) {
+            // :  y(i) = y(i) - 360.0;
+          }
+
+          // :  while y(i) < -180.0
+          while (xa_idx_1 < -180.0) {
+            // :  y(i) = y(i) + 360.0;
+            xa_idx_1 += 360.0;
+          }
+
+          xb[1] = std::abs(xa_idx_1);
+          st = (57.295779513082323 * rt_atan2d_snf(P_0[5], P_0[2]) + 90.0) -
+            57.295779513082323 * std::asin(yb[2]);
+          ya[2] = st;
+
+          // :  while y(i) >= 180.0
+          for (xa_idx_2 = (rtb_Gain_o_idx_2 + rtU.theta_off[2]) - st; xa_idx_2 >=
+               180.0; xa_idx_2 -= 360.0) {
+            // :  y(i) = y(i) - 360.0;
+          }
+
+          // :  while y(i) < -180.0
+          while (xa_idx_2 < -180.0) {
+            // :  y(i) = y(i) + 360.0;
+            xa_idx_2 += 360.0;
+          }
+
+          xb[2] = std::abs(xa_idx_2);
+          if (maximum(xb) < 0.1) {
+            // :  T = normalize(T);
+            rtDW.T.a = yc_idx_2;
+            rtDW.T.b = rtb_Product1_tmp;
+            rtDW.T.c = rtb_Product2_tmp;
+            rtDW.T.d = b_n_tmp;
+
+            // :  attitude = compact(T);
+            rtDW.attitude_ok[0] = rtDW.T.a;
+            rtDW.attitude_ok[1] = rtDW.T.b;
+            rtDW.attitude_ok[2] = rtDW.T.c;
+            rtDW.attitude_ok[3] = rtDW.T.d;
+
+            // :  attitude_ok = attitude;
+            exitg1 = 1;
+          } else {
+            // :  p = [cosd(theta) sind(theta) Pz];
+            yb[0] = ya[0];
+            yb[1] = ya[1];
+            yb[2] = st;
+            cosd(yb);
+            sind(ya);
+            P_0[3] = ya[0];
+            P_0[1] = yb[1];
+            P_0[4] = ya[1];
+            P_0[2] = yb[2];
+            P_0[5] = ya[2];
+
+            // :  q1xp1 = cross(q(1,:),p(1,:));
+            ya[0] = rtDW.Pz_i[0] * up_tmp_0 - P_0[3] * up_tmp_1;
+            ya[1] = yb[0] * up_tmp_1 - rtDW.Pz_i[0] * up_tmp;
+            ya[2] = up_tmp * P_0[3] - yb[0] * up_tmp_0;
+
+            // :  q2xp2 = cross(q(2,:),p(2,:));
+            yb[0] = rtDW.Pz_i[1] * up_tmp_3 - P_0[4] * up_tmp_4;
+            yb[1] = P_0[1] * up_tmp_4 - rtDW.Pz_i[1] * up_tmp_2;
+            yb[2] = up_tmp_2 * P_0[4] - P_0[1] * up_tmp_3;
+
+            // :  q3xp3 = cross(q(3,:),p(3,:));
+            yc_idx_2 = b_n * P_0[5] - P_0[2] * b_yc;
+
+            // :  if min(abs([q1xp1(3) q2xp2(3) q3xp3(3)])) == 0.0
+            xb[0] = std::abs(ya[2]);
+            xb[1] = std::abs(yb[2]);
+            xb[2] = std::abs(yc_idx_2);
+            if (minimum(xb) == 0.0) {
+              // :  if step > 0.001
+              if (step_0 > 0.001) {
+                // :  step = 0.5*step;
+                step_0 *= 0.5;
+
+                // :  T = Told;
+                rtDW.T = Told;
+                guard11 = true;
+              } else if (first_try) {
+                // :  elseif first_try
+                // :  first_try = false;
+                first_try = false;
+
+                // :  step = 0.01;
+                step_0 = 0.01;
+
+                // :  hyaw = 0.1666*(theta_diff(1)+theta_diff(2)+theta_diff(3)); 
+                absx = ((rtb_Gain_o_idx_0 + rtb_Gain_o_idx_1) + rtb_Gain_o_idx_2)
+                  * 0.1666;
+
+                // :  T = quaternion(cosd(hyaw),0,0,sind(0.5*hyaw));
+                rtDW.T.a = absx;
+                cosd_f(&rtDW.T.a);
+                rtDW.T.b = 0.0;
+                rtDW.T.c = 0.0;
+                rtDW.T.d = 0.5 * absx;
+                sind_c(&rtDW.T.d);
+                guard11 = true;
+              } else {
+                guard1 = true;
+                exitg1 = 1;
+              }
+            } else {
+              // :  if det([q1xp1/q1xp1(3); q2xp2/q2xp2(3); q3xp3/q3xp3(3)]) == 0.0 
+              st = ya[0] / ya[2];
+              ya_0[0] = st;
+              b_n_tmp = yb[0] / yb[2];
+              ya_0[1] = b_n_tmp;
+              b_yc = (rtDW.Pz_i[2] * b_yc - P_0[5] * theta) / yc_idx_2;
+              ya_0[2] = b_yc;
+              rtb_Product1_tmp = ya[1] / ya[2];
+              ya_0[3] = rtb_Product1_tmp;
+              rtb_Product2_tmp = yb[1] / yb[2];
+              ya_0[4] = rtb_Product2_tmp;
+              b_n = (P_0[2] * theta - rtDW.Pz_i[2] * b_n) / yc_idx_2;
+              ya_0[5] = b_n;
+              theta = ya[2] / ya[2];
+              ya_0[6] = theta;
+              up_tmp = yb[2] / yb[2];
+              ya_0[7] = up_tmp;
+              yc_idx_2 /= yc_idx_2;
+              ya_0[8] = yc_idx_2;
+              if (det(ya_0) == 0.0) {
+                // :  if step > 0.001
+                if (step_0 > 0.001) {
+                  // :  step = 0.5*step;
+                  step_0 *= 0.5;
+
+                  // :  T = Told;
+                  rtDW.T = Told;
+                  guard11 = true;
+                } else if (first_try) {
+                  // :  elseif first_try
+                  // :  first_try = false;
+                  first_try = false;
+
+                  // :  step = 0.01;
+                  step_0 = 0.01;
+
+                  // :  hyaw = 0.1666*(theta_diff(1)+theta_diff(2)+theta_diff(3)); 
+                  absx = ((rtb_Gain_o_idx_0 + rtb_Gain_o_idx_1) +
+                          rtb_Gain_o_idx_2) * 0.1666;
+
+                  // :  T = quaternion(cosd(hyaw),0,0,sind(0.5*hyaw));
+                  rtDW.T.a = absx;
+                  cosd_f(&rtDW.T.a);
+                  rtDW.T.b = 0.0;
+                  rtDW.T.c = 0.0;
+                  rtDW.T.d = 0.5 * absx;
+                  sind_c(&rtDW.T.d);
+                  guard11 = true;
+                } else {
+                  guard1 = true;
+                  exitg1 = 1;
+                }
+              } else {
+                // :  Told = T;
+                Told = rtDW.T;
+
+                // :  T = quaternion(([q1xp1/q1xp1(3); q2xp2/q2xp2(3); q3xp3/q3xp3(3)]\(step*theta_err))','rotvec')*T; 
+                ya_0[0] = st;
+                ya_0[1] = b_n_tmp;
+                ya_0[2] = b_yc;
+                ya[0] = step_0 * absx;
+                ya_0[3] = rtb_Product1_tmp;
+                ya_0[4] = rtb_Product2_tmp;
+                ya_0[5] = b_n;
+                ya[1] = step_0 * xa_idx_1;
+                ya_0[6] = theta;
+                ya_0[7] = up_tmp;
+                ya_0[8] = yc_idx_2;
+                ya[2] = step_0 * xa_idx_2;
+                mldivide(ya_0, ya, yb);
+                absx = 1.0;
+                xa_idx_1 = 0.0;
+                xa_idx_2 = 0.0;
+                b_n = 0.0;
+                ya[0] = yb[0] * yb[0];
+                ya[1] = yb[1] * yb[1];
+                ya[2] = yb[2] * yb[2];
+                theta = std::sqrt((ya[0] + ya[1]) + ya[2]);
+                st = std::sin(theta / 2.0);
+                if (theta != 0.0) {
+                  yb[0] = yb[0] / theta * st;
+                  yb[1] = yb[1] / theta * st;
+                  yb[2] = yb[2] / theta * st;
+                  absx = std::cos(theta / 2.0);
+                  xa_idx_1 = yb[0];
+                  xa_idx_2 = yb[1];
+                  b_n = yb[2];
+                }
+
+                theta = rtDW.T.a;
+                st = rtDW.T.b;
+                b_yc = rtDW.T.c;
+                rtDW.T.a = ((absx * rtDW.T.a - xa_idx_1 * rtDW.T.b) - xa_idx_2 *
+                            rtDW.T.c) - b_n * rtDW.T.d;
+                rtDW.T.b = ((absx * rtDW.T.b + xa_idx_1 * theta) + xa_idx_2 *
+                            rtDW.T.d) - b_n * rtDW.T.c;
+                rtDW.T.c = ((absx * rtDW.T.c - xa_idx_1 * rtDW.T.d) + xa_idx_2 *
+                            theta) + b_n * st;
+                rtDW.T.d = ((absx * rtDW.T.d + xa_idx_1 * b_yc) - xa_idx_2 * st)
+                  + b_n * theta;
+                guard11 = true;
+              }
+            }
+          }
+        }
+      }
+
+      if (guard11) {
+        idx++;
+        guard1 = false;
+      }
+    } else {
+      guard1 = true;
+      exitg1 = 1;
+    }
+  } while (exitg1 == 0);
+
+  if (guard1) {
     // :  T = quaternion(1,0,0,0);
     rtDW.T.a = 1.0;
     rtDW.T.b = 0.0;
     rtDW.T.c = 0.0;
     rtDW.T.d = 0.0;
 
-    // :  singularity_reg = 0;
-    rtDW.singularity_reg_not_empty = true;
-  }
-
-  // :  theta_diff = Wrap180(theta_diff);
-  // :  y = x;
-  // :  for i=1:3
-  // :  if max(abs(theta_diff)) < 5.0
-  // :  while y(i) > 180.0
-  while (rtb_Gain_o_idx_0 > 180.0) {
-    // :  y(i) = y(i) - 360.0;
-    rtb_Gain_o_idx_0 -= 360.0;
-  }
-
-  // :  while y(i) < -180.0
-  while (rtb_Gain_o_idx_0 < -180.0) {
-    // :  y(i) = y(i) + 360.0;
-    rtb_Gain_o_idx_0 += 360.0;
-  }
-
-  xa[0] = std::abs(rtb_Gain_o_idx_0);
-
-  // :  while y(i) > 180.0
-  while (rtb_Gain_o_idx_1 > 180.0) {
-    // :  y(i) = y(i) - 360.0;
-    rtb_Gain_o_idx_1 -= 360.0;
-  }
-
-  // :  while y(i) < -180.0
-  while (rtb_Gain_o_idx_1 < -180.0) {
-    // :  y(i) = y(i) + 360.0;
-    rtb_Gain_o_idx_1 += 360.0;
-  }
-
-  xa[1] = std::abs(rtb_Gain_o_idx_1);
-
-  // :  while y(i) > 180.0
-  while (rtb_Gain_o_idx_2 > 180.0) {
-    // :  y(i) = y(i) - 360.0;
-    rtb_Gain_o_idx_2 -= 360.0;
-  }
-
-  // :  while y(i) < -180.0
-  while (rtb_Gain_o_idx_2 < -180.0) {
-    // :  y(i) = y(i) + 360.0;
-    rtb_Gain_o_idx_2 += 360.0;
-  }
-
-  xa[2] = std::abs(rtb_Gain_o_idx_2);
-  if (maximum(xa) < 5.0) {
-    // :  singularity_reg = 0;
-    rtDW.singularity_reg = 0.0;
-  }
-
-  // :  if singularity_reg
-  if (rtDW.singularity_reg != 0.0) {
-    // :  attitude = compact(T);
-    rtb_attitude_idx_0 = rtDW.T.a;
-    yc_idx_2 = rtDW.T.b;
-    b_n = rtDW.T.c;
-    st = rtDW.T.d;
-
-    // Outport: '<Root>/singularity'
-    // :  singularity = singularity_reg;
-    rtY.singularity = rtDW.singularity_reg;
-
-    // :  cycles = 0;
-    cycles = 0;
-  } else {
-    // :  for cycles=1:200
-    cycles = 1;
-    idx = 0;
-    guard1 = false;
-    do {
-      exitg1 = 0;
-      if (idx < 200) {
-        cycles = idx + 1;
-
-        // :  q = rotatepoint(T,Q);
-        theta = std::sqrt(((rtDW.T.a * rtDW.T.a + rtDW.T.b * rtDW.T.b) +
-                           rtDW.T.c * rtDW.T.c) + rtDW.T.d * rtDW.T.d);
-        rtb_attitude_idx_0 = rtDW.T.a / theta;
-        yc_idx_2 = rtDW.T.b / theta;
-        b_n = rtDW.T.c / theta;
-        st = rtDW.T.d / theta;
-        up[0] = 0.0;
-        up[1] = 0.0;
-        up[2] = 0.0;
-        std::memcpy(&up[3], &rtDW.Q_p[0], 9U * sizeof(real_T));
-        yb[0] = ((rtb_attitude_idx_0 * up[0] - yc_idx_2 * up[3]) - b_n * up[6])
-          - st * up[9];
-        ya[0] = ((rtb_attitude_idx_0 * up[3] + yc_idx_2 * up[0]) + b_n * up[9])
-          - st * up[6];
-        xa[0] = ((rtb_attitude_idx_0 * up[6] - yc_idx_2 * up[9]) + b_n * up[0])
-          + st * up[3];
-        xb[0] = ((rtb_attitude_idx_0 * up[9] + yc_idx_2 * up[6]) - b_n * up[3])
-          + st * up[0];
-        yb[1] = ((rtb_attitude_idx_0 * up[1] - yc_idx_2 * up[4]) - b_n * up[7])
-          - st * up[10];
-        ya[1] = ((rtb_attitude_idx_0 * up[4] + yc_idx_2 * up[1]) + b_n * up[10])
-          - st * up[7];
-        xa[1] = ((rtb_attitude_idx_0 * up[7] - yc_idx_2 * up[10]) + b_n * up[1])
-          + st * up[4];
-        xb[1] = ((rtb_attitude_idx_0 * up[10] + yc_idx_2 * up[7]) - b_n * up[4])
-          + st * up[1];
-        yb[2] = ((rtb_attitude_idx_0 * up[2] - yc_idx_2 * up[5]) - b_n * up[8])
-          - st * up[11];
-        ya[2] = ((rtb_attitude_idx_0 * up[5] + yc_idx_2 * up[2]) + b_n * up[11])
-          - st * up[8];
-        xa[2] = ((rtb_attitude_idx_0 * up[8] - yc_idx_2 * up[11]) + b_n * up[2])
-          + st * up[5];
-        xb[2] = ((rtb_attitude_idx_0 * up[11] + yc_idx_2 * up[8]) - b_n * up[5])
-          + st * up[2];
-        up_tmp = ((yb[0] * -yc_idx_2 + ya[0] * rtb_attitude_idx_0) + xa[0] * -st)
-          - xb[0] * -b_n;
-        up_tmp_0 = ((yb[0] * -b_n - ya[0] * -st) + xa[0] * rtb_attitude_idx_0) +
-          xb[0] * -yc_idx_2;
-        up_tmp_1 = ((yb[0] * -st + ya[0] * -b_n) - xa[0] * -yc_idx_2) + xb[0] *
-          rtb_attitude_idx_0;
-        up[0] = ((yb[0] * rtb_attitude_idx_0 - ya[0] * -yc_idx_2) - xa[0] * -b_n)
-          - xb[0] * -st;
-        up[3] = up_tmp;
-        up[6] = up_tmp_0;
-        up[9] = up_tmp_1;
-        up_tmp_2 = ((yb[1] * -yc_idx_2 + ya[1] * rtb_attitude_idx_0) + xa[1] *
-                    -st) - xb[1] * -b_n;
-        up_tmp_3 = ((yb[1] * -b_n - ya[1] * -st) + xa[1] * rtb_attitude_idx_0) +
-          xb[1] * -yc_idx_2;
-        up_tmp_4 = ((yb[1] * -st + ya[1] * -b_n) - xa[1] * -yc_idx_2) + xb[1] *
-          rtb_attitude_idx_0;
-        up[1] = ((yb[1] * rtb_attitude_idx_0 - ya[1] * -yc_idx_2) - xa[1] * -b_n)
-          - xb[1] * -st;
-        up[4] = up_tmp_2;
-        up[7] = up_tmp_3;
-        up[10] = up_tmp_4;
-        theta = ((yb[2] * -yc_idx_2 + ya[2] * rtb_attitude_idx_0) + xa[2] * -st)
-          - xb[2] * -b_n;
-        rtb_Product1 = ((yb[2] * -b_n - ya[2] * -st) + xa[2] *
-                        rtb_attitude_idx_0) + xb[2] * -yc_idx_2;
-        maxval = ((yb[2] * -st + ya[2] * -b_n) - xa[2] * -yc_idx_2) + xb[2] *
-          rtb_attitude_idx_0;
-        up[2] = ((yb[2] * rtb_attitude_idx_0 - ya[2] * -yc_idx_2) - xa[2] * -b_n)
-          - xb[2] * -st;
-        up[5] = theta;
-        up[8] = rtb_Product1;
-        up[11] = maxval;
-        for (r1 = 0; r1 < 3; r1++) {
-          r2 = (r1 + 1) * 3;
-          P_0[3 * r1] = up[r2];
-          P_0[3 * r1 + 1] = up[r2 + 1];
-          P_0[3 * r1 + 2] = up[r2 + 2];
-        }
-
-        // :  m = [sqrt(q(1,1)^2+q(1,2)^2) sqrt(q(2,1)^2+q(2,2)^2) sqrt(q(3,1)^2+q(3,2)^2)]; 
-        absx = std::sqrt(P_0[0] * P_0[0] + P_0[3] * P_0[3]);
-        tmp = std::sqrt(P_0[1] * P_0[1] + P_0[4] * P_0[4]);
-        tmp_0 = std::sqrt(P_0[2] * P_0[2] + P_0[5] * P_0[5]);
-
-        // :  if min(abs(m)) == 0
-        xa[0] = absx;
-        xa[1] = tmp;
-        xa[2] = tmp_0;
-        if (minimum(xa) == 0.0) {
-          // :  cycles = -1;
-          cycles = -1;
-          guard1 = true;
-          exitg1 = 1;
-        } else {
-          // :  arg = [(PQ(1)-Pz(1)*q(1,3))/m(1); (PQ(2)-Pz(2)*q(2,3))/m(2); (PQ(3)-Pz(3)*q(3,3))/m(3)]; 
-          yb[0] = (rtDW.PQ_f[0] - rtDW.Pz_b[0] * up_tmp_1) / absx;
-          yb[1] = (rtDW.PQ_f[1] - rtDW.Pz_b[1] * up_tmp_4) / tmp;
-          yb[2] = (rtDW.PQ_f[2] - rtDW.Pz_b[2] * maxval) / tmp_0;
-
-          // :  if max(abs(arg)) > 1.0
-          xa[0] = std::abs(yb[0]);
-          xa[1] = std::abs(yb[1]);
-          xa[2] = std::abs(yb[2]);
-          if (maximum(xa) > 1.0) {
-            // :  cycles = -2;
-            cycles = -2;
-            guard1 = true;
-            exitg1 = 1;
-          } else {
-            // :  theta = atan2d(q(:,2),q(:,1))+[90; 90; 90;]-asind(arg);
-            // :  theta_err = Wrap180(theta_diff+theta_off-theta);
-            // :  y = x;
-            // :  for i=1:3
-            // :  if max(abs(theta_err)) < 0.01
-            absx = (57.295779513082323 * rt_atan2d_snf(P_0[3], P_0[0]) + 90.0) -
-              57.295779513082323 * std::asin(yb[0]);
-            ya[0] = absx;
-            xb[0] = (rtb_Gain_o_idx_0 + rtU.theta_off[0]) - absx;
-
-            // :  while y(i) > 180.0
-            while (xb[0] > 180.0) {
-              // :  y(i) = y(i) - 360.0;
-              xb[0] -= 360.0;
-            }
-
-            // :  while y(i) < -180.0
-            while (xb[0] < -180.0) {
-              // :  y(i) = y(i) + 360.0;
-              xb[0] += 360.0;
-            }
-
-            xa[0] = std::abs(xb[0]);
-            absx = (57.295779513082323 * rt_atan2d_snf(P_0[4], P_0[1]) + 90.0) -
-              57.295779513082323 * std::asin(yb[1]);
-            ya[1] = absx;
-            xb[1] = (rtb_Gain_o_idx_1 + rtU.theta_off[1]) - absx;
-
-            // :  while y(i) > 180.0
-            while (xb[1] > 180.0) {
-              // :  y(i) = y(i) - 360.0;
-              xb[1] -= 360.0;
-            }
-
-            // :  while y(i) < -180.0
-            while (xb[1] < -180.0) {
-              // :  y(i) = y(i) + 360.0;
-              xb[1] += 360.0;
-            }
-
-            xa[1] = std::abs(xb[1]);
-            absx = (57.295779513082323 * rt_atan2d_snf(P_0[5], P_0[2]) + 90.0) -
-              57.295779513082323 * std::asin(yb[2]);
-            ya[2] = absx;
-            xb[2] = (rtb_Gain_o_idx_2 + rtU.theta_off[2]) - absx;
-
-            // :  while y(i) > 180.0
-            while (xb[2] > 180.0) {
-              // :  y(i) = y(i) - 360.0;
-              xb[2] -= 360.0;
-            }
-
-            // :  while y(i) < -180.0
-            while (xb[2] < -180.0) {
-              // :  y(i) = y(i) + 360.0;
-              xb[2] += 360.0;
-            }
-
-            xa[2] = std::abs(xb[2]);
-            if (maximum(xa) < 0.01) {
-              // :  T = normalize(T);
-              rtDW.T.a = rtb_attitude_idx_0;
-              rtDW.T.b = yc_idx_2;
-              rtDW.T.c = b_n;
-              rtDW.T.d = st;
-
-              // :  attitude = compact(T);
-              // :  singularity = singularity_reg;
-              rtY.singularity = rtDW.singularity_reg;
-              exitg1 = 1;
-            } else {
-              // :  p = [cosd(theta) sind(theta) Pz];
-              yb[0] = ya[0];
-              yb[1] = ya[1];
-              yb[2] = absx;
-              cosd(yb);
-              sind(ya);
-              P_0[3] = ya[0];
-              P_0[1] = yb[1];
-              P_0[4] = ya[1];
-              P_0[2] = yb[2];
-              P_0[5] = ya[2];
-
-              // :  q1xp1 = cross(q(1,:),p(1,:));
-              ya[0] = rtDW.Pz_b[0] * up_tmp_0 - P_0[3] * up_tmp_1;
-              ya[1] = yb[0] * up_tmp_1 - rtDW.Pz_b[0] * up_tmp;
-              ya[2] = up_tmp * P_0[3] - yb[0] * up_tmp_0;
-
-              // :  q2xp2 = cross(q(2,:),p(2,:));
-              yb[0] = rtDW.Pz_b[1] * up_tmp_3 - P_0[4] * up_tmp_4;
-              yb[1] = P_0[1] * up_tmp_4 - rtDW.Pz_b[1] * up_tmp_2;
-              yb[2] = up_tmp_2 * P_0[4] - P_0[1] * up_tmp_3;
-
-              // :  q3xp3 = cross(q(3,:),p(3,:));
-              yc_idx_2 = theta * P_0[5] - P_0[2] * rtb_Product1;
-
-              // :  if min(abs([q1xp1(3) q2xp2(3) q3xp3(3)])) == 0.0
-              xa[0] = std::abs(ya[2]);
-              xa[1] = std::abs(yb[2]);
-              xa[2] = std::abs(yc_idx_2);
-              if (minimum(xa) == 0.0) {
-                // :  cycles = -3;
-                cycles = -3;
-                guard1 = true;
-                exitg1 = 1;
-              } else {
-                // :  if det([q1xp1/q1xp1(3); q2xp2/q2xp2(3); q3xp3/q3xp3(3)]) == 0.0 
-                st = ya[0] / ya[2];
-                ya_0[0] = st;
-                absx = yb[0] / yb[2];
-                ya_0[1] = absx;
-                b_n = (rtDW.Pz_b[2] * rtb_Product1 - P_0[5] * maxval) / yc_idx_2;
-                ya_0[2] = b_n;
-                rtb_Product1 = ya[1] / ya[2];
-                ya_0[3] = rtb_Product1;
-                rtb_attitude_idx_0 = yb[1] / yb[2];
-                ya_0[4] = rtb_attitude_idx_0;
-                theta = (P_0[2] * maxval - rtDW.Pz_b[2] * theta) / yc_idx_2;
-                ya_0[5] = theta;
-                maxval = ya[2] / ya[2];
-                ya_0[6] = maxval;
-                up_tmp = yb[2] / yb[2];
-                ya_0[7] = up_tmp;
-                yc_idx_2 /= yc_idx_2;
-                ya_0[8] = yc_idx_2;
-                if (det(ya_0) == 0.0) {
-                  // :  cycles = -4;
-                  cycles = -4;
-                  guard1 = true;
-                  exitg1 = 1;
-                } else {
-                  // :  T = quaternion(([q1xp1/q1xp1(3); q2xp2/q2xp2(3); q3xp3/q3xp3(3)]\(0.02*theta_err))','rotvec')*T; 
-                  xb[0] *= 0.02;
-                  P_0[0] = st;
-                  P_0[1] = absx;
-                  P_0[2] = b_n;
-                  xb[1] *= 0.02;
-                  P_0[3] = rtb_Product1;
-                  P_0[4] = rtb_attitude_idx_0;
-                  P_0[5] = theta;
-                  xb[2] *= 0.02;
-                  P_0[6] = maxval;
-                  P_0[7] = up_tmp;
-                  P_0[8] = yc_idx_2;
-                  r1 = 0;
-                  r2 = 1;
-                  r3 = 2;
-                  maxval = std::abs(st);
-                  absx = std::abs(absx);
-                  if (absx > maxval) {
-                    maxval = absx;
-                    r1 = 1;
-                    r2 = 0;
-                  }
-
-                  if (std::abs(b_n) > maxval) {
-                    r1 = 2;
-                    r2 = 1;
-                    r3 = 0;
-                  }
-
-                  P_0[r2] /= P_0[r1];
-                  P_0[r3] /= P_0[r1];
-                  P_0[r2 + 3] -= P_0[r1 + 3] * P_0[r2];
-                  P_0[r3 + 3] -= P_0[r1 + 3] * P_0[r3];
-                  P_0[r2 + 6] -= P_0[r1 + 6] * P_0[r2];
-                  P_0[r3 + 6] -= P_0[r1 + 6] * P_0[r3];
-                  if (std::abs(P_0[r3 + 3]) > std::abs(P_0[r2 + 3])) {
-                    rtemp = r2;
-                    r2 = r3;
-                    r3 = rtemp;
-                  }
-
-                  P_0[r3 + 3] /= P_0[r2 + 3];
-                  P_0[r3 + 6] -= P_0[r3 + 3] * P_0[r2 + 6];
-                  yb[1] = xb[r2] - xb[r1] * P_0[r2];
-                  yb[2] = (xb[r3] - xb[r1] * P_0[r3]) - P_0[r3 + 3] * yb[1];
-                  yb[2] /= P_0[r3 + 6];
-                  yb[0] = xb[r1] - P_0[r1 + 6] * yb[2];
-                  yb[1] -= P_0[r2 + 6] * yb[2];
-                  yb[1] /= P_0[r2 + 3];
-                  yb[0] -= P_0[r1 + 3] * yb[1];
-                  yb[0] /= P_0[r1];
-                  maxval = 1.0;
-                  absx = 0.0;
-                  rtb_Product1 = 0.0;
-                  b_n = 0.0;
-                  ya[0] = yb[0] * yb[0];
-                  ya[1] = yb[1] * yb[1];
-                  ya[2] = yb[2] * yb[2];
-                  theta = std::sqrt((ya[0] + ya[1]) + ya[2]);
-                  st = std::sin(theta / 2.0);
-                  if (theta != 0.0) {
-                    yb[0] = yb[0] / theta * st;
-                    yb[1] = yb[1] / theta * st;
-                    yb[2] = yb[2] / theta * st;
-                    maxval = std::cos(theta / 2.0);
-                    absx = yb[0];
-                    rtb_Product1 = yb[1];
-                    b_n = yb[2];
-                  }
-
-                  theta = rtDW.T.a;
-                  st = rtDW.T.b;
-                  yc_idx_2 = rtDW.T.c;
-                  rtDW.T.a = ((maxval * rtDW.T.a - absx * rtDW.T.b) -
-                              rtb_Product1 * rtDW.T.c) - b_n * rtDW.T.d;
-                  rtDW.T.b = ((maxval * rtDW.T.b + absx * theta) + rtb_Product1 *
-                              rtDW.T.d) - b_n * rtDW.T.c;
-                  rtDW.T.c = ((maxval * rtDW.T.c - absx * rtDW.T.d) +
-                              rtb_Product1 * theta) + b_n * st;
-                  rtDW.T.d = ((maxval * rtDW.T.d + absx * yc_idx_2) -
-                              rtb_Product1 * st) + b_n * theta;
-                  idx++;
-                  guard1 = false;
-                }
-              }
-            }
-          }
-        }
-      } else {
-        guard1 = true;
-        exitg1 = 1;
-      }
-    } while (exitg1 == 0);
-
-    if (guard1) {
-      // :  T = quaternion(1,0,0,0);
-      rtDW.T.a = 1.0;
-      rtDW.T.b = 0.0;
-      rtDW.T.c = 0.0;
-      rtDW.T.d = 0.0;
-
-      // :  attitude = compact(T);
-      rtb_attitude_idx_0 = rtDW.T.a;
-      yc_idx_2 = rtDW.T.b;
-      b_n = rtDW.T.b;
-      st = rtDW.T.b;
-
-      // :  singularity_reg = 1;
-      rtDW.singularity_reg = 1.0;
-
-      // :  singularity = singularity_reg;
-      rtY.singularity = 1.0;
-    }
+    // :  attitude = attitude_ok;
+    // :  singularity = 1;
+    singularity = 1;
   }
 
   // Sqrt: '<S12>/sqrt' incorporates:
+  //   MATLAB Function: '<S1>/motors2ypr'
   //   Product: '<S13>/Product'
   //   Product: '<S13>/Product1'
   //   Product: '<S13>/Product2'
   //   Product: '<S13>/Product3'
   //   Sum: '<S13>/Sum'
 
-  maxval = std::sqrt(((rtb_attitude_idx_0 * rtb_attitude_idx_0 + yc_idx_2 *
-                       yc_idx_2) + b_n * b_n) + st * st);
+  step_0 = std::sqrt(((rtDW.attitude_ok[0] * rtDW.attitude_ok[0] +
+                       rtDW.attitude_ok[1] * rtDW.attitude_ok[1]) +
+                      rtDW.attitude_ok[2] * rtDW.attitude_ok[2]) +
+                     rtDW.attitude_ok[3] * rtDW.attitude_ok[3]);
 
-  // Product: '<S7>/Product'
-  absx = rtb_attitude_idx_0 / maxval;
+  // Product: '<S7>/Product' incorporates:
+  //   MATLAB Function: '<S1>/motors2ypr'
 
-  // Product: '<S7>/Product1'
-  rtb_Product1 = yc_idx_2 / maxval;
+  absx = rtDW.attitude_ok[0] / step_0;
 
-  // Product: '<S7>/Product2'
-  b_n /= maxval;
+  // Product: '<S7>/Product1' incorporates:
+  //   MATLAB Function: '<S1>/motors2ypr'
 
-  // Product: '<S7>/Product3'
-  maxval = st / maxval;
+  xa_idx_1 = rtDW.attitude_ok[1] / step_0;
+
+  // Product: '<S7>/Product2' incorporates:
+  //   MATLAB Function: '<S1>/motors2ypr'
+
+  xa_idx_2 = rtDW.attitude_ok[2] / step_0;
+
+  // Product: '<S7>/Product3' incorporates:
+  //   MATLAB Function: '<S1>/motors2ypr'
+
+  step_0 = rtDW.attitude_ok[3] / step_0;
 
   // Fcn: '<S2>/fcn3'
-  theta = (rtb_Product1 * maxval - absx * b_n) * -2.0;
+  b_n = (xa_idx_1 * step_0 - absx * xa_idx_2) * -2.0;
 
   // Fcn: '<S2>/fcn2' incorporates:
   //   Fcn: '<S2>/fcn5'
 
   rtb_Gain_o_idx_2 = absx * absx;
-  rtb_Gain_o_idx_1 = rtb_Product1 * rtb_Product1;
-  st = b_n * b_n;
-  yc_idx_2 = maxval * maxval;
+  rtb_Gain_o_idx_1 = xa_idx_1 * xa_idx_1;
+  theta = xa_idx_2 * xa_idx_2;
+  st = step_0 * step_0;
 
   // Gain: '<S3>/Gain' incorporates:
   //   Fcn: '<S2>/fcn1'
   //   Fcn: '<S2>/fcn2'
   //   Trigonometry: '<S6>/Trigonometric Function1'
 
-  rtb_Gain_o_idx_0 = rt_atan2d_snf((rtb_Product1 * b_n + absx * maxval) * 2.0,
-    ((rtb_Gain_o_idx_2 + rtb_Gain_o_idx_1) - st) - yc_idx_2) *
-    57.295779513082323;
+  rtb_Gain_o_idx_0 = rt_atan2d_snf((xa_idx_1 * xa_idx_2 + absx * step_0) * 2.0,
+    ((rtb_Gain_o_idx_2 + rtb_Gain_o_idx_1) - theta) - st) * 57.295779513082323;
 
   // If: '<S8>/If' incorporates:
   //   Constant: '<S10>/Constant'
   //   Constant: '<S9>/Constant'
 
-  if (theta > 1.0) {
+  if (b_n > 1.0) {
     // Outputs for IfAction SubSystem: '<S8>/If Action Subsystem' incorporates:
     //   ActionPort: '<S9>/Action Port'
 
-    theta = 1.0;
+    b_n = 1.0;
 
     // End of Outputs for SubSystem: '<S8>/If Action Subsystem'
-  } else if (theta < -1.0) {
+  } else if (b_n < -1.0) {
     // Outputs for IfAction SubSystem: '<S8>/If Action Subsystem1' incorporates:
     //   ActionPort: '<S10>/Action Port'
 
-    theta = 1.0;
+    b_n = 1.0;
 
     // End of Outputs for SubSystem: '<S8>/If Action Subsystem1'
   }
@@ -1445,9 +1696,8 @@ void wrist_decoupler::step()
   //   Fcn: '<S2>/fcn5'
   //   Trigonometry: '<S6>/Trigonometric Function3'
 
-  rtb_Gain_o_idx_2 = rt_atan2d_snf((b_n * maxval + absx * rtb_Product1) * 2.0,
-    ((rtb_Gain_o_idx_2 - rtb_Gain_o_idx_1) - st) + yc_idx_2) *
-    57.295779513082323;
+  rtb_Gain_o_idx_2 = rt_atan2d_snf((xa_idx_2 * step_0 + absx * xa_idx_1) * 2.0,
+    ((rtb_Gain_o_idx_2 - rtb_Gain_o_idx_1) - theta) + st) * 57.295779513082323;
 
   // MATLAB Function: '<S1>/ypr2motors' incorporates:
   //   Inport: '<Root>/arm_bend'
@@ -1458,45 +1708,45 @@ void wrist_decoupler::step()
   if (!rtDW.Pz_not_empty) {
     // :  Pz = -tand(arm_bend)*[1; 1; 1];
     if (rtIsInf(rtU.arm_bend) || rtIsNaN(rtU.arm_bend)) {
-      maxval = (rtNaN);
+      step_0 = (rtNaN);
     } else {
-      maxval = rt_remd_snf(rtU.arm_bend, 360.0);
-      absx = std::abs(maxval);
+      step_0 = rt_remd_snf(rtU.arm_bend, 360.0);
+      absx = std::abs(step_0);
       if (absx > 180.0) {
-        if (maxval > 0.0) {
-          maxval -= 360.0;
+        if (step_0 > 0.0) {
+          step_0 -= 360.0;
         } else {
-          maxval += 360.0;
+          step_0 += 360.0;
         }
 
-        absx = std::abs(maxval);
+        absx = std::abs(step_0);
       }
 
       if (absx <= 45.0) {
-        maxval *= 0.017453292519943295;
+        step_0 *= 0.017453292519943295;
         n = 0;
       } else if (absx <= 135.0) {
-        if (maxval > 0.0) {
-          maxval = (maxval - 90.0) * 0.017453292519943295;
+        if (step_0 > 0.0) {
+          step_0 = (step_0 - 90.0) * 0.017453292519943295;
           n = 1;
         } else {
-          maxval = (maxval + 90.0) * 0.017453292519943295;
+          step_0 = (step_0 + 90.0) * 0.017453292519943295;
           n = -1;
         }
-      } else if (maxval > 0.0) {
-        maxval = (maxval - 180.0) * 0.017453292519943295;
+      } else if (step_0 > 0.0) {
+        step_0 = (step_0 - 180.0) * 0.017453292519943295;
         n = 2;
       } else {
-        maxval = (maxval + 180.0) * 0.017453292519943295;
+        step_0 = (step_0 + 180.0) * 0.017453292519943295;
         n = -2;
       }
 
-      maxval = std::tan(maxval);
+      step_0 = std::tan(step_0);
       if ((n == 1) || (n == -1)) {
-        absx = 1.0 / maxval;
-        maxval = -(1.0 / maxval);
-        if (rtIsInf(maxval) && (n == 1)) {
-          maxval = absx;
+        absx = 1.0 / step_0;
+        step_0 = -(1.0 / step_0);
+        if (rtIsInf(step_0) && (n == 1)) {
+          step_0 = absx;
         }
       }
     }
@@ -1504,11 +1754,11 @@ void wrist_decoupler::step()
     rtDW.Pz_not_empty = true;
 
     // :  P = [cosd(theta_off) sind(theta_off) Pz];
-    rtDW.Pz[0] = -maxval;
+    rtDW.Pz[0] = -step_0;
     yb[0] = rtU.theta_off[0];
-    rtDW.Pz[1] = -maxval;
+    rtDW.Pz[1] = -step_0;
     yb[1] = rtU.theta_off[1];
-    rtDW.Pz[2] = -maxval;
+    rtDW.Pz[2] = -step_0;
     yb[2] = rtU.theta_off[2];
     cosd(yb);
     ya[0] = rtU.theta_off[0];
@@ -1566,12 +1816,12 @@ void wrist_decoupler::step()
   //   Inport: '<Root>/ypr_star'
   //   Switch: '<S1>/Switch'
 
-  absx *= 0.017453292519943295;
-  rtb_Gain_o_idx_1 = std::cos(absx);
-  maxval = std::sin(absx);
-  absx = 0.017453292519943295 * rtU.ypr_star[1];
-  b_n = std::cos(absx);
-  st = std::sin(absx);
+  st = 0.017453292519943295 * absx;
+  step_0 = std::cos(st);
+  rtb_Gain_o_idx_1 = std::sin(st);
+  st = 0.017453292519943295 * rtU.ypr_star[1];
+  xa_idx_1 = std::cos(st);
+  xa_idx_2 = std::sin(st);
 
   // Switch: '<S1>/Switch' incorporates:
   //   Gain: '<S1>/Gain'
@@ -1588,108 +1838,108 @@ void wrist_decoupler::step()
   //   Inport: '<Root>/theta_off'
   //   Switch: '<S1>/Switch'
 
-  absx *= 0.017453292519943295;
-  rtb_Product1 = std::cos(absx);
-  absx = std::sin(absx);
-  b[0] = rtb_Gain_o_idx_1 * b_n;
-  yc_idx_2 = st * absx;
-  b[3] = yc_idx_2 * rtb_Gain_o_idx_1 - maxval * rtb_Product1;
-  rtb_attitude_idx_0 = st * rtb_Product1;
-  b[6] = rtb_attitude_idx_0 * rtb_Gain_o_idx_1 + maxval * absx;
-  b[1] = maxval * b_n;
-  b[4] = yc_idx_2 * maxval + rtb_Gain_o_idx_1 * rtb_Product1;
-  b[7] = rtb_attitude_idx_0 * maxval - rtb_Gain_o_idx_1 * absx;
-  b[2] = -st;
-  b[5] = b_n * absx;
-  b[8] = b_n * rtb_Product1;
-  for (r1 = 0; r1 < 3; r1++) {
-    rtb_Gain_o_idx_1 = rtDW.Q[r1 + 3];
-    maxval = rtDW.Q[r1];
-    absx = rtDW.Q[r1 + 6];
+  st = 0.017453292519943295 * absx;
+  absx = std::cos(st);
+  st = std::sin(st);
+  b[0] = step_0 * xa_idx_1;
+  theta = xa_idx_2 * st;
+  b[3] = theta * step_0 - rtb_Gain_o_idx_1 * absx;
+  b_yc = xa_idx_2 * absx;
+  b[6] = b_yc * step_0 + rtb_Gain_o_idx_1 * st;
+  b[1] = rtb_Gain_o_idx_1 * xa_idx_1;
+  b[4] = theta * rtb_Gain_o_idx_1 + step_0 * absx;
+  b[7] = b_yc * rtb_Gain_o_idx_1 - step_0 * st;
+  b[2] = -xa_idx_2;
+  b[5] = xa_idx_1 * st;
+  b[8] = xa_idx_1 * absx;
+  for (k = 0; k < 3; k++) {
+    step_0 = rtDW.Q[k + 3];
+    rtb_Gain_o_idx_1 = rtDW.Q[k];
+    absx = rtDW.Q[k + 6];
     for (idx = 0; idx < 3; idx++) {
-      P_0[r1 + 3 * idx] = (b[idx + 3] * rtb_Gain_o_idx_1 + maxval * b[idx]) +
+      P_0[k + 3 * idx] = (b[idx + 3] * step_0 + rtb_Gain_o_idx_1 * b[idx]) +
         b[idx + 6] * absx;
     }
   }
 
   // :  m = [sqrt(q(1,1)^2+q(1,2)^2) sqrt(q(2,1)^2+q(2,2)^2) sqrt(q(3,1)^2+q(3,2)^2)]; 
   absx = std::sqrt(P_0[0] * P_0[0] + P_0[3] * P_0[3]);
-  tmp = std::sqrt(P_0[1] * P_0[1] + P_0[4] * P_0[4]);
-  tmp_0 = std::sqrt(P_0[2] * P_0[2] + P_0[5] * P_0[5]);
+  xa_idx_1 = std::sqrt(P_0[1] * P_0[1] + P_0[4] * P_0[4]);
+  xa_idx_2 = std::sqrt(P_0[2] * P_0[2] + P_0[5] * P_0[5]);
 
   // :  if min(abs(m)) == 0
   ya[0] = absx;
-  ya[1] = tmp;
-  ya[2] = tmp_0;
+  ya[1] = xa_idx_1;
+  ya[2] = xa_idx_2;
   if (minimum(ya) == 0.0) {
     // :  theta = last_theta_ok;
-    xb[0] = rtDW.last_theta_ok[0];
-    xb[1] = rtDW.last_theta_ok[1];
-    xb[2] = rtDW.last_theta_ok[2];
+    absx = rtDW.last_theta_ok[0];
+    xa_idx_1 = rtDW.last_theta_ok[1];
+    xa_idx_2 = rtDW.last_theta_ok[2];
 
     // Outport: '<Root>/out_of_range'
     // :  out_of_range = 1;
     rtY.out_of_range = 1.0;
   } else {
     // :  arg = [(PQ(1)-Pz(1)*q(1,3))/m(1); (PQ(2)-Pz(2)*q(2,3))/m(2); (PQ(3)-Pz(3)*q(3,3))/m(3)]; 
-    xa[0] = (rtDW.PQ[0] - rtDW.Pz[0] * P_0[6]) / absx;
-    xa[1] = (rtDW.PQ[1] - rtDW.Pz[1] * P_0[7]) / tmp;
-    xa[2] = (rtDW.PQ[2] - rtDW.Pz[2] * P_0[8]) / tmp_0;
+    xb[0] = (rtDW.PQ[0] - rtDW.Pz[0] * P_0[6]) / absx;
+    xb[1] = (rtDW.PQ[1] - rtDW.Pz[1] * P_0[7]) / xa_idx_1;
+    xb[2] = (rtDW.PQ[2] - rtDW.Pz[2] * P_0[8]) / xa_idx_2;
 
-    // :  if max(abs(arg)) > 1
-    ya[0] = std::abs(xa[0]);
-    ya[1] = std::abs(xa[1]);
-    ya[2] = std::abs(xa[2]);
+    // :  if max(abs(arg)) > 0.99
+    ya[0] = std::abs(xb[0]);
+    ya[1] = std::abs(xb[1]);
+    ya[2] = std::abs(xb[2]);
     if (!rtIsNaN(ya[0])) {
       idx = 1;
     } else {
       idx = 0;
-      r1 = 2;
+      k = 2;
       exitg2 = false;
-      while ((!exitg2) && (r1 < 4)) {
-        if (!rtIsNaN(ya[r1 - 1])) {
-          idx = r1;
+      while ((!exitg2) && (k < 4)) {
+        if (!rtIsNaN(ya[k - 1])) {
+          idx = k;
           exitg2 = true;
         } else {
-          r1++;
+          k++;
         }
       }
     }
 
     if (idx == 0) {
-      maxval = ya[0];
+      step_0 = ya[0];
     } else {
-      maxval = ya[idx - 1];
-      for (r1 = idx + 1; r1 < 4; r1++) {
-        absx = ya[r1 - 1];
-        if (maxval < absx) {
-          maxval = absx;
+      step_0 = ya[idx - 1];
+      for (k = idx + 1; k < 4; k++) {
+        st = ya[k - 1];
+        if (step_0 < st) {
+          step_0 = st;
         }
       }
     }
 
-    if (maxval > 1.0) {
+    if (step_0 > 0.99) {
       // :  theta = last_theta_ok;
-      xb[0] = rtDW.last_theta_ok[0];
-      xb[1] = rtDW.last_theta_ok[1];
-      xb[2] = rtDW.last_theta_ok[2];
+      absx = rtDW.last_theta_ok[0];
+      xa_idx_1 = rtDW.last_theta_ok[1];
+      xa_idx_2 = rtDW.last_theta_ok[2];
 
       // Outport: '<Root>/out_of_range'
-      // :  out_of_range = 1;
-      rtY.out_of_range = 1.0;
+      // :  out_of_range = 2;
+      rtY.out_of_range = 2.0;
     } else {
       // :  theta = atan2d(q(:,2),q(:,1))+[90; 90; 90;]-asind(arg);
-      rtb_Gain_o_idx_1 = (57.295779513082323 * rt_atan2d_snf(P_0[3], P_0[0]) +
-                          90.0) - 57.295779513082323 * std::asin(xa[0]);
-      maxval = (57.295779513082323 * rt_atan2d_snf(P_0[4], P_0[1]) + 90.0) -
-        57.295779513082323 * std::asin(xa[1]);
-      absx = (57.295779513082323 * rt_atan2d_snf(P_0[5], P_0[2]) + 90.0) -
-        57.295779513082323 * std::asin(xa[2]);
+      absx = (57.295779513082323 * rt_atan2d_snf(P_0[3], P_0[0]) + 90.0) -
+        57.295779513082323 * std::asin(xb[0]);
+      rtb_Gain_o_idx_1 = (57.295779513082323 * rt_atan2d_snf(P_0[4], P_0[1]) +
+                          90.0) - 57.295779513082323 * std::asin(xb[1]);
+      step_0 = (57.295779513082323 * rt_atan2d_snf(P_0[5], P_0[2]) + 90.0) -
+        57.295779513082323 * std::asin(xb[2]);
 
       // :  gap = abs(Wrap180([(theta(2)-theta(1)) (theta(3)-theta(2)) (theta(1)-theta(3))])); 
-      yb[0] = maxval - rtb_Gain_o_idx_1;
-      yb[1] = absx - maxval;
-      yb[2] = rtb_Gain_o_idx_1 - absx;
+      yb[0] = rtb_Gain_o_idx_1 - absx;
+      yb[1] = step_0 - rtb_Gain_o_idx_1;
+      yb[2] = absx - step_0;
 
       // :  y = x;
       // :  for i=1:3
@@ -1738,63 +1988,58 @@ void wrist_decoupler::step()
       // :  if min(gap) < 33.0
       if (minimum(ya) < 33.0) {
         // :  theta = last_theta_ok;
-        xb[0] = rtDW.last_theta_ok[0];
-        xb[1] = rtDW.last_theta_ok[1];
-        xb[2] = rtDW.last_theta_ok[2];
+        absx = rtDW.last_theta_ok[0];
+        xa_idx_1 = rtDW.last_theta_ok[1];
+        xa_idx_2 = rtDW.last_theta_ok[2];
 
         // Outport: '<Root>/out_of_range'
-        // :  out_of_range = 1;
-        rtY.out_of_range = 1.0;
+        // :  out_of_range = 3;
+        rtY.out_of_range = 3.0;
       } else {
         // :  theta = Wrap180(theta-theta_off);
         // :  y = x;
         // :  for i=1:3
         // :  last_theta_ok = theta;
-        xb[0] = rtb_Gain_o_idx_1 - rtU.theta_off[0];
-
         // :  while y(i) > 180.0
-        while (xb[0] > 180.0) {
+        for (absx -= rtU.theta_off[0]; absx > 180.0; absx -= 360.0) {
           // :  y(i) = y(i) - 360.0;
-          xb[0] -= 360.0;
         }
 
         // :  while y(i) < -180.0
-        while (xb[0] < -180.0) {
+        while (absx < -180.0) {
           // :  y(i) = y(i) + 360.0;
-          xb[0] += 360.0;
+          absx += 360.0;
         }
 
-        rtDW.last_theta_ok[0] = xb[0];
-        xb[1] = maxval - rtU.theta_off[1];
+        rtDW.last_theta_ok[0] = absx;
 
         // :  while y(i) > 180.0
-        while (xb[1] > 180.0) {
+        for (xa_idx_1 = rtb_Gain_o_idx_1 - rtU.theta_off[1]; xa_idx_1 > 180.0;
+             xa_idx_1 -= 360.0) {
           // :  y(i) = y(i) - 360.0;
-          xb[1] -= 360.0;
         }
 
         // :  while y(i) < -180.0
-        while (xb[1] < -180.0) {
+        while (xa_idx_1 < -180.0) {
           // :  y(i) = y(i) + 360.0;
-          xb[1] += 360.0;
+          xa_idx_1 += 360.0;
         }
 
-        rtDW.last_theta_ok[1] = xb[1];
-        xb[2] = absx - rtU.theta_off[2];
+        rtDW.last_theta_ok[1] = xa_idx_1;
 
         // :  while y(i) > 180.0
-        while (xb[2] > 180.0) {
+        for (xa_idx_2 = step_0 - rtU.theta_off[2]; xa_idx_2 > 180.0; xa_idx_2 -=
+             360.0) {
           // :  y(i) = y(i) - 360.0;
-          xb[2] -= 360.0;
         }
 
         // :  while y(i) < -180.0
-        while (xb[2] < -180.0) {
+        while (xa_idx_2 < -180.0) {
           // :  y(i) = y(i) + 360.0;
-          xb[2] += 360.0;
+          xa_idx_2 += 360.0;
         }
 
-        rtDW.last_theta_ok[2] = xb[2];
+        rtDW.last_theta_ok[2] = xa_idx_2;
 
         // Outport: '<Root>/out_of_range' incorporates:
         //   Inport: '<Root>/theta_off'
@@ -1808,7 +2053,7 @@ void wrist_decoupler::step()
   // End of Outputs for SubSystem: '<Root>/wrist_decoupler'
 
   // Outport: '<Root>/theta_star'
-  rtY.theta_star[0] = xb[0];
+  rtY.theta_star[0] = absx;
 
   // Outputs for Atomic SubSystem: '<Root>/wrist_decoupler'
   // Switch: '<S1>/Switch1' incorporates:
@@ -1827,7 +2072,7 @@ void wrist_decoupler::step()
   // End of Outputs for SubSystem: '<Root>/wrist_decoupler'
 
   // Outport: '<Root>/theta_star'
-  rtY.theta_star[1] = xb[1];
+  rtY.theta_star[1] = xa_idx_1;
 
   // Outputs for Atomic SubSystem: '<Root>/wrist_decoupler'
   // If: '<S8>/If' incorporates:
@@ -1836,12 +2081,12 @@ void wrist_decoupler::step()
   //   Switch: '<S1>/Switch1'
   //   Trigonometry: '<S6>/trigFcn'
 
-  rtY.ypr_meas[1] = 57.295779513082323 * std::asin(theta);
+  rtY.ypr_meas[1] = 57.295779513082323 * std::asin(b_n);
 
   // End of Outputs for SubSystem: '<Root>/wrist_decoupler'
 
   // Outport: '<Root>/theta_star'
-  rtY.theta_star[2] = xb[2];
+  rtY.theta_star[2] = xa_idx_2;
 
   // Outputs for Atomic SubSystem: '<Root>/wrist_decoupler'
   // Switch: '<S1>/Switch1' incorporates:
@@ -1856,6 +2101,11 @@ void wrist_decoupler::step()
     // Outport: '<Root>/ypr_meas'
     rtY.ypr_meas[2] = rtb_Gain_o_idx_2;
   }
+
+  // Outport: '<Root>/singularity' incorporates:
+  //   MATLAB Function: '<S1>/motors2ypr'
+
+  rtY.singularity = singularity;
 
   // Outport: '<Root>/cycles' incorporates:
   //   MATLAB Function: '<S1>/motors2ypr'

--- a/emBODY/eBcode/arch-arm/mbd/wrist_decoupler/wrist_decoupler.h
+++ b/emBODY/eBcode/arch-arm/mbd/wrist_decoupler/wrist_decoupler.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'wrist_decoupler'.
 //
-// Model version                  : 7.13
-// Simulink Coder version         : 9.9 (R2023a) 19-Nov-2022
-// C/C++ source code generated on : Tue Jul 25 11:18:40 2023
+// Model version                  : 8.5
+// Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
+// C/C++ source code generated on : Wed Feb 14 13:47:53 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -109,12 +109,12 @@ class wrist_decoupler
     real_T PQ[3];                      // '<S1>/ypr2motors'
     real_T Q[9];                       // '<S1>/ypr2motors'
     real_T last_theta_ok[3];           // '<S1>/ypr2motors'
-    real_T Q_p[9];                     // '<S1>/motors2ypr'
-    real_T PQ_f[3];                    // '<S1>/motors2ypr'
-    real_T Pz_b[3];                    // '<S1>/motors2ypr'
-    real_T singularity_reg;            // '<S1>/motors2ypr'
+    real_T Q_a[9];                     // '<S1>/motors2ypr'
+    real_T PQ_c[3];                    // '<S1>/motors2ypr'
+    real_T Pz_i[3];                    // '<S1>/motors2ypr'
+    real_T attitude_ok[4];             // '<S1>/motors2ypr'
     boolean_T Pz_not_empty;            // '<S1>/ypr2motors'
-    boolean_T singularity_reg_not_empty;// '<S1>/motors2ypr'
+    boolean_T Q_not_empty;             // '<S1>/motors2ypr'
   };
 
   // External inputs (root inport signals with default storage)
@@ -170,9 +170,12 @@ class wrist_decoupler
   // private member function(s) for subsystem '<Root>'
   void cosd(real_T x[3]);
   void sind(real_T x[3]);
-  real_T maximum(const real_T x[3]);
+  void cosd_f(real_T *x);
+  void sind_c(real_T *x);
   real_T minimum(const real_T x[3]);
+  real_T maximum(const real_T x[3]);
   real_T det(const real_T x[9]);
+  void mldivide(const real_T A[9], const real_T B_0[3], real_T Y[3]);
 
   // Real-Time Model
   RT_MODEL rtM;
@@ -190,25 +193,25 @@ class wrist_decoupler
 //  MATLAB hilite_system command to trace the generated code back
 //  to the parent model.  For example,
 //
-//  hilite_system('spherical_wrist/Position_Controller/wrist_decoupler')    - opens subsystem spherical_wrist/Position_Controller/wrist_decoupler
-//  hilite_system('spherical_wrist/Position_Controller/wrist_decoupler/Kp') - opens and selects block Kp
+//  hilite_system('spherical_wrist2/Position_Controller/wrist_decoupler')    - opens subsystem spherical_wrist2/Position_Controller/wrist_decoupler
+//  hilite_system('spherical_wrist2/Position_Controller/wrist_decoupler/Kp') - opens and selects block Kp
 //
 //  Here is the system hierarchy for this model
 //
-//  '<Root>' : 'spherical_wrist/Position_Controller'
-//  '<S1>'   : 'spherical_wrist/Position_Controller/wrist_decoupler'
-//  '<S2>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles'
-//  '<S3>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/Radians to Degrees'
-//  '<S4>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/motors2ypr'
-//  '<S5>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/ypr2motors'
-//  '<S6>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation'
-//  '<S7>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Quaternion Normalize'
-//  '<S8>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input'
-//  '<S9>'   : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input/If Action Subsystem'
-//  '<S10>'  : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input/If Action Subsystem1'
-//  '<S11>'  : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input/If Action Subsystem2'
-//  '<S12>'  : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Quaternion Normalize/Quaternion Modulus'
-//  '<S13>'  : 'spherical_wrist/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Quaternion Normalize/Quaternion Modulus/Quaternion Norm'
+//  '<Root>' : 'spherical_wrist2/Position_Controller'
+//  '<S1>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler'
+//  '<S2>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles'
+//  '<S3>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/Radians to Degrees'
+//  '<S4>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/motors2ypr'
+//  '<S5>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/ypr2motors'
+//  '<S6>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation'
+//  '<S7>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Quaternion Normalize'
+//  '<S8>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input'
+//  '<S9>'   : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input/If Action Subsystem'
+//  '<S10>'  : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input/If Action Subsystem1'
+//  '<S11>'  : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Angle Calculation/Protect asincos input/If Action Subsystem2'
+//  '<S12>'  : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Quaternion Normalize/Quaternion Modulus'
+//  '<S13>'  : 'spherical_wrist2/Position_Controller/wrist_decoupler/Quaternions to Rotation Angles/Quaternion Normalize/Quaternion Modulus/Quaternion Norm'
 
 #endif                                 // RTW_HEADER_wrist_decoupler_h_
 


### PR DESCRIPTION
Build here: https://github.com/robotology/icub-firmware-build/pull/139

I have improved the gradient descent in the direct kinematics solver (motor angles -> yaw, pitch, roll), so that now it never reaches singularity even if brutalised with a cycle of +/- 75 degrees in pitch and roll targets, at high speed, with large overshootings.

> [!important]
The inverse kinematics algebraic solver prevents generating motor targets mechanically unreachable.

![304749959-88f2a7ef-f569-4424-825d-4394c75f5352](https://github.com/robotology/icub-firmware/assets/4729270/06733b96-3516-44a1-8f41-fc3fdf3312aa)

Now the solver tries to solve for the new ypr configuration starting from the configuration of the previous control cycle, but if it leads to invalid solution it performs backtracking and reduces the step of the gradient descent. If it still fails, the initial position is resetted to (0,0,0). In this way, the average number of required steps is 4.

It is likely that all the parking procedures (startup and emergency) will result unneccessary after some time of use of the robot, and we'll be able to remove them.