### PR TITLE
Fix/versions alignment amc2c v3.0.3 + amcbldc 2.0.13

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -38,9 +38,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 0, 1, 0},   // application version
+        {3, 0, 2, 0},   // application version
         {2, 0},         // protocol version
-        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::six, 16, 45}
+        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::eleven, 16, 00}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -38,9 +38,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 0, 2, 0},   // application version
+        {3, 0, 3, 0},   // application version
         {2, 0},         // protocol version
-        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::eleven, 16, 00}
+        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::fourteen, 11, 30}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/motorhal.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/motorhal/motorhal.h
@@ -196,8 +196,7 @@ namespace embot::hw::analog {
     
 struct Configuration
 {
-    uint32_t ciao {0};
-    
+    //uint32_t ciao {0};
         
     constexpr Configuration() = default;
     constexpr bool isvalid() const { return true; }

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
@@ -30,7 +30,7 @@ namespace embot::app::board::amcbldc::info {
     
     constexpr embot::prot::can::applicationInfo applInfo 
     {   
-        embot::prot::can::versionOfAPPLICATION {2, 0, 12},    
+        embot::prot::can::versionOfAPPLICATION {2, 0, 13},    
         embot::prot::can::versionOfCANPROTOCOL {2, 0}   
     };
 

--- a/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/application/src/app-board-amcbldc/embot_app_board_amcbldc_info.cpp
@@ -30,7 +30,7 @@ namespace embot::app::board::amcbldc::info {
     
     constexpr embot::prot::can::applicationInfo applInfo 
     {   
-        embot::prot::can::versionOfAPPLICATION {2, 0, 11},    
+        embot::prot::can::versionOfAPPLICATION {2, 0, 12},    
         embot::prot::can::versionOfCANPROTOCOL {2, 0}   
     };
 


### PR DESCRIPTION
In https://github.com/robotology/icub-firmware/pull/480 and https://github.com/robotology/icub-firmware/pull/482 I was missing to push the sources with the updated versions info for `amc2c` and `amcbldc`.

This PR increase the version by one to be sure to be aligned.

cc @marcoaccame 