### PR TITLE
amcbldc v2.0.11 + amc2c v3.0.1.0 Handling of overcurrent flag w/ the new codegen

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -38,9 +38,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 0, 0, 0},   // application version
+        {3, 0, 1, 0},   // application version
         {2, 0},         // protocol version
-        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::one, 17, 17}
+        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::six, 16, 45}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
@@ -30,7 +30,7 @@ namespace embot::app::board::amcbldc::info {
     
     constexpr embot::prot::can::applicationInfo applInfo 
     {   
-        embot::prot::can::versionOfAPPLICATION {2, 0, 10},    
+        embot::prot::can::versionOfAPPLICATION {2, 0, 11},    
         embot::prot::can::versionOfCANPROTOCOL {2, 0}   
     };
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.13
+// Model version                  : 7.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:25 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.13
+// Model version                  : 7.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:25 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.13
+// Model version                  : 7.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:25 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.13
+// Model version                  : 7.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:25 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -115,6 +115,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T overcurrent;
   boolean_T enable_thermal_protection;
 };
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:24 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:24 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:24 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:24 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 6.3
+// Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:30 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -93,8 +93,15 @@ void can_encoder(const BUS_MESSAGES_TX *rtu_messages_tx, const BUS_STATUS_TX
               sizeof(uint8_T));
   rtb_BusCreator_m.packet.PAYLOAD[2] = tmp2[0];
   rtb_BusCreator_m.packet.PAYLOAD[3] = tmp2[1];
-  rtb_BusCreator_m.packet.PAYLOAD[4] =
-    rtu_messages_tx->status.flags.ExternalFaultAsserted;
+  if (rtu_messages_tx->status.flags.OverCurrentFailure) {
+    rtb_BusCreator_m.packet.PAYLOAD[4] = static_cast<uint8_T>
+      (static_cast<int32_T>(rtu_messages_tx->status.flags.ExternalFaultAsserted)
+       | 8);
+  } else {
+    rtb_BusCreator_m.packet.PAYLOAD[4] =
+      rtu_messages_tx->status.flags.ExternalFaultAsserted;
+  }
+
   rtb_BusCreator_m.packet.PAYLOAD[5] = 0U;
   rtb_BusCreator_m.packet.PAYLOAD[6] = 0U;
   rtb_BusCreator_m.packet.PAYLOAD[7] = 0U;

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 6.3
+// Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:30 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 6.3
+// Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:30 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'can_encoder'.
 //
-// Model version                  : 6.3
+// Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:30 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/FOCInnerLoop.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/FOCInnerLoop.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/FOCInnerLoop.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_data.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.18
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:36 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -100,6 +100,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T overcurrent;
   boolean_T enable_thermal_protection;
 };
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:43 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:43 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:43 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:43 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -45,6 +45,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T overcurrent;
   boolean_T enable_thermal_protection;
 };
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:57 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:57 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:57 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:57 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:05 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:05 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:05 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:55:05 2024
+// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:08 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -1177,6 +1177,7 @@ void SupervisorFSM_RX_Init(Flags *rty_Flags, ConfigurationParameters
   rty_Flags->enable_sending_msg_status =
     SupervisorFSM_RX_B.enableSendingMsgStatus;
   rty_Flags->fault_button = false;
+  rty_Flags->overcurrent = false;
   rty_Flags->enable_thermal_protection = SupervisorFSM_RX_ConstB.Constant5;
 
   // SystemInitialize for BusCreator: '<Root>/Bus Creator1' incorporates:
@@ -1317,8 +1318,6 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
           if (SupervisorFSM_RX_B.areLimitsSet) {
             SupervisorFSM_RX_DW.is_OverCurrent = SupervisorFSM_RX_IN_NoFault;
             SupervisorFSM_RX_B.isInOverCurrent = false;
-
-            // MotorFaultFlags.overCurrent=0;
           }
           break;
 
@@ -1328,8 +1327,6 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
               rtb_UnitDelay_thresholds_motorOverloadCurrents) {
             SupervisorFSM_RX_DW.is_OverCurrent =
               SupervisorFSM_RX_IN_OverCurrentFault;
-
-            // MotorFaultFlags.overCurrent=1;
             SupervisorFSM_RX_B.isInOverCurrent = true;
 
             // Outputs for Function Call SubSystem: '<Root>/Control Mode Handler Motor 0' 
@@ -1345,8 +1342,6 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
               rtb_UnitDelay_thresholds_motorOverloadCurrents) {
             SupervisorFSM_RX_DW.is_OverCurrent = SupervisorFSM_RX_IN_NoFault;
             SupervisorFSM_RX_B.isInOverCurrent = false;
-
-            // MotorFaultFlags.overCurrent=0;
           }
           break;
         }
@@ -1376,6 +1371,7 @@ void SupervisorFSM_RX(const SensorsData *rtu_SensorsData, const ExternalFlags
   rty_Flags->enable_sending_msg_status =
     SupervisorFSM_RX_B.enableSendingMsgStatus;
   rty_Flags->fault_button = SupervisorFSM_RX_B.isFaultButtonPressed;
+  rty_Flags->overcurrent = SupervisorFSM_RX_B.isInOverCurrent;
   rty_Flags->enable_thermal_protection = SupervisorFSM_RX_ConstB.Constant5;
 
   // BusCreator: '<Root>/Bus Creator1' incorporates:

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:08 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_data.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_data.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:08 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:08 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:08 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -395,6 +395,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T overcurrent;
   boolean_T enable_thermal_protection;
 };
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 7.3
+// Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:17 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -129,6 +129,7 @@ void SupervisorFSM_TX(const SensorsData *rtu_SensorsData, const EstimatedData
       (rtu_Flags->control_mode);
     rty_MessagesTx->status.pwm_fbk = rtu_ControlOutputs->Vq;
     rty_MessagesTx->status.flags.ExternalFaultAsserted = rtu_Flags->fault_button;
+    rty_MessagesTx->status.flags.OverCurrentFailure = rtu_Flags->overcurrent;
     SupervisorFSM_TX_DW.ev_statusEventCounter++;
   }
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 7.3
+// Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:17 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 7.3
+// Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:17 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_TX'.
 //
-// Model version                  : 7.3
+// Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Tue Feb 13 11:54:17 2024
+// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -150,6 +150,7 @@ struct Flags
   ControlModes control_mode;
   boolean_T enable_sending_msg_status;
   boolean_T fault_button;
+  boolean_T overcurrent;
   boolean_T enable_thermal_protection;
 };
 


### PR DESCRIPTION
**What's new:**

- update codegen w/ changes done in https://github.com/robotology/icub-firmware-models/pull/83

**Note:**
- Tested on `lego-setup`
- Binaries released in: https://github.com/robotology/icub-firmware-build/pull/142

