### PR TITLE
Fix on all Diagnostic error

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v1/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {1, 13},
-            {2024, Month::Feb, Day::fifteen, 11, 00}
+            {1, 14},
+            {2024, Month::Feb, Day::twentythree, 13, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          83
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          84
 
 //  </h>version
 
@@ -89,11 +89,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          8
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_CANmonitor.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_CANmonitor.h
@@ -169,7 +169,7 @@ and `justLOST` states may happen if some boards keep on disappearing and reappea
             
             constexpr Config(const MAP &map, embot::core::relTime rc, Report rm, embot::core::relTime rr, const char *o, eOmn_serv_category_t s)
             {
-                target = map; periodofcheck = rc; reportmode = rm; ownername = o; servicecategory = s; 
+                target = map; periodofcheck = rc; reportmode = rm; periodofreport = rr; ownername = o; servicecategory = s; 
             }  
             
             Config() = default;

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          65
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          66
 
 //  </h>version
 
@@ -83,11 +83,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          8
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          86
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          87
 
 //  </h>version
 
@@ -92,11 +92,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          8
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          23
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 


### PR DESCRIPTION
Add mspassed to State::justLOST
Fix errors with service category passed, time from last contact and can mapping in canmonitor errors Fix Config constexpr, Initialize boards2report as boards2touch periodofreport params not updated to prv var
boards2report now initialized to zero as for boards2touch instead of to be re-initialized at each CANmonitor.tick() call initially set as _config.target and cleaned at CANmonitor.stop() 
Now the diagnostic maps are filled correctly.
Clean boads2report when inside the check and reset periodofreport to 10 sec.

Report all fixes:
- state justLOST e justFOUND have the mspassed, i.e. the milliseconds passed from the last moment the boards were reachable and the boards were unreachable respectively
- boards2report are updated correctly during the touch of the boards, so that we can send the updated masks at the moment of the report 
- servicecategory passed correctly for all states
- period of report updated in the Config constructor 