### PR TITLE
Improved dual core boot for `amcfoc` 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcfocm4/bsp/embot_hw_bsp_DRIVER_amcfocm4.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfocm4/bsp/embot_hw_bsp_DRIVER_amcfocm4.cpp
@@ -60,7 +60,7 @@ bool embot::hw::bsp::DRIVER::init(const embot::hw::Config &config)
     
     
     // and then, in here we do what we must
-    embot::hw::dualcore::start2();
+    embot::hw::dualcore::init();
     
     return true;    
 }

--- a/emBODY/eBcode/arch-arm/board/amcfocm4/bsp/embot_hw_bsp_amcfocm4.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfocm4/bsp/embot_hw_bsp_amcfocm4.cpp
@@ -66,7 +66,7 @@ bool embot::hw::bsp::specialize()
 {
     // all the rest
     // nothing for now
-    __HAL_RCC_GPIOE_CLK_ENABLE();
+
     
     
     return true;  

--- a/emBODY/eBcode/arch-arm/board/amcfocm4/bsp/system_stm32h7xx-cm4-cm7-gated.c
+++ b/emBODY/eBcode/arch-arm/board/amcfocm4/bsp/system_stm32h7xx-cm4-cm7-gated.c
@@ -1,0 +1,1089 @@
+
+#if defined(dualcore_BOOT_cm4master)
+
+/**
+  ******************************************************************************
+  * @file    Templates/BootCM4_CM7Gated/Common/Src/system_stm32h7xx.c
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex-Mx Device Peripheral Access Layer System Source File.
+  *
+  *   This file provides two functions and one global variable to be called from 
+  *   user application:
+  *      - SystemInit(): This function is called at startup just after reset and 
+  *                      before branch to main program. This call is made inside
+  *                      the "startup_stm32h7xx.s" file.
+  *
+  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
+  *                                  by the user application to setup the SysTick 
+  *                                  timer or configure other parameters.
+  *                                     
+  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+  *                                 be called whenever the core clock is changed
+  *                                 during program execution.
+  *
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32h7xx_system
+  * @{
+  */  
+  
+/** @addtogroup STM32H7xx_System_Private_Includes
+  * @{
+  */
+
+
+#include "stm32hal.h"
+//#include "stm32h7xx.h"
+
+#include <math.h>
+
+#if !defined  (HSE_VALUE)
+#define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (CSI_VALUE)
+  #define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* CSI_VALUE */
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Defines
+  * @{
+  */
+
+/************************* Miscellaneous Configuration ************************/
+/*!< Uncomment the following line if you need to use external SDRAM mounted
+     on DISCO board as data memory  */
+/*#define DATA_IN_ExtSDRAM*/
+
+/*!< Uncomment the following line if you need to relocate your vector Table in
+     Internal SRAM. */
+/* #define VECT_TAB_SRAM */
+#define VECT_TAB_OFFSET  0x00000000UL       /*!< Vector Table base offset field. 
+                                      This value must be a multiple of 0x200. */
+/******************************************************************************/
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Variables
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency 
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+  */
+  uint32_t SystemCoreClock = 64000000;
+  uint32_t SystemD2Clock = 64000000;
+  const  uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_FunctionPrototypes
+  * @{
+  */
+#if defined (DATA_IN_ExtSDRAM)
+  static void SystemInit_ExtMemCtl(void); 
+#endif /* DATA_IN_ExtSDRAM */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Setup the microcontroller system
+  *         Initialize the FPU setting, vector table location and External memory 
+  *         configuration.
+  * @param  None
+  * @retval None
+  */
+void SystemInit (void)
+{    
+  /* FPU settings ------------------------------------------------------------*/
+  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
+  #endif
+	
+#ifdef CORE_CM4 
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+  /* Set HSION bit */
+  RCC->CR |= RCC_CR_HSION;
+  
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000000;
+
+  /* Reset HSEON, CSSON , CSION,RC48ON, CSIKERON PLL1ON, PLL2ON and PLL3ON bits */
+  RCC->CR &= 0xEAF6ED7FU;
+
+  /* Reset D1CFGR register */
+  RCC->D1CFGR = 0x00000000;
+
+  /* Reset D2CFGR register */
+  RCC->D2CFGR = 0x00000000;
+  
+  /* Reset D3CFGR register */
+  RCC->D3CFGR = 0x00000000;
+
+  /* Reset PLLCKSELR register */
+  RCC->PLLCKSELR = 0x00000000;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x00000000;
+  /* Reset PLL1DIVR register */
+  RCC->PLL1DIVR = 0x00000000;
+  /* Reset PLL1FRACR register */
+  RCC->PLL1FRACR = 0x00000000;
+
+  /* Reset PLL2DIVR register */
+  RCC->PLL2DIVR = 0x00000000;
+
+  /* Reset PLL2FRACR register */
+  
+  RCC->PLL2FRACR = 0x00000000;
+  /* Reset PLL3DIVR register */
+  RCC->PLL3DIVR = 0x00000000;
+
+  /* Reset PLL3FRACR register */
+  RCC->PLL3FRACR = 0x00000000;
+  
+  /* Reset HSEBYP bit */
+  RCC->CR &= 0xFFFBFFFFU;
+
+  /* Disable all interrupts */
+  RCC->CIER = 0x00000000;
+  
+
+
+/*
+   * Disable the FMC bank1 (enabled after reset).
+   * This, prevents CPU speculation access on this bank which blocks the use of FMC during
+   * 24us. During this time the others FMC master (such as LTDC) cannot use it!
+   */
+  FMC_Bank1_R->BTCR[0] = 0x000030D2;
+
+
+#if defined (DATA_IN_ExtSDRAM)
+  SystemInit_ExtMemCtl(); 
+#endif /* DATA_IN_ExtSDRAM */
+ 
+#endif /* CORE_CM4*/
+
+#ifdef CORE_CM4
+
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = D2_AXISRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+#else
+  SCB->VTOR = FLASH_BANK2_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+#endif  
+
+#else
+#ifdef CORE_CM7
+  
+  /* Change  the switch matrix read issuing capability to 1 for the AXI SRAM target (Target 7) */
+  if((DBGMCU->IDCODE & 0xFFFF0000U) < 0x20000000U)
+  {
+    /* if stm32h7 revY*/
+    /* Change  the switch matrix read issuing capability to 1 for the AXI SRAM target (Target 7) */
+    *((__IO uint32_t*)0x51008108) = 0x00000001U;
+  }
+  
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET;       /* Vector Table Relocation in Internal SRAM */
+#else
+  SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET;       /* Vector Table Relocation in Internal FLASH */
+#endif  
+
+#else
+#error Please #define CORE_CM4 or CORE_CM7
+#endif                       
+#endif
+
+}
+
+/**
+   * @brief  Update SystemCoreClock variable according to Clock Register Values.
+  *         The SystemCoreClock variable contains the core clock , it can
+  *         be used by the user application to setup the SysTick timer or configure
+  *         other parameters.
+  *           
+  * @note   Each time the core clock changes, this function must be called
+  *         to update SystemCoreClock variable value. Otherwise, any configuration
+  *         based on this variable will be incorrect.         
+  *     
+  * @note   - The system frequency computed by this function is not the real 
+  *           frequency in the chip. It is calculated based on the predefined 
+  *           constant and the selected clock source:
+  *             
+  *           - If SYSCLK source is CSI, SystemCoreClock will contain the CSI_VALUE(*)                                 
+  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(**)
+  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(***) 
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the CSI_VALUE(*),
+  *             HSI_VALUE(**) or HSE_VALUE(***) multiplied/divided by the PLL factors.
+  *
+  *         (*) CSI_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *             4 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.        
+  *         (**) HSI_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *             64 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.   
+  *    
+  *         (***)HSE_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *              25 MHz), user has to ensure that HSE_VALUE is same as the real
+  *              frequency of the crystal used. Otherwise, this function may
+  *              have wrong result.
+  *                
+  *         - The result of this function could be not correct when using fractional
+  *           value for HSE crystal.
+  * @param  None
+  * @retval None
+  */
+void SystemCoreClockUpdate (void)
+{
+  uint32_t pllp, pllsource, pllm, pllfracen, hsivalue, tmp;
+  uint32_t common_system_clock;
+  float_t fracn1, pllvco;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+
+  switch (RCC->CFGR & RCC_CFGR_SWS)
+  {
+  case RCC_CFGR_SWS_HSI:  /* HSI used as system clock source */
+    common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+    break;
+
+  case RCC_CFGR_SWS_CSI:  /* CSI used as system clock  source */
+    common_system_clock = CSI_VALUE;
+    break;
+
+  case RCC_CFGR_SWS_HSE:  /* HSE used as system clock  source */
+    common_system_clock = HSE_VALUE;
+    break;
+
+  case RCC_CFGR_SWS_PLL1:  /* PLL1 used as system clock  source */
+
+    /* PLL_VCO = (HSE_VALUE or HSI_VALUE or CSI_VALUE/ PLLM) * PLLN
+    SYSCLK = PLL_VCO / PLLR
+    */
+    pllsource = (RCC->PLLCKSELR & RCC_PLLCKSELR_PLLSRC);
+    pllm = ((RCC->PLLCKSELR & RCC_PLLCKSELR_DIVM1)>> 4)  ;
+    pllfracen = ((RCC->PLLCFGR & RCC_PLLCFGR_PLL1FRACEN)>>RCC_PLLCFGR_PLL1FRACEN_Pos);
+    fracn1 = (float_t)(uint32_t)(pllfracen* ((RCC->PLL1FRACR & RCC_PLL1FRACR_FRACN1)>> 3));
+
+    if (pllm != 0U)
+    {
+      switch (pllsource)
+      {
+        case RCC_PLLCKSELR_PLLSRC_HSI:  /* HSI used as PLL clock source */
+
+        hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3)) ;
+        pllvco = ( (float_t)hsivalue / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+
+        break;
+
+        case RCC_PLLCKSELR_PLLSRC_CSI:  /* CSI used as PLL clock source */
+          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+
+        case RCC_PLLCKSELR_PLLSRC_HSE:  /* HSE used as PLL clock source */
+          pllvco = ((float_t)HSE_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+
+      default:
+          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+      }
+      pllp = (((RCC->PLL1DIVR & RCC_PLL1DIVR_P1) >>9) + 1U ) ;
+      common_system_clock =  (uint32_t)(float_t)(pllvco/(float_t)pllp);
+    }
+    else
+    {
+      common_system_clock = 0U;
+    }
+    break;
+
+  default:
+    common_system_clock = CSI_VALUE;
+    break;
+  }
+
+  /* Compute SystemClock frequency --------------------------------------------------*/
+  tmp = D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_D1CPRE)>> RCC_D1CFGR_D1CPRE_Pos];
+
+  /* common_system_clock frequency : CM7 CPU frequency  */
+  common_system_clock >>= tmp;
+
+  /* SystemD2Clock frequency : CM4 CPU, AXI and AHBs Clock frequency  */
+  SystemD2Clock = (common_system_clock >> ((D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_HPRE)>> RCC_D1CFGR_HPRE_Pos]) & 0x1FU));
+
+#if defined(DUAL_CORE) && defined(CORE_CM4)
+  SystemCoreClock = SystemD2Clock;
+#else
+  SystemCoreClock = common_system_clock;
+#endif /* DUAL_CORE && CORE_CM4 */
+}
+#if defined (DATA_IN_ExtSDRAM)
+/**
+  * @brief  Setup the external memory controller.
+  *         Called in startup_stm32h7xx.s before jump to main.
+  *         This function configures the external memories SDRAM
+  *         This SDRAM will be used as program data memory (including heap and stack).
+  * @param  None
+  * @retval None
+  */
+void SystemInit_ExtMemCtl(void)
+{
+  __IO uint32_t tmp = 0;
+  register uint32_t tmpreg = 0, timeout = 0xFFFF;
+  register __IO uint32_t index;
+
+  /* Enable GPIOD, GPIOE, GPIOF, GPIOG, GPIOH and GPIOI interface 
+      clock */
+  RCC->AHB4ENR |= 0x000001F8;
+
+  /* Delay after an RCC peripheral clock enabling */
+  tmp = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_GPIOEEN);
+  
+  /* Connect PDx pins to FMC Alternate function */
+  GPIOD->AFR[0]  = 0x000000CC;
+  GPIOD->AFR[1]  = 0xCC000CCC;
+  /* Configure PDx pins in Alternate function mode */  
+  GPIOD->MODER   = 0xAFEAFFFA;
+  /* Configure PDx pins speed to 100 MHz */  
+  GPIOD->OSPEEDR = 0xF03F000F;
+  /* Configure PDx pins Output type to push-pull */  
+  GPIOD->OTYPER  = 0x00000000;
+  /* Configure PDx pins in Pull-up */
+  GPIOD->PUPDR   = 0x50150005;
+   
+  /* Connect PEx pins to FMC Alternate function */
+  GPIOE->AFR[0]  = 0xC00000CC;
+  GPIOE->AFR[1]  = 0xCCCCCCCC;
+  /* Configure PEx pins in Alternate function mode */ 
+  GPIOE->MODER   = 0xAAAABFFA;
+  /* Configure PEx pins speed to 100 MHz */ 
+  GPIOE->OSPEEDR = 0xFFFFC00F;
+  /* Configure PEx pins Output type to push-pull */  
+  GPIOE->OTYPER  = 0x00000000;
+  /* Configure PEx pins in Pull-up */
+  GPIOE->PUPDR   = 0x55554005;
+  
+  /* Connect PFx pins to FMC Alternate function */
+  GPIOF->AFR[0]  = 0x00CCCCCC;
+  GPIOF->AFR[1]  = 0xCCCCC000;
+  /* Configure PFx pins in Alternate function mode */   
+  GPIOF->MODER   = 0xAABFFAAA;
+  /* Configure PFx pins speed to 100 MHz */ 
+  GPIOF->OSPEEDR = 0xFFC00FFF;
+  /* Configure PFx pins Output type to push-pull */  
+  GPIOF->OTYPER  = 0x00000000;
+  /* Configure PFx pins in Pull-up */
+  GPIOF->PUPDR   = 0x55400555;
+  
+  /* Connect PGx pins to FMC Alternate function */
+  GPIOG->AFR[0]  = 0x00CC00CC;
+  GPIOG->AFR[1]  = 0xC000000C;
+  /* Configure PGx pins in Alternate function mode */ 
+  GPIOG->MODER   = 0xBFFEFAFA;
+ /* Configure PGx pins speed to 100 MHz */ 
+  GPIOG->OSPEEDR = 0xC0030F0F;
+  /* Configure PGx pins Output type to push-pull */  
+  GPIOG->OTYPER  = 0x00000000;
+  /* Configure PGx pins in Pull-up */ 
+  GPIOG->PUPDR   = 0x40010505;
+  
+  /* Connect PHx pins to FMC Alternate function */
+  GPIOH->AFR[0]  = 0xCCC00000;
+  GPIOH->AFR[1]  = 0xCCCCCCCC;
+  /* Configure PHx pins in Alternate function mode */ 
+  GPIOH->MODER   = 0xAAAAABFF;
+  /* Configure PHx pins speed to 100 MHz */ 
+  GPIOH->OSPEEDR = 0xFFFFFC00;
+  /* Configure PHx pins Output type to push-pull */  
+  GPIOH->OTYPER  = 0x00000000;
+  /* Configure PHx pins in Pull-up */
+  GPIOH->PUPDR   = 0x55555400;
+  
+/*-- FMC Configuration ------------------------------------------------------*/
+  /* Enable the FMC interface clock */
+  (RCC->AHB3ENR |= (RCC_AHB3ENR_FMCEN));
+  /*SDRAM Timing and access interface configuration*/
+  /*LoadToActiveDelay  = 2
+    ExitSelfRefreshDelay = 6
+    SelfRefreshTime      = 4
+    RowCycleDelay        = 6
+    WriteRecoveryTime    = 2
+    RPDelay              = 2
+    RCDDelay             = 2
+    SDBank             = FMC_SDRAM_BANK2
+    ColumnBitsNumber   = FMC_SDRAM_COLUMN_BITS_NUM_8 
+    RowBitsNumber      = FMC_SDRAM_ROW_BITS_NUM_12
+    MemoryDataWidth    = FMC_SDRAM_MEM_BUS_WIDTH_16
+    InternalBankNumber = FMC_SDRAM_INTERN_BANKS_NUM_4
+    CASLatency         = FMC_SDRAM_CAS_LATENCY_2
+    WriteProtection    = FMC_SDRAM_WRITE_PROTECTION_DISABLE
+    SDClockPeriod      = FMC_SDRAM_CLOCK_PERIOD_2
+    ReadBurst          = FMC_SDRAM_RBURST_ENABLE
+    ReadPipeDelay      = FMC_SDRAM_RPIPE_DELAY_0*/
+  
+  FMC_Bank5_6_R->SDCR[0] = 0x00001800;
+  FMC_Bank5_6_R->SDCR[1] = 0x00000154;
+  FMC_Bank5_6_R->SDTR[0] = 0x00105000;
+  FMC_Bank5_6_R->SDTR[1] = 0x01010351;
+
+  /* SDRAM initialization sequence */
+  /* Clock enable command */ 
+  FMC_Bank5_6_R->SDCMR = 0x00000009; 
+  tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  }
+
+  /* Delay */
+  for (index = 0; index<1000; index++);
+  
+  /* PALL command */ 
+    FMC_Bank5_6_R->SDCMR = 0x0000000A; 	
+  timeout = 0xFFFF;
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  }
+  
+  FMC_Bank5_6_R->SDCMR = 0x000000EB;
+  timeout = 0xFFFF;
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  }
+
+  FMC_Bank5_6_R->SDCMR = 0x0004400C;
+  timeout = 0xFFFF;
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  } 
+  /* Set refresh count */
+  tmpreg = FMC_Bank5_6_R->SDRTR;
+  FMC_Bank5_6_R->SDRTR = (tmpreg | (0x00000603<<1));
+
+  /* Disable write protection */
+  tmpreg = FMC_Bank5_6_R->SDCR[1]; 
+  FMC_Bank5_6_R->SDCR[1] = (tmpreg & 0xFFFFFDFF);
+
+   /*FMC controller Enable*/
+  FMC_Bank1_R->BTCR[0]  |= 0x80000000;
+  
+  (void)(tmp);
+}
+#endif /* DATA_IN_ExtSDRAM */
+
+  
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#elif defined(dualcore_BOOT_cm7master)
+
+/**
+  ******************************************************************************
+  * @file    Templates/BootCM7_CM4Gated/Common/Src/system_stm32h7xx.c
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex-Mx Device Peripheral Access Layer System Source File.
+  *
+  *   This file provides two functions and one global variable to be called from 
+  *   user application:
+  *      - SystemInit(): This function is called at startup just after reset and 
+  *                      before branch to main program. This call is made inside
+  *                      the "startup_stm32h7xx.s" file.
+  *
+  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
+  *                                  by the user application to setup the SysTick 
+  *                                  timer or configure other parameters.
+  *                                     
+  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+  *                                 be called whenever the core clock is changed
+  *                                 during program execution.
+  *
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32h7xx_system
+  * @{
+  */  
+  
+/** @addtogroup STM32H7xx_System_Private_Includes
+  * @{
+  */
+
+#include "stm32hal.h"
+//#include "stm32h7xx.h"
+
+#include <math.h>
+
+#if !defined  (HSE_VALUE)
+#define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (CSI_VALUE)
+  #define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* CSI_VALUE */
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Defines
+  * @{
+  */
+
+/************************* Miscellaneous Configuration ************************/
+/*!< Uncomment the following line if you need to use external SDRAM mounted
+     on DISCO board as data memory  */
+/*#define DATA_IN_ExtSDRAM*/
+
+/*!< Uncomment the following line if you need to relocate your vector Table in
+     Internal SRAM. */
+/* #define VECT_TAB_SRAM */
+#define VECT_TAB_OFFSET  0x00000000UL       /*!< Vector Table base offset field. 
+                                      This value must be a multiple of 0x200. */
+/******************************************************************************/
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Variables
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency 
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+  */
+  uint32_t SystemCoreClock = 64000000;
+  uint32_t SystemD2Clock = 64000000;
+  const  uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_FunctionPrototypes
+  * @{
+  */
+#if defined (DATA_IN_ExtSDRAM)
+  static void SystemInit_ExtMemCtl(void); 
+#endif /* DATA_IN_ExtSDRAM */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Setup the microcontroller system
+  *         Initialize the FPU setting, vector table location and External memory 
+  *         configuration.
+  * @param  None
+  * @retval None
+  */
+void SystemInit (void)
+{    
+  /* FPU settings ------------------------------------------------------------*/
+  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
+  #endif
+
+#ifdef CORE_CM7 
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+  /* Set HSION bit */
+  RCC->CR |= RCC_CR_HSION;
+  
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000000;
+
+  /* Reset HSEON, CSSON , CSION,RC48ON, CSIKERON PLL1ON, PLL2ON and PLL3ON bits */
+  RCC->CR &= 0xEAF6ED7FU;
+
+  /* Reset D1CFGR register */
+  RCC->D1CFGR = 0x00000000;
+
+  /* Reset D2CFGR register */
+  RCC->D2CFGR = 0x00000000;
+  
+  /* Reset D3CFGR register */
+  RCC->D3CFGR = 0x00000000;
+
+  /* Reset PLLCKSELR register */
+  RCC->PLLCKSELR = 0x00000000;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x00000000;
+  /* Reset PLL1DIVR register */
+  RCC->PLL1DIVR = 0x00000000;
+  /* Reset PLL1FRACR register */
+  RCC->PLL1FRACR = 0x00000000;
+
+  /* Reset PLL2DIVR register */
+  RCC->PLL2DIVR = 0x00000000;
+
+  /* Reset PLL2FRACR register */
+  
+  RCC->PLL2FRACR = 0x00000000;
+  /* Reset PLL3DIVR register */
+  RCC->PLL3DIVR = 0x00000000;
+
+  /* Reset PLL3FRACR register */
+  RCC->PLL3FRACR = 0x00000000;
+  
+  /* Reset HSEBYP bit */
+  RCC->CR &= 0xFFFBFFFFU;
+
+  /* Disable all interrupts */
+  RCC->CIER = 0x00000000;
+
+  /* Change  the switch matrix read issuing capability to 1 for the AXI SRAM target (Target 7) */
+  if((DBGMCU->IDCODE & 0xFFFF0000U) < 0x20000000U)
+  {
+    /* if stm32h7 revY*/
+    /* Change  the switch matrix read issuing capability to 1 for the AXI SRAM target (Target 7) */
+    *((__IO uint32_t*)0x51008108) = 0x00000001U;
+  }
+  
+
+
+/*
+   * Disable the FMC bank1 (enabled after reset).
+   * This, prevents CPU speculation access on this bank which blocks the use of FMC during
+   * 24us. During this time the others FMC master (such as LTDC) cannot use it!
+   */
+  FMC_Bank1_R->BTCR[0] = 0x000030D2;
+
+
+#if defined (DATA_IN_ExtSDRAM)
+  SystemInit_ExtMemCtl(); 
+#endif /* DATA_IN_ExtSDRAM */
+ 
+#endif /* CORE_CM7*/
+
+#ifdef CORE_CM4
+
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = D2_AXISRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+#else
+  SCB->VTOR = FLASH_BANK2_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+#endif  
+
+#else
+#ifdef CORE_CM7
+
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET;       /* Vector Table Relocation in Internal SRAM */
+#else
+  SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET;       /* Vector Table Relocation in Internal FLASH */
+#endif  
+
+#else
+#error Please #define CORE_CM4 or CORE_CM7
+#endif                       
+#endif
+
+}
+
+/**
+   * @brief  Update SystemCoreClock variable according to Clock Register Values.
+  *         The SystemCoreClock variable contains the core clock , it can
+  *         be used by the user application to setup the SysTick timer or configure
+  *         other parameters.
+  *           
+  * @note   Each time the core clock changes, this function must be called
+  *         to update SystemCoreClock variable value. Otherwise, any configuration
+  *         based on this variable will be incorrect.         
+  *     
+  * @note   - The system frequency computed by this function is not the real 
+  *           frequency in the chip. It is calculated based on the predefined 
+  *           constant and the selected clock source:
+  *             
+  *           - If SYSCLK source is CSI, SystemCoreClock will contain the CSI_VALUE(*)                                 
+  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(**)
+  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(***) 
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the CSI_VALUE(*),
+  *             HSI_VALUE(**) or HSE_VALUE(***) multiplied/divided by the PLL factors.
+  *
+  *         (*) CSI_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *             4 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.        
+  *         (**) HSI_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *             64 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.   
+  *    
+  *         (***)HSE_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *              25 MHz), user has to ensure that HSE_VALUE is same as the real
+  *              frequency of the crystal used. Otherwise, this function may
+  *              have wrong result.
+  *                
+  *         - The result of this function could be not correct when using fractional
+  *           value for HSE crystal.
+  * @param  None
+  * @retval None
+  */
+void SystemCoreClockUpdate (void)
+{
+  uint32_t pllp, pllsource, pllm, pllfracen, hsivalue, tmp;
+  uint32_t common_system_clock;
+  float_t fracn1, pllvco;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+
+  switch (RCC->CFGR & RCC_CFGR_SWS)
+  {
+  case RCC_CFGR_SWS_HSI:  /* HSI used as system clock source */
+    common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+    break;
+
+  case RCC_CFGR_SWS_CSI:  /* CSI used as system clock  source */
+    common_system_clock = CSI_VALUE;
+    break;
+
+  case RCC_CFGR_SWS_HSE:  /* HSE used as system clock  source */
+    common_system_clock = HSE_VALUE;
+    break;
+
+  case RCC_CFGR_SWS_PLL1:  /* PLL1 used as system clock  source */
+
+    /* PLL_VCO = (HSE_VALUE or HSI_VALUE or CSI_VALUE/ PLLM) * PLLN
+    SYSCLK = PLL_VCO / PLLR
+    */
+    pllsource = (RCC->PLLCKSELR & RCC_PLLCKSELR_PLLSRC);
+    pllm = ((RCC->PLLCKSELR & RCC_PLLCKSELR_DIVM1)>> 4)  ;
+    pllfracen = ((RCC->PLLCFGR & RCC_PLLCFGR_PLL1FRACEN)>>RCC_PLLCFGR_PLL1FRACEN_Pos);
+    fracn1 = (float_t)(uint32_t)(pllfracen* ((RCC->PLL1FRACR & RCC_PLL1FRACR_FRACN1)>> 3));
+
+    if (pllm != 0U)
+    {
+      switch (pllsource)
+      {
+        case RCC_PLLCKSELR_PLLSRC_HSI:  /* HSI used as PLL clock source */
+
+        hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3)) ;
+        pllvco = ( (float_t)hsivalue / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+
+        break;
+
+        case RCC_PLLCKSELR_PLLSRC_CSI:  /* CSI used as PLL clock source */
+          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+
+        case RCC_PLLCKSELR_PLLSRC_HSE:  /* HSE used as PLL clock source */
+          pllvco = ((float_t)HSE_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+
+      default:
+          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+      }
+      pllp = (((RCC->PLL1DIVR & RCC_PLL1DIVR_P1) >>9) + 1U ) ;
+      common_system_clock =  (uint32_t)(float_t)(pllvco/(float_t)pllp);
+    }
+    else
+    {
+      common_system_clock = 0U;
+    }
+    break;
+
+  default:
+    common_system_clock = CSI_VALUE;
+    break;
+  }
+
+  /* Compute SystemClock frequency --------------------------------------------------*/
+  tmp = D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_D1CPRE)>> RCC_D1CFGR_D1CPRE_Pos];
+
+  /* common_system_clock frequency : CM7 CPU frequency  */
+  common_system_clock >>= tmp;
+
+  /* SystemD2Clock frequency : CM4 CPU, AXI and AHBs Clock frequency  */
+  SystemD2Clock = (common_system_clock >> ((D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_HPRE)>> RCC_D1CFGR_HPRE_Pos]) & 0x1FU));
+
+#if defined(DUAL_CORE) && defined(CORE_CM4)
+  SystemCoreClock = SystemD2Clock;
+#else
+  SystemCoreClock = common_system_clock;
+#endif /* DUAL_CORE && CORE_CM4 */
+}
+#if defined (DATA_IN_ExtSDRAM)
+/**
+  * @brief  Setup the external memory controller.
+  *         Called in startup_stm32h7xx.s before jump to main.
+  *         This function configures the external memories SDRAM
+  *         This SDRAM will be used as program data memory (including heap and stack).
+  * @param  None
+  * @retval None
+  */
+void SystemInit_ExtMemCtl(void)
+{
+  __IO uint32_t tmp = 0;
+  register uint32_t tmpreg = 0, timeout = 0xFFFF;
+  register __IO uint32_t index;
+
+  /* Enable GPIOD, GPIOE, GPIOF, GPIOG, GPIOH and GPIOI interface 
+      clock */
+  RCC->AHB4ENR |= 0x000001F8;
+
+  /* Delay after an RCC peripheral clock enabling */
+  tmp = READ_BIT(RCC->AHB4ENR, RCC_AHB4ENR_GPIOEEN);
+  
+  /* Connect PDx pins to FMC Alternate function */
+  GPIOD->AFR[0]  = 0x000000CC;
+  GPIOD->AFR[1]  = 0xCC000CCC;
+  /* Configure PDx pins in Alternate function mode */  
+  GPIOD->MODER   = 0xAFEAFFFA;
+  /* Configure PDx pins speed to 100 MHz */  
+  GPIOD->OSPEEDR = 0xF03F000F;
+  /* Configure PDx pins Output type to push-pull */  
+  GPIOD->OTYPER  = 0x00000000;
+  /* Configure PDx pins in Pull-up */
+  GPIOD->PUPDR   = 0x50150005;
+   
+  /* Connect PEx pins to FMC Alternate function */
+  GPIOE->AFR[0]  = 0xC00000CC;
+  GPIOE->AFR[1]  = 0xCCCCCCCC;
+  /* Configure PEx pins in Alternate function mode */ 
+  GPIOE->MODER   = 0xAAAABFFA;
+  /* Configure PEx pins speed to 100 MHz */ 
+  GPIOE->OSPEEDR = 0xFFFFC00F;
+  /* Configure PEx pins Output type to push-pull */  
+  GPIOE->OTYPER  = 0x00000000;
+  /* Configure PEx pins in Pull-up */
+  GPIOE->PUPDR   = 0x55554005;
+  
+  /* Connect PFx pins to FMC Alternate function */
+  GPIOF->AFR[0]  = 0x00CCCCCC;
+  GPIOF->AFR[1]  = 0xCCCCC000;
+  /* Configure PFx pins in Alternate function mode */   
+  GPIOF->MODER   = 0xAABFFAAA;
+  /* Configure PFx pins speed to 100 MHz */ 
+  GPIOF->OSPEEDR = 0xFFC00FFF;
+  /* Configure PFx pins Output type to push-pull */  
+  GPIOF->OTYPER  = 0x00000000;
+  /* Configure PFx pins in Pull-up */
+  GPIOF->PUPDR   = 0x55400555;
+  
+  /* Connect PGx pins to FMC Alternate function */
+  GPIOG->AFR[0]  = 0x00CC00CC;
+  GPIOG->AFR[1]  = 0xC000000C;
+  /* Configure PGx pins in Alternate function mode */ 
+  GPIOG->MODER   = 0xBFFEFAFA;
+ /* Configure PGx pins speed to 100 MHz */ 
+  GPIOG->OSPEEDR = 0xC0030F0F;
+  /* Configure PGx pins Output type to push-pull */  
+  GPIOG->OTYPER  = 0x00000000;
+  /* Configure PGx pins in Pull-up */ 
+  GPIOG->PUPDR   = 0x40010505;
+  
+  /* Connect PHx pins to FMC Alternate function */
+  GPIOH->AFR[0]  = 0xCCC00000;
+  GPIOH->AFR[1]  = 0xCCCCCCCC;
+  /* Configure PHx pins in Alternate function mode */ 
+  GPIOH->MODER   = 0xAAAAABFF;
+  /* Configure PHx pins speed to 100 MHz */ 
+  GPIOH->OSPEEDR = 0xFFFFFC00;
+  /* Configure PHx pins Output type to push-pull */  
+  GPIOH->OTYPER  = 0x00000000;
+  /* Configure PHx pins in Pull-up */
+  GPIOH->PUPDR   = 0x55555400;
+  
+/*-- FMC Configuration ------------------------------------------------------*/
+  /* Enable the FMC interface clock */
+  (RCC->AHB3ENR |= (RCC_AHB3ENR_FMCEN));
+  /*SDRAM Timing and access interface configuration*/
+  /*LoadToActiveDelay  = 2
+    ExitSelfRefreshDelay = 6
+    SelfRefreshTime      = 4
+    RowCycleDelay        = 6
+    WriteRecoveryTime    = 2
+    RPDelay              = 2
+    RCDDelay             = 2
+    SDBank             = FMC_SDRAM_BANK2
+    ColumnBitsNumber   = FMC_SDRAM_COLUMN_BITS_NUM_8 
+    RowBitsNumber      = FMC_SDRAM_ROW_BITS_NUM_12
+    MemoryDataWidth    = FMC_SDRAM_MEM_BUS_WIDTH_16
+    InternalBankNumber = FMC_SDRAM_INTERN_BANKS_NUM_4
+    CASLatency         = FMC_SDRAM_CAS_LATENCY_2
+    WriteProtection    = FMC_SDRAM_WRITE_PROTECTION_DISABLE
+    SDClockPeriod      = FMC_SDRAM_CLOCK_PERIOD_2
+    ReadBurst          = FMC_SDRAM_RBURST_ENABLE
+    ReadPipeDelay      = FMC_SDRAM_RPIPE_DELAY_0*/
+  
+  FMC_Bank5_6_R->SDCR[0] = 0x00001800;
+  FMC_Bank5_6_R->SDCR[1] = 0x00000154;
+  FMC_Bank5_6_R->SDTR[0] = 0x00105000;
+  FMC_Bank5_6_R->SDTR[1] = 0x01010351;
+
+  /* SDRAM initialization sequence */
+  /* Clock enable command */ 
+  FMC_Bank5_6_R->SDCMR = 0x00000009; 
+  tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  }
+
+  /* Delay */
+  for (index = 0; index<1000; index++);
+  
+  /* PALL command */ 
+    FMC_Bank5_6_R->SDCMR = 0x0000000A; 	
+  timeout = 0xFFFF;
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  }
+  
+  FMC_Bank5_6_R->SDCMR = 0x000000EB;
+  timeout = 0xFFFF;
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  }
+
+  FMC_Bank5_6_R->SDCMR = 0x0004400C;
+  timeout = 0xFFFF;
+  while((tmpreg != 0) && (timeout-- > 0))
+  {
+    tmpreg = FMC_Bank5_6_R->SDSR & 0x00000020; 
+  } 
+  /* Set refresh count */
+  tmpreg = FMC_Bank5_6_R->SDRTR;
+  FMC_Bank5_6_R->SDRTR = (tmpreg | (0x00000603<<1));
+
+  /* Disable write protection */
+  tmpreg = FMC_Bank5_6_R->SDCR[1]; 
+  FMC_Bank5_6_R->SDCR[1] = (tmpreg & 0xFFFFFDFF);
+
+   /*FMC controller Enable*/
+  FMC_Bank1_R->BTCR[0]  |= 0x80000000;
+ 
+  (void)(tmp);
+}
+#endif /* DATA_IN_ExtSDRAM */
+
+  
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#else
+    #warning pls choose either dualcore_BOOT_cm4master or dualcore_BOOT_cm7master
+#endif

--- a/emBODY/eBcode/arch-arm/board/amcfocm4/examples/embot-os/proj/amcfocm4-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcfocm4/examples/embot-os/proj/amcfocm4-embot-os.uvoptx
@@ -135,7 +135,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z20 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z16 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -327,7 +327,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP1123199 -O16846 -S12 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO51 -TC200000000 -TT400000000 -TP12 -TDX14 -TDD0 -TDS8001 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP1123199 -O462 -S12 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO51 -TC200000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8001 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -342,7 +342,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z0 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z12 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -364,11 +364,6 @@
       <WatchWindow1>
         <Ww>
           <count>0</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>SystemCoreClock,0x0A</ItemText>
-        </Ww>
-        <Ww>
-          <count>1</count>
           <WinNumber>1</WinNumber>
           <ItemText>SystemCoreClock,0x0A</ItemText>
         </Ww>
@@ -430,6 +425,12 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
         <Enable>0</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
@@ -442,7 +443,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -594,7 +595,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -802,7 +803,7 @@
 
   <Group>
     <GroupName>embot::app</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -818,6 +819,30 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>7</GroupNumber>
+      <FileNumber>28</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\embot_app_scope.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_scope.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>7</GroupNumber>
+      <FileNumber>29</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_tools.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -828,7 +853,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -840,7 +865,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -852,7 +877,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -864,7 +889,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -876,7 +901,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>34</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -888,13 +913,25 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>33</FileNumber>
+      <FileNumber>35</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\bsp\embot_hw_flash_amcfocm4.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_hw_flash_amcfocm4.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>36</FileNumber>
+      <FileType>1</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\bsp\system_stm32h7xx-cm4-cm7-gated.c</PathWithFileName>
+      <FilenameWithoutPath>system_stm32h7xx-cm4-cm7-gated.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -908,7 +945,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>34</FileNumber>
+      <FileNumber>37</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amcfocm4/examples/embot-os/proj/amcfocm4-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcfocm4/examples/embot-os/proj/amcfocm4-embot-os.uvprojx
@@ -340,7 +340,7 @@
               <MiscControls>-Ddualcore_BOOT_cm7master -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMCFOCM4 STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\libs\highlevel\services\embenv\api</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -568,6 +568,16 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -602,6 +612,11 @@
               <FileName>embot_hw_flash_amcfocm4.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\embot_hw_flash_amcfocm4.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>system_stm32h7xx-cm4-cm7-gated.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\bsp\system_stm32h7xx-cm4-cm7-gated.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -1071,7 +1086,7 @@
               <MiscControls> -Ddualcore_BOOT_cm4master -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMCFOCM4 STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\libs\highlevel\services\embenv\api</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -1299,6 +1314,16 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1333,6 +1358,11 @@
               <FileName>embot_hw_flash_amcfocm4.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\embot_hw_flash_amcfocm4.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>system_stm32h7xx-cm4-cm7-gated.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\bsp\system_stm32h7xx-cm4-cm7-gated.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcfocm7/bsp/embot_hw_bsp_DRIVER_amcfocm7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfocm7/bsp/embot_hw_bsp_DRIVER_amcfocm7.cpp
@@ -55,9 +55,8 @@ bool embot::hw::bsp::DRIVER::init(const embot::hw::Config &config)
     cfg.tick1ms_get = _get1millitick;       
     stm32hal_config(&cfg);
     
-    // but start it in a special way
-    
-    embot::hw::dualcore::start2();
+    // but init it in a special way    
+    embot::hw::dualcore::init();
     
     return true;    
 }

--- a/emBODY/eBcode/arch-arm/board/amcfocm7/examples/embot-os/proj/amcfocm7-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcfocm7/examples/embot-os/proj/amcfocm7-embot-os.uvoptx
@@ -120,7 +120,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UAny -O206 -S12 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO18 -TC400000000 -TT100000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP1123199 -O206 -S12 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO65587 -TC400000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8001 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -140,7 +140,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z0 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z15 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -158,24 +158,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>117</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134250224</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\bsp\embot_hw_dualcore_bsp_amcfocm7.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\amcfocm7\../../../bsp/embot_hw_dualcore_bsp_amcfocm7.cpp\117</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>
@@ -240,6 +223,12 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
         <Enable>1</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
@@ -342,14 +331,14 @@
         <tDllPa></tDllPa>
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
-        <tIfile></tIfile>
+        <tIfile>.\eventviewer-amcfoc-cfg.ini</tIfile>
         <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP1123199 -O16846 -S12 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO19 -TC400000000 -TT200000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD20000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP1123199 -O16846 -S12 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO65555 -TC400000000 -TT200000000 -TP18 -TDX0 -TDD0 -TDS8001 -TDT0 -TDC10 -TIE80000001 -TIP9 -FO7 -FD20000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -369,7 +358,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z0 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z9 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -452,8 +441,14 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
-        <Enable>1</Enable>
+        <Enable>0</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
@@ -816,6 +811,30 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>7</GroupNumber>
+      <FileNumber>26</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\embot_app_scope.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_scope.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>7</GroupNumber>
+      <FileNumber>27</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_tools.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>
@@ -826,7 +845,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>26</FileNumber>
+      <FileNumber>28</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -838,7 +857,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>27</FileNumber>
+      <FileNumber>29</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -850,7 +869,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>28</FileNumber>
+      <FileNumber>30</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -862,7 +881,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>29</FileNumber>
+      <FileNumber>31</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -874,7 +893,7 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>30</FileNumber>
+      <FileNumber>32</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -886,13 +905,25 @@
     </File>
     <File>
       <GroupNumber>8</GroupNumber>
-      <FileNumber>31</FileNumber>
+      <FileNumber>33</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\bsp\embot_hw_bsp_gpio.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_hw_bsp_gpio.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>8</GroupNumber>
+      <FileNumber>34</FileNumber>
+      <FileType>1</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\bsp\system_stm32h7xx-cm4-cm7-gated.c</PathWithFileName>
+      <FilenameWithoutPath>system_stm32h7xx-cm4-cm7-gated.c</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
@@ -906,7 +937,7 @@
     <RteFlg>0</RteFlg>
     <File>
       <GroupNumber>9</GroupNumber>
-      <FileNumber>32</FileNumber>
+      <FileNumber>35</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>

--- a/emBODY/eBcode/arch-arm/board/amcfocm7/examples/embot-os/proj/amcfocm7-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcfocm7/examples/embot-os/proj/amcfocm7-embot-os.uvprojx
@@ -314,7 +314,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -340,7 +340,7 @@
               <MiscControls>-Ddualcore_BOOT_cm7master -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMCFOCM7 STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -558,6 +558,16 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -592,6 +602,11 @@
               <FileName>embot_hw_bsp_gpio.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\embot_hw_bsp_gpio.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>system_stm32h7xx-cm4-cm7-gated.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\bsp\system_stm32h7xx-cm4-cm7-gated.c</FilePath>
             </File>
           </Files>
         </Group>
@@ -1035,7 +1050,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>
@@ -1061,7 +1076,7 @@
               <MiscControls>-Ddualcore_BOOT_cm4master -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_STM32HAL STM32HAL_BOARD_AMCFOCM7 STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\bsp;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -1279,6 +1294,16 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\embot_app_theLEDmanager.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_app_scope.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\embot_app_scope.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_tools.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools\embot_tools.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -1313,6 +1338,11 @@
               <FileName>embot_hw_bsp_gpio.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\embot_hw_bsp_gpio.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>system_stm32h7xx-cm4-cm7-gated.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\..\..\bsp\system_stm32h7xx-cm4-cm7-gated.c</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcfocm7/examples/embot-os/proj/eventviewer-amcfoc-cfg.ini
+++ b/emBODY/eBcode/arch-arm/board/amcfocm7/examples/embot-os/proj/eventviewer-amcfoc-cfg.ini
@@ -10,9 +10,8 @@
 /* development tools. Nothing else gives you the right to use this software.  */
 /******************************************************************************/
 
-
+// maybe use _WDWORD(regaddr, _RDWORD(regaddr) | val) or something similar that act only on the wanted positions
 FUNC void DebugSetup (void) {
-
   _WDWORD(0x580244E0, _RDWORD(0x580244E0) | 0x0000001C); // RCC_AHB4ENR:   IO port C D E clocks enabled (E is bit pos 4, D pos 3, C pos 2)
     
   _WDWORD(0x58021000, 0x000002A0);                       // GPIOE_MODER:   PE2..PE4 = Alternate function mode: it must be 10b in pairs in pos = 2, 3, 4
@@ -29,7 +28,6 @@ FUNC void DebugSetup (void) {
   _WDWORD(0x58020808, 0x03000000);                       // GPIOC_OSPEEDR: PC12     = 100 MHz speed. it must be 11b in pairs in pos = 12 
   _WDWORD(0x5802080C, 0x00000000);                       // GPIOC_PUPDR:   PC12     = No Pull-up/Pull-down. it must be 00b in pos = 12
   _WDWORD(0x58020824, 0x00000000);                       // GPIOC_AFRH:    PC12     = AF0 with AF0 = 0000b in pos = 12-8=4       
-
 
 // <h> Debug MCU Configuration
 //   <o1.0>    DBG_SLEEP     <i> Debug Sleep Mode

--- a/emBODY/eBcode/arch-arm/board/amcfocm7/system_stm32h7xx_dualcore_boot_cm4_cm7.c
+++ b/emBODY/eBcode/arch-arm/board/amcfocm7/system_stm32h7xx_dualcore_boot_cm4_cm7.c
@@ -1,0 +1,395 @@
+/**
+  ******************************************************************************
+  * @file    system_stm32h7xx_dualcore_boot_cm4_cm7.c
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex-Mx Device Peripheral Access Layer System Source File.
+  *          This provides system initialization template function is case of
+  *          an application using a dual core STM32H7 device where
+  *          Cortex-M7 and Cortex-M4 boot are enabled at the FLASH option bytes
+  *
+  *   This file provides two functions and one global variable to be called from
+  *   user application:
+  *      - SystemInit(): This function is called at startup just after reset and
+  *                      before branch to main program. This call is made inside
+  *                      the "startup_stm32h7xx.s" file.
+  *
+  *      - SystemCoreClock variable: Contains the core clock, it can be used
+  *                                  by the user application to setup the SysTick
+  *                                  timer or configure other parameters.
+  *
+  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+  *                                 be called whenever the core clock is changed
+  *                                 during program execution.
+  *
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32h7xx_system
+  * @{
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Includes
+  * @{
+  */
+
+#include "stm32h7xx.h"
+#include <math.h>
+
+#if !defined  (HSE_VALUE)
+#define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (CSI_VALUE)
+  #define CSI_VALUE    ((uint32_t)4000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* CSI_VALUE */
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)64000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Defines
+  * @{
+  */
+
+/************************* Miscellaneous Configuration ************************/
+/*!< Uncomment the following line if you need to relocate your vector Table in
+     Internal SRAM. */
+/* #define VECT_TAB_SRAM */
+#define VECT_TAB_OFFSET  0x00000000UL /*!< Vector Table base offset field.
+                                      This value must be a multiple of 0x200. */
+/******************************************************************************/
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Variables
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+  */
+  uint32_t SystemCoreClock = 64000000;
+  uint32_t SystemD2Clock = 64000000;
+  const  uint8_t D1CorePrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_FunctionPrototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32H7xx_System_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Setup the microcontroller system
+  *         Initialize the FPU setting and  vector table location
+  *         configuration.
+  * @param  None
+  * @retval None
+  */
+void SystemInit (void)
+{
+  /* FPU settings ------------------------------------------------------------*/
+  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
+  #endif
+
+    /*SEVONPEND enabled so that an interrupt coming from the CPU(n) interrupt signal is
+     detectable by the CPU after a WFI/WFE instruction.*/
+ SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
+
+#ifdef CORE_CM7
+  /* Reset the RCC clock configuration to the default reset state ------------*/
+   /* Increasing the CPU frequency */
+  if(FLASH_LATENCY_DEFAULT  > (READ_BIT((FLASH->ACR), FLASH_ACR_LATENCY)))
+  {
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+	MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, (uint32_t)(FLASH_LATENCY_DEFAULT));
+  }
+
+  /* Set HSION bit */
+  RCC->CR |= RCC_CR_HSION;
+
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000000;
+
+  /* Reset HSEON, HSECSSON, CSION, RC48ON, CSIKERON, PLL1ON, PLL2ON and PLL3ON bits */
+  RCC->CR &= 0xEAF6ED7FU;
+
+   /* Decreasing the number of wait states because of lower CPU frequency */
+  if(FLASH_LATENCY_DEFAULT  < (READ_BIT((FLASH->ACR), FLASH_ACR_LATENCY)))
+  {
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+	MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, (uint32_t)(FLASH_LATENCY_DEFAULT));
+  }
+
+  /* Reset D1CFGR register */
+  RCC->D1CFGR = 0x00000000;
+
+  /* Reset D2CFGR register */
+  RCC->D2CFGR = 0x00000000;
+
+  /* Reset D3CFGR register */
+  RCC->D3CFGR = 0x00000000;
+
+  /* Reset PLLCKSELR register */
+  RCC->PLLCKSELR = 0x02020200;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x01FF0000;
+  /* Reset PLL1DIVR register */
+  RCC->PLL1DIVR = 0x01010280;
+  /* Reset PLL1FRACR register */
+  RCC->PLL1FRACR = 0x00000000;
+
+  /* Reset PLL2DIVR register */
+  RCC->PLL2DIVR = 0x01010280;
+
+  /* Reset PLL2FRACR register */
+
+  RCC->PLL2FRACR = 0x00000000;
+  /* Reset PLL3DIVR register */
+  RCC->PLL3DIVR = 0x01010280;
+
+  /* Reset PLL3FRACR register */
+  RCC->PLL3FRACR = 0x00000000;
+
+  /* Reset HSEBYP bit */
+  RCC->CR &= 0xFFFBFFFFU;
+
+  /* Disable all interrupts */
+  RCC->CIER = 0x00000000;
+
+  /* Enable CortexM7 HSEM EXTI line (line 78)*/
+  EXTI_D2->EMR3 |= 0x4000UL;
+
+
+  if((DBGMCU->IDCODE & 0xFFFF0000U) < 0x20000000U)
+  {
+    /* if stm32h7 revY*/
+    /* Change  the switch matrix read issuing capability to 1 for the AXI SRAM target (Target 7) */
+    *((__IO uint32_t*)0x51008108) = 0x000000001U;
+  }
+
+#endif /* CORE_CM7*/
+
+#ifdef CORE_CM4
+
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = D2_AXISRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+#else
+  SCB->VTOR = FLASH_BANK2_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+#endif
+
+#else
+#ifdef CORE_CM7
+
+  /*
+   * Disable the FMC bank1 (enabled after reset).
+   * This, prevents CPU speculation access on this bank which blocks the use of FMC during
+   * 24us. During this time the others FMC master (such as LTDC) cannot use it!
+   */
+  FMC_Bank1_R->BTCR[0] = 0x000030D2;
+
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal D1 AXI-RAM */
+#else
+  SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET;       /* Vector Table Relocation in Internal FLASH */
+#endif
+
+#else
+#error Please #define CORE_CM4 or CORE_CM7
+#endif
+#endif
+
+}
+
+/**
+   * @brief  Update SystemCoreClock variable according to Clock Register Values.
+  *         The SystemCoreClock variable contains the core clock , it can
+  *         be used by the user application to setup the SysTick timer or configure
+  *         other parameters.
+  *
+  * @note   Each time the core clock changes, this function must be called
+  *         to update SystemCoreClock variable value. Otherwise, any configuration
+  *         based on this variable will be incorrect.
+  *
+  * @note   - The system frequency computed by this function is not the real
+  *           frequency in the chip. It is calculated based on the predefined
+  *           constant and the selected clock source:
+  *
+  *           - If SYSCLK source is CSI, SystemCoreClock will contain the CSI_VALUE(*)
+  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(**)
+  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(***)
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the CSI_VALUE(*),
+  *             HSI_VALUE(**) or HSE_VALUE(***) multiplied/divided by the PLL factors.
+  *
+  *         (*) CSI_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *             4 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.
+  *         (**) HSI_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *             64 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.
+  *
+  *         (***)HSE_VALUE is a constant defined in stm32h7xx_hal.h file (default value
+  *              25 MHz), user has to ensure that HSE_VALUE is same as the real
+  *              frequency of the crystal used. Otherwise, this function may
+  *              have wrong result.
+  *
+  *         - The result of this function could be not correct when using fractional
+  *           value for HSE crystal.
+  * @param  None
+  * @retval None
+  */
+void SystemCoreClockUpdate (void)
+{
+  uint32_t pllp, pllsource, pllm, pllfracen, hsivalue, tmp;
+  uint32_t common_system_clock;
+  float_t fracn1, pllvco;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+
+  switch (RCC->CFGR & RCC_CFGR_SWS)
+  {
+  case RCC_CFGR_SWS_HSI:  /* HSI used as system clock source */
+    common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+    break;
+
+  case RCC_CFGR_SWS_CSI:  /* CSI used as system clock  source */
+    common_system_clock = CSI_VALUE;
+    break;
+
+  case RCC_CFGR_SWS_HSE:  /* HSE used as system clock  source */
+    common_system_clock = HSE_VALUE;
+    break;
+
+  case RCC_CFGR_SWS_PLL1:  /* PLL1 used as system clock  source */
+
+    /* PLL_VCO = (HSE_VALUE or HSI_VALUE or CSI_VALUE/ PLLM) * PLLN
+    SYSCLK = PLL_VCO / PLLR
+    */
+    pllsource = (RCC->PLLCKSELR & RCC_PLLCKSELR_PLLSRC);
+    pllm = ((RCC->PLLCKSELR & RCC_PLLCKSELR_DIVM1)>> 4)  ;
+    pllfracen = ((RCC->PLLCFGR & RCC_PLLCFGR_PLL1FRACEN)>>RCC_PLLCFGR_PLL1FRACEN_Pos);
+    fracn1 = (float_t)(uint32_t)(pllfracen* ((RCC->PLL1FRACR & RCC_PLL1FRACR_FRACN1)>> 3));
+
+    if (pllm != 0U)
+    {
+      switch (pllsource)
+      {
+        case RCC_PLLCKSELR_PLLSRC_HSI:  /* HSI used as PLL clock source */
+
+        hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3)) ;
+        pllvco = ( (float_t)hsivalue / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+
+        break;
+
+        case RCC_PLLCKSELR_PLLSRC_CSI:  /* CSI used as PLL clock source */
+          pllvco = ((float_t)CSI_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+
+        case RCC_PLLCKSELR_PLLSRC_HSE:  /* HSE used as PLL clock source */
+          pllvco = ((float_t)HSE_VALUE / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+
+      default:
+          hsivalue = (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3)) ;
+          pllvco = ((float_t)hsivalue / (float_t)pllm) * ((float_t)(uint32_t)(RCC->PLL1DIVR & RCC_PLL1DIVR_N1) + (fracn1/(float_t)0x2000) +(float_t)1 );
+        break;
+      }
+      pllp = (((RCC->PLL1DIVR & RCC_PLL1DIVR_P1) >>9) + 1U ) ;
+      common_system_clock =  (uint32_t)(float_t)(pllvco/(float_t)pllp);
+    }
+    else
+    {
+      common_system_clock = 0U;
+    }
+    break;
+
+  default:
+    common_system_clock = (uint32_t) (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV)>> 3));
+    break;
+  }
+
+  /* Compute SystemClock frequency --------------------------------------------------*/
+  tmp = D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_D1CPRE)>> RCC_D1CFGR_D1CPRE_Pos];
+
+  /* common_system_clock frequency : CM7 CPU frequency  */
+  common_system_clock >>= tmp;
+
+  /* SystemD2Clock frequency : CM4 CPU, AXI and AHBs Clock frequency  */
+  SystemD2Clock = (common_system_clock >> ((D1CorePrescTable[(RCC->D1CFGR & RCC_D1CFGR_HPRE)>> RCC_D1CFGR_HPRE_Pos]) & 0x1FU));
+
+#if defined(DUAL_CORE) && defined(CORE_CM4)
+  SystemCoreClock = SystemD2Clock;
+#else
+  SystemCoreClock = common_system_clock;
+#endif /* DUAL_CORE && CORE_CM4 */
+}
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_dualcore.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_dualcore.h
@@ -19,9 +19,9 @@
 namespace embot::hw::dualcore {
         
     enum class CORE : uint8_t { cm4 = 0, cm7 = 1, none = 31, maxnumberof = 2 };
-    enum class BOOT : uint8_t { cm4master = 0, cm7master = 1, none = 31 };
+    enum class BOOT : uint8_t { cm4master = 0, cm7master = 1, none = 31, maxnumberof = 2 };
     
-    // what is actually executed .. just before embot:hw::bsp::specialize()
+    
     struct Config
     {   
         enum class HW : uint8_t { dontinit = 0, forceinit = 1 };
@@ -42,13 +42,9 @@ namespace embot::hw::dualcore {
     CORE core();
     BOOT boot();
     
-    // it must be called in main() before start()
-    bool config(const Config &on);
-    
-    // it must be called just after embot::hw::bsp::DRIVER::init() or even better instead that
-    bool start();
-    
-    bool start2();
+
+    bool config(const Config &on);   
+    bool init();
     
    
 } // namespace embot::hw::dualcore {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_dualcore_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_dualcore_bsp.h
@@ -24,9 +24,10 @@ namespace embot::hw::dualcore::bsp {
     struct PROP
     {
         embot::hw::dualcore::CORE core {embot::hw::dualcore::CORE::cm7}; 
-        embot::hw::dualcore::BOOT boot {embot::hw::dualcore::BOOT::cm7master}; 
+        embot::hw::dualcore::BOOT boot {embot::hw::dualcore::BOOT::cm7master};
+        embot::hw::MTX mtx {embot::hw::MTX::one};         
         constexpr PROP() = default;
-        constexpr PROP(embot::hw::dualcore::CORE c, embot::hw::dualcore::BOOT b) : core(c), boot(b) {} 
+        constexpr PROP(embot::hw::dualcore::CORE c, embot::hw::dualcore::BOOT b, embot::hw::MTX m) : core(c), boot(b), mtx(m) {} 
     };
        
     struct BSP : public embot::hw::bsp::SUPP
@@ -43,8 +44,7 @@ namespace embot::hw::dualcore::bsp {
         bool supported() const { return embot::hw::bsp::SUPP::supported(thempu); }
         bool config(const Config &c) const;
         const Config& config() const;
-        bool start() const;
-        bool hwinit() const;
+        bool init() const;
     };
     
     const BSP& getBSP();

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.dualcore.uvoptx
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.dualcore.uvoptx
@@ -827,7 +827,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -1015,7 +1015,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -1150,7 +1150,7 @@
 
   <Group>
     <GroupName>driver-stm32h7-v1A0</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.dualcore.uvprojx
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.dualcore.uvprojx
@@ -9489,6 +9489,57 @@
               <FileName>system_stm32h7xx_dualcore_boot_cm4_cm7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\src\driver\stm32h7-v1A0\src\system_stm32h7xx_dualcore_boot_cm4_cm7.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>stm32h7xx_ll_gpio.c</FileName>
@@ -11103,6 +11154,57 @@
               <FileName>stm32h7xx_hal_msp.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\src\board\amcfocm7\v1A0\src\stm32h7xx_hal_msp.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
           </Files>
         </Group>
@@ -11812,6 +11914,57 @@
               <FileName>system_stm32h7xx_dualcore_boot_cm4_cm7.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\src\driver\stm32h7-v1A0\src\system_stm32h7xx_dualcore_boot_cm4_cm7.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>stm32h7xx_ll_gpio.c</FileName>
@@ -13357,6 +13510,57 @@
               <FileName>stm32h7xx_hal_msp.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\src\board\amcfocm4\v1A0\src\stm32h7xx_hal_msp.c</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
           </Files>
         </Group>


### PR DESCRIPTION
This PR improves the PR #481 and adds some performance tests on the the cores.

The boot strategy now uses a `SystemInit()` function, the one executed before the` main()`, that changes its behavior depending on the four cases of `CORE_CM4` or `CORE_CM7` when it is `dualcore_BOOT_cm4master` or `dualcore_BOOT_cm7master`.

This PR can be safely merged as it does not touch any other code than for board `amcfoc`.