### PR TITLE
BAT updates

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 1},
-            {2024, Month::Mar, Day::fifteen, 12, 00}
+            {2, 2},
+            {2024, Month::Mar, Day::twentyone, 15, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Inc/BAT_B.h
@@ -140,5 +140,6 @@ extern adc_measure_t mean;
 extern uint32_t adc_values[9];
 extern fifo adc_samples;
 extern uint32_t vBatterydV;
+extern uint32_t iBatterydA;
 
 #endif

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -11,7 +11,7 @@
 
 char Firmware_vers = 1;
 char Revision_vers = 3;
-char Build_number  = 3;
+char Build_number  = 4;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis
 uint32_t vhyst=0;    // voltage hysteresis
@@ -108,13 +108,14 @@ uint16_t Battery_low=3300*7;    // 7s5p battery
 #ifdef BAT_B_Generic
 uint32_t VTH[7]={32000, 34000, 36000, 38000, 40000, 42000, 44000};   // threshold in mV iCub 2.5 Battery
 uint16_t Battery_high=4200*10;   // 10s3p battery
-uint16_t Battery_low=3300*10;    // 10s3p battery
+uint16_t Battery_low=3000*10;    // 10s3p battery
 #endif
 
 adc_measure_t adc_measure = {0};  // initialize all adc values to 0
 adc_measure_t mean = {0};         // initialize all average values to 0
 uint32_t adc_values[9];           // contains all ADC channels conversion
-uint32_t vBatterydV = 0;          // varibale used for sending mean.V_BATTERY to EMS in deciVolt
+uint32_t vBatterydV = 0;          // variable used for sending mean.V_BATTERY to EMS in deciVolt
+uint32_t iBatterydA = 0;          // variable used for sending the mean.I_BATTERY_M_B in deciAmpere
 
 uint16_t adc_sample = 0;
 

--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/Display_uOLED.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/Display_uOLED.c
@@ -24,9 +24,6 @@ void Display_uOLED_init(){
 
 
 void Display_uOLED_128_G2(){
-  if(mean.V_BATTERY > Battery_high)       {Battery_charge=100;}
-  else if(mean.V_BATTERY < Battery_low)   {Battery_charge=0;}
-  else                                    {Battery_charge = 100*(mean.V_BATTERY-Battery_low)/(Battery_high-Battery_low);}
   
   //uOLED_Parameters[0] 
   //uOLED_Parameters[1] 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          86
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          87
 
 //  </h>version
 
@@ -91,9 +91,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/embot_app_eth_theBATservice.h
@@ -95,7 +95,7 @@ public:
   static constexpr eOas_battery_status_t defaultBATstatus{
       .timedvalue = {.age = 0,
                      .temperature = 0,
-                     //.status = 0,
+                     .status = 0,
                      .voltage = 0,
                      .current = 0,
                      .charge = 0}};

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          68
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          69
 
 //  </h>version
 
@@ -85,9 +85,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          89
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          90
 
 //  </h>version
 
@@ -94,9 +94,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 


### PR DESCRIPTION
This PR implements the improvements required in https://github.com/robotology/icub-firmware/issues/476 .

Changes of this PR:
- Update status bat to uint16_t for struct `eOas_battery_timedvalue_t` valid for both BAT and BMS devices
- Add total absorbed current to BAT yarp port
- Set BAT port voltage as the INPUT voltage
- Move the calculation of the BAT Battery_Charge from the methods related to the display only to a proper place with an ad-hoc function
- Update bat v1.3.4, ems v3.87, mc4plus v3.90, mc2plus 3.69, amc 2.2

Related to: 
- https://github.com/robotology/icub-firmware-shared/pull/95
- https://github.com/robotology/icub-main/pull/953
- https://github.com/robotology/icub-firmware-build/pull/146