### PR TITLE
codegen: pwm scaled by Vcc when set as target in openloop - icub-fw-models: 1be8d979

### DIFF
--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.12
+// Model version                  : 7.13
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
+// C/C++ source code generated on : Wed Mar 13 10:40:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M
@@ -257,7 +257,7 @@ void AMC_BLDC_step_FOC(void)           // Sample time: [4.5E-5s, 0.0s]
     AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_Bu[AMC_BLDC_DW.RTBInsertedForAdapter_InsertedFor_Adapter2_at_outport_0_5_RD];
 
   // ModelReference: '<Root>/FOC' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
   //   Outport generated from: '<Root>/Out Bus Element'
 
   control_foc(&AMC_BLDC_U.SensorsData_p,
@@ -310,7 +310,7 @@ void AMC_BLDC_step_FOC(void)           // Sample time: [4.5E-5s, 0.0s]
   // End of RateTransition generated from: '<Root>/Adapter1'
 
   // RateTransition generated from: '<Root>/Adapter3' incorporates:
-  //   Inport generated from: '<Root>/In Bus Element5'
+  //   Inport generated from: '<Root>/In Bus Element6'
 
   rtw_mutex_lock();
   wrBufIdx = static_cast<int8_T>

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.12
+// Model version                  : 7.13
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
+// C/C++ source code generated on : Wed Mar 13 10:40:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.12
+// Model version                  : 7.13
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
+// C/C++ source code generated on : Wed Mar 13 10:40:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/amc-bldc/AMC_BLDC_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'AMC_BLDC'.
 //
-// Model version                  : 7.12
+// Model version                  : 7.13
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:21 2024
+// C/C++ source code generated on : Wed Mar 13 10:40:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:32 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:32 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:32 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-decoder/can_decoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:25 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:32 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/can-encoder/can_encoder_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.9
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:31 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:43 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/FOCInnerLoop.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/FOCInnerLoop.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.18
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:55 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.18
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:55 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.18
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:55 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_data.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_data.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.18
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:55 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_private.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.18
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:55 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-foc/control_foc_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.18
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:37 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:55 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:07 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:07 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:07 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/control-outer/control_outer_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:43 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:07 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:26 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:26 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:26 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/estimator/estimation_velocity_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:56 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:26 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/filter-current/filter_current_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 6.3
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:01:04 2024
+// C/C++ source code generated on : Wed Mar 13 10:36:38 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/const_params.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/const_params.cpp
@@ -7,9 +7,9 @@
 //
 //  Code generation for model "estimation_velocity".
 //
-//  Model version              : 6.4
+//  Model version              : 5.1
 //  Simulink Coder version : 23.2 (R2023b) 01-Aug-2023
-//  C++ source code generated on : Mon Jan 15 18:18:33 2024
+//  C++ source code generated on : Wed Sep 20 16:39:02 2023
 
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetInf.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetInf.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetInf.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetInf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 #ifndef RTW_HEADER_rtGetInf_h_
 #define RTW_HEADER_rtGetInf_h_

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetNaN.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetNaN.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 #include "rtwtypes.h"
 

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetNaN.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtGetNaN.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 #ifndef RTW_HEADER_rtGetNaN_h_
 #define RTW_HEADER_rtGetNaN_h_

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_hypotf.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_hypotf.cpp
@@ -3,28 +3,20 @@
 // granting, nonprofit, education, and research organizations only. Not
 // for commercial or industrial use.
 //
-// File: rt_hypotf_snf.cpp
+// File: rt_hypotf.cpp
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 5.1
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Sep 20 16:39:02 2023
+// C/C++ source code generated on : Mon Mar  4 13:07:25 2024
 //
 #include "rtwtypes.h"
-#include "rt_hypotf_snf.h"
+#include "rt_hypotf.h"
 #include <cmath>
-
-extern "C"
-{
-
-#include "rt_nonfinite.h"
-
-}
-
 #include "mw_cmsis.h"
 
-real32_T rt_hypotf_snf(real32_T u0, real32_T u1)
+real32_T rt_hypotf(real32_T u0, real32_T u1)
 {
   real32_T a;
   real32_T b;
@@ -40,8 +32,6 @@ real32_T rt_hypotf_snf(real32_T u0, real32_T u1)
     b /= a;
     mw_arm_sqrt_f32(b * b + 1.0F, &tmp);
     y = tmp * a;
-  } else if (rtIsNaNF(b)) {
-    y = (rtNaNF);
   } else {
     y = a * 1.41421354F;
   }

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_hypotf.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_hypotf.h
@@ -3,21 +3,21 @@
 // granting, nonprofit, education, and research organizations only. Not
 // for commercial or industrial use.
 //
-// File: rt_hypotf_snf.h
+// File: rt_hypotf.h
 //
 // Code generated for Simulink model 'estimation_velocity'.
 //
-// Model version                  : 5.1
+// Model version                  : 6.19
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Sep 20 16:39:02 2023
+// C/C++ source code generated on : Mon Mar  4 13:07:25 2024
 //
-#ifndef RTW_HEADER_rt_hypotf_snf_h_
-#define RTW_HEADER_rt_hypotf_snf_h_
+#ifndef RTW_HEADER_rt_hypotf_h_
+#define RTW_HEADER_rt_hypotf_h_
 #include "rtwtypes.h"
 
-extern real32_T rt_hypotf_snf(real32_T u0, real32_T u1);
+extern real32_T rt_hypotf(real32_T u0, real32_T u1);
 
-#endif                                 // RTW_HEADER_rt_hypotf_snf_h_
+#endif                                 // RTW_HEADER_rt_hypotf_h_
 
 //
 // File trailer for generated code.

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_nonfinite.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_nonfinite.cpp
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 extern "C"
 {

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_nonfinite.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_nonfinite.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 #ifndef RTW_HEADER_rt_nonfinite_h_
 #define RTW_HEADER_rt_nonfinite_h_

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundd.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundd.cpp
@@ -3,26 +3,26 @@
 // granting, nonprofit, education, and research organizations only. Not
 // for commercial or industrial use.
 //
-// File: rt_roundd_snf.cpp
+// File: rt_roundd.cpp
 //
-// Code generated for Simulink model 'SupervisorFSM_RX'.
+// Code generated for Simulink model 'supervisor'.
 //
-// Model version                  : 6.22
+// Model version                  : 1.291
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Sep 20 16:37:54 2023
+// C/C++ source code generated on : Mon Mar  4 14:29:48 2024
 //
 #include "rtwtypes.h"
-#include "rt_roundd_snf.h"
+#include "rt_roundd.h"
 #include <cmath>
 
-real_T rt_roundd_snf(real_T u)
+real_T rt_roundd(real_T u)
 {
   real_T y;
   if (std::abs(u) < 4.503599627370496E+15) {
     if (u >= 0.5) {
       y = std::floor(u + 0.5);
     } else if (u > -0.5) {
-      y = u * 0.0;
+      y = 0.0;
     } else {
       y = std::ceil(u - 0.5);
     }

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundd.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundd.h
@@ -1,0 +1,26 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: rt_roundd.h
+//
+// Code generated for Simulink model 'supervisor'.
+//
+// Model version                  : 1.291
+// Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
+// C/C++ source code generated on : Mon Mar  4 14:29:48 2024
+//
+#ifndef RTW_HEADER_rt_roundd_h_
+#define RTW_HEADER_rt_roundd_h_
+#include "rtwtypes.h"
+
+extern real_T rt_roundd(real_T u);
+
+#endif                                 // RTW_HEADER_rt_roundd_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundd_snf.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundd_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 6.22
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:17:08 2024
+// C/C++ source code generated on : Wed Sep 20 16:37:54 2023
 //
 #ifndef RTW_HEADER_rt_roundd_snf_h_
 #define RTW_HEADER_rt_roundd_snf_h_

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundf.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundf.cpp
@@ -3,26 +3,26 @@
 // granting, nonprofit, education, and research organizations only. Not
 // for commercial or industrial use.
 //
-// File: rt_roundf_snf.cpp
+// File: rt_roundf.cpp
 //
-// Code generated for Simulink model 'SupervisorFSM_RX'.
+// Code generated for Simulink model 'supervisor'.
 //
-// Model version                  : 7.4
+// Model version                  : 1.291
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 22 16:05:02 2024
+// C/C++ source code generated on : Mon Mar  4 14:39:53 2024
 //
 #include "rtwtypes.h"
-#include "rt_roundf_snf.h"
+#include "rt_roundf.h"
 #include <cmath>
 
-real32_T rt_roundf_snf(real32_T u)
+real32_T rt_roundf(real32_T u)
 {
   real32_T y;
   if (std::abs(u) < 8.388608E+6F) {
     if (u >= 0.5F) {
       y = std::floor(u + 0.5F);
     } else if (u > -0.5F) {
-      y = u * 0.0F;
+      y = 0.0F;
     } else {
       y = std::ceil(u - 0.5F);
     }

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundf.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundf.h
@@ -1,0 +1,26 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: rt_roundf.h
+//
+// Code generated for Simulink model 'supervisor'.
+//
+// Model version                  : 1.291
+// Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
+// C/C++ source code generated on : Mon Mar  4 14:39:53 2024
+//
+#ifndef RTW_HEADER_rt_roundf_h_
+#define RTW_HEADER_rt_roundf_h_
+#include "rtwtypes.h"
+
+extern real32_T rt_roundf(real32_T u);
+
+#endif                                 // RTW_HEADER_rt_roundf_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundf_snf.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rt_roundf_snf.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:17:08 2024
+// C/C++ source code generated on : Mon Jan 22 16:05:02 2024
 //
 #ifndef RTW_HEADER_rt_roundf_snf_h_
 #define RTW_HEADER_rt_roundf_snf_h_

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtw_defines.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtw_defines.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 6.22
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:17:08 2024
+// C/C++ source code generated on : Wed Sep 20 16:37:54 2023
 //
 
 #ifndef RTW_HEADER_rtw_defines_h_

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtwtypes.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/rtwtypes.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'SupervisorFSM_RX'.
 //
-// Model version                  : 7.5
+// Model version                  : 6.22
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:17:08 2024
+// C/C++ source code generated on : Wed Sep 20 16:37:54 2023
 //
 #ifndef RTWTYPES_H
 #define RTWTYPES_H

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/zero_crossing_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/sharedutils/zero_crossing_types.h
@@ -7,9 +7,9 @@
 //
 // Code generated for Simulink model 'control_foc'.
 //
-// Model version                  : 6.16
+// Model version                  : 5.12
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Mon Jan 15 18:18:06 2024
+// C/C++ source code generated on : Wed Sep 20 16:38:40 2023
 //
 #ifndef ZERO_CROSSING_TYPES_H
 #define ZERO_CROSSING_TYPES_H

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:00 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:00 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_data.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_data.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:00 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:00 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-rx/SupervisorFSM_RX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.7
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:13 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:00 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.cpp
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.cpp
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:18 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:18 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_private.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_private.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:18 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M

--- a/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_types.h
+++ b/emBODY/eBcode/arch-arm/mbd/amcbldc/supervisor-tx/SupervisorFSM_TX_types.h
@@ -9,7 +9,7 @@
 //
 // Model version                  : 7.4
 // Simulink Coder version         : 23.2 (R2023b) 01-Aug-2023
-// C/C++ source code generated on : Wed Mar  6 15:00:19 2024
+// C/C++ source code generated on : Wed Mar 13 10:35:18 2024
 //
 // Target selection: ert.tlc
 // Embedded hardware selection: ARM Compatible->ARM Cortex-M


### PR DESCRIPTION
As the title says. 
See the contributions in icub-firmware-models:

- https://github.com/robotology/icub-firmware-models/issues/84#issuecomment-1988950037
- https://github.com/robotology/icub-firmware-models/commit/1be8d9790b3affaabcfa1251f132345e3dfc8fe5
- https://github.com/robotology/icub-firmware-models/issues/10#issuecomment-1994157081

The change applies to boards that use the generated code with MBD.

