### PR TITLE
Fix to ICC communication between the `amc` and `amc2c` board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 2},
-            {2024, Month::Mar, Day::twentyone, 15, 00}
+            {2, 3},
+            {2024, Month::Apr, Day::eleven, 11, 18}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvoptx
@@ -358,7 +358,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP1123199 -O16846 -S12 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO32819 -TC200000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8001 -TDT0 -TDC1F -TIE1 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP1123199 -O16846 -S12 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO32819 -TC200000000 -TT400000000 -TP18 -TDX0 -TDD0 -TDS8001 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -373,7 +373,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z21 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z12 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -445,7 +445,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>1</periodic>
-        <aLwin>0</aLwin>
+        <aLwin>1</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -481,6 +481,12 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <SystemViewers>
+        <Entry>
+          <Name>OS Support\Event Viewer</Name>
+          <WinId>35905</WinId>
+        </Entry>
+      </SystemViewers>
       <DebugDescription>
         <Enable>0</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
@@ -698,7 +704,7 @@
 
   <Group>
     <GroupName>theMBD</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -718,7 +724,7 @@
 
   <Group>
     <GroupName>embot::app::bldc</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -786,7 +792,7 @@
 
   <Group>
     <GroupName>embot::app::application</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -842,7 +848,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -958,7 +964,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1170,7 +1176,7 @@
 
   <Group>
     <GroupName>embot::hw::lowlevel-0optimized</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1190,7 +1196,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1282,7 +1288,7 @@
 
   <Group>
     <GroupName>motorhal</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -38,9 +38,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 0, 3, 0},   // application version
+        {3, 0, 4, 0},   // application version
         {2, 0},         // protocol version
-        {2024, embot::app::eth::Month::Mar, embot::app::eth::Day::fourteen, 11, 30}
+        {2024, embot::app::eth::Month::Apr, embot::app::eth::Day::eleven, 11, 15}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.cpp
@@ -428,6 +428,8 @@ void embot::app::board::amc2c::theMBD::Impl::onEXTFAULTpressedreleased(void *own
 // Called every 1 ms
 bool embot::app::board::amc2c::theMBD::Impl::tick(const std::vector<embot::app::bldc::MSG> &inputmessages, std::vector<embot::app::bldc::MSG> &outputmessages)
 {     
+#if defined(COMM_BUS_LOCKED_AT_FIRST_MC_RECEPTION)
+    // the first time we receive a message we use its bus forever    
     static bool lockedtobus {false};
 
     if((false == lockedtobus) && (false == inputmessages.empty()))
@@ -435,6 +437,14 @@ bool embot::app::board::amc2c::theMBD::Impl::tick(const std::vector<embot::app::
         lockedtobus = true;
         bus2use = inputmessages[0].location.getbus();
     }
+#else
+    // we allow the bus to change in the lifetime of the board. 
+    // we reply to the bus of the first input message    
+    if(false == inputmessages.empty())
+    {
+        bus2use = inputmessages[0].location.getbus();
+    }
+#endif    
 
     // in here... 
     // inputmessages.size() is always <= 4.
@@ -483,6 +493,16 @@ bool embot::app::board::amc2c::theMBD::Impl::tick(const std::vector<embot::app::
     
     // read Vcc (in Volts)
     AMC_BLDC_U.SensorsData_p.supplyvoltagesensors.voltage = _rounder.getRoundedValueOf(embot::hw::motor::getVIN());
+
+// just a print debug    
+//    constexpr embot::core::Time freq { embot::core::time1second };
+//    static embot::core::Time tt = embot::core::now();
+//    embot::core::Time n = embot::core::now();
+//    if((n-tt) > freq)
+//    {
+//        tt = n;
+//        embot::core::print("Vcc = " + std::to_string(embot::hw::motor::getVIN()));
+//    }
     
     
     // -----------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c_config.h
@@ -29,6 +29,7 @@
     #define EMBOT_ENABLE_hw_button
     
     #define EMBOT_ENABLE_hw_motor
+    #define EMBOT_ENABLE_hw_analog_ish
     #define EMBOT_ENABLE_hw_flash
     #define EMBOT_ENABLE_hw_timer
     #define EMBOT_ENABLE_hw_can

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_motor_bsp_amc2c.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_motor_bsp_amc2c.cpp
@@ -98,21 +98,28 @@ namespace embot::hw::motor::bsp {
  
 
 // the motorhal requires:
-// ADC1, ADC2, ADC3
-// TIM1, TIM4, TIM5, TIM6
+// ADC1, ADC2
+// TIM1, TIM4, TIM5
+// ADC3 and TIM6 for measuring power supply and currents
 
 
 namespace embot::hw::motor::bsp::amc2c {
     
     ADC_HandleTypeDef hADC1;
     ADC_HandleTypeDef hADC2;
-    ADC_HandleTypeDef hADC3;
+
     DMA_HandleTypeDef hdma_adc1;
-    DMA_HandleTypeDef hdma_adc3;
+
     TIM_HandleTypeDef hTIM1;
     TIM_HandleTypeDef hTIM4;
-    TIM_HandleTypeDef hTIM5;
-    TIM_HandleTypeDef hTIM6;
+    TIM_HandleTypeDef hTIM5;   
+    
+#if defined(EMBOT_ENABLE_hw_analog_ish)     
+    TIM_HandleTypeDef hTIM6;    
+    ADC_HandleTypeDef hADC3;    
+    DMA_HandleTypeDef hdma_adc3;
+#endif    
+
 }
 
 namespace embot::hw::motor::bsp::amc2c {
@@ -124,9 +131,11 @@ namespace embot::hw::motor::bsp::amc2c {
     void MX_DMA_Init();
     void MX_ADC1_Init();
     void MX_ADC2_Init();
+    
+#if defined(EMBOT_ENABLE_hw_analog_ish)    
     void MX_ADC3_Init();
     void MX_TIM6_Init();
-    
+#endif    
     
     void Init_MOTOR(embot::hw::MOTOR h)
     {
@@ -141,11 +150,15 @@ namespace embot::hw::motor::bsp::amc2c {
         MX_ADC2_Init();
 //        MX_DAC1_Init();
         MX_TIM1_Init();
-        
+
+#if defined(EMBOT_ENABLE_hw_analog_ish)
+        // TIM6 ticks ADC3 to retrieves the values        
         MX_ADC3_Init();
-        MX_TIM6_Init();
-        
-        // something else
+        MX_TIM6_Init();       
+#endif    
+    
+        // something else ?
+        // ...
     }
     
     void Init_MOTORHAL_testmode(embot::hw::MOTOR h)
@@ -605,6 +618,8 @@ namespace embot::hw::motor::bsp::amc2c {
         /* USER CODE END TIM5_Init 2 */
 
     }    
+
+#if defined(EMBOT_ENABLE_hw_analog_ish)
     
     void MX_TIM6_Init(void)
     {
@@ -646,6 +661,8 @@ namespace embot::hw::motor::bsp::amc2c {
       /* USER CODE END TIM6_Init 2 */
     }
 
+#endif // #if defined(EMBOT_ENABLE_hw_analog_ish)
+    
     void DeInit_TIM5()
     {
         // HAL_TIM_IC_ConfigChannel() inversa for TIM_CHANNEL_3 and TIM_CHANNEL_4
@@ -957,6 +974,8 @@ namespace embot::hw::motor::bsp::amc2c {
 
     }
 
+#if defined(EMBOT_ENABLE_hw_analog_ish)
+    
     void MX_ADC3_Init(void)
     {
 
@@ -1061,6 +1080,7 @@ namespace embot::hw::motor::bsp::amc2c {
 
     }
     
+#endif // #if defined(EMBOT_ENABLE_hw_analog_ish)    
 
 } // namespace embot::hw::motor::bsp {
 
@@ -1077,7 +1097,9 @@ extern "C" {
     {
         HAL_ADC_IRQHandler(&embot::hw::motor::bsp::amc2c::hADC1);
         HAL_ADC_IRQHandler(&embot::hw::motor::bsp::amc2c::hADC2);
+#if defined(EMBOT_ENABLE_hw_analog_ish)        
         HAL_ADC_IRQHandler(&embot::hw::motor::bsp::amc2c::hADC3);
+#endif
     }   
 
     // DMA2 stream0 global interrupt
@@ -1085,13 +1107,15 @@ extern "C" {
     {
         HAL_DMA_IRQHandler(&embot::hw::motor::bsp::amc2c::hdma_adc1);
     }
-    
+
+#if defined(EMBOT_ENABLE_hw_analog_ish)      
     // DMA1 stream4 global interrupt
     void DMA1_Stream4_IRQHandler(void)
     {
         HAL_DMA_IRQHandler(&embot::hw::motor::bsp::amc2c::hdma_adc3);
     }
-
+#endif
+    
     // - msp functions    
     
     static uint32_t HAL_RCC_ADC12_CLK_ENABLED=0;
@@ -1215,6 +1239,7 @@ extern "C" {
 
             /* USER CODE END ADC2_MspInit 1 */
         }
+#if defined(EMBOT_ENABLE_hw_analog_ish)          
         else if(hadc->Instance==ADC3)
         {
         /* USER CODE BEGIN ADC3_MspInit 0 */
@@ -1266,6 +1291,7 @@ extern "C" {
           
           /* USER CODE END ADC3_MspInit 1 */
         }
+#endif // #if defined(EMBOT_ENABLE_hw_analog_ish)          
 
     }
 
@@ -1350,6 +1376,7 @@ extern "C" {
 
             /* USER CODE END ADC2_MspDeInit 1 */
         }
+#if defined(EMBOT_ENABLE_hw_analog_ish)        
         else if(hadc->Instance==ADC3)
         {
             /* USER CODE BEGIN ADC3_MspDeInit 0 */
@@ -1372,6 +1399,7 @@ extern "C" {
             
             /* USER CODE END ADC3_MspDeInit 1 */
         }
+#endif // #if defined(EMBOT_ENABLE_hw_analog_ish)        
     }    
 
 
@@ -1579,6 +1607,7 @@ namespace embot::hw::motor::bsp::amc2c {
 
             /* USER CODE END TIM4_MspInit 1 */
         }
+#if defined(EMBOT_ENABLE_hw_analog_ish)        
         else if(htim_base->Instance==TIM6)
         {
         /* USER CODE BEGIN TIM6_MspInit 0 */
@@ -1590,6 +1619,7 @@ namespace embot::hw::motor::bsp::amc2c {
 
         /* USER CODE END TIM6_MspInit 1 */
         }
+#endif // #if defined(EMBOT_ENABLE_hw_analog_ish)        
     }
 
     void TIM_base_MspDeInit(TIM_HandleTypeDef* htim_base)
@@ -1651,6 +1681,7 @@ namespace embot::hw::motor::bsp::amc2c {
 
             /* USER CODE END TIM4_MspDeInit 1 */
         }
+#if defined(EMBOT_ENABLE_hw_analog_ish)        
         else if(htim_base->Instance==TIM6)
         {
         /* USER CODE BEGIN TIM6_MspDeInit 0 */
@@ -1662,6 +1693,7 @@ namespace embot::hw::motor::bsp::amc2c {
         
         /* USER CODE END TIM6_MspDeInit 1 */
         }
+#endif // #if defined(EMBOT_ENABLE_hw_analog_ish)        
     }    
 } // namespace embot::hw::motor::bsp::amc2c {
 

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_mtx_bsp_amc2c.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_mtx_bsp_amc2c.cpp
@@ -128,9 +128,9 @@ namespace embot::hw::mtx::bsp {
         
         if(false == irqinitted)
         {
-            HAL_NVIC_SetPriority(HSEM1_IRQn, 10, 0);
+            HAL_NVIC_SetPriority(HSEM1_IRQn, 0, 0);
             HAL_NVIC_EnableIRQ(HSEM1_IRQn);
-            HAL_NVIC_SetPriority(HSEM2_IRQn, 10, 0);
+            HAL_NVIC_SetPriority(HSEM2_IRQn, 0, 0);
             HAL_NVIC_EnableIRQ(HSEM2_IRQn);            
             irqinitted = true;
         }           

--- a/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h
@@ -26,6 +26,7 @@
     #define EMBOT_ENABLE_hw_led
     #define EMBOT_ENABLE_hw_can
     #define EMBOT_ENABLE_hw_motor
+    #define EMBOT_ENABLE_hw_analog_ish
     #define EMBOT_ENABLE_hw_button
 
     // #define EMBOT_ENABLE_hw_i2c    

--- a/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theApplication.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theApplication.cpp
@@ -149,17 +149,27 @@ void embot::app::bldc::theApplication::Impl::onDefaultError(void* errparam)
     //for(;;);    
 }
 
+#define MOREpriority2COMMthread
 
 void embot::app::bldc::theApplication::Impl::justbeforeSchedulerStart(embot::os::Thread *t, void* initparam)
 {
     Impl *impl = reinterpret_cast<Impl*>(initparam);    
+    
+#if defined(MOREpriority2COMMthread)    
+    constexpr embot::os::Priority pcomm { embot::os::Priority::high45 };
+    constexpr embot::os::Priority pctrl { embot::os::Priority::high44 };
+#else    
+    constexpr embot::os::Priority pcomm { embot::os::Priority::high44 };
+    constexpr embot::os::Priority pctrl { embot::os::Priority::high45 };
+#endif    
+
 
     // we perform in here all operations formerly done by theCANboardInfo such as synch the application info etc.
     impl->_canagentcore = impl->_config.core.getagentcore();
     // we start communication
     embot::app::bldc::theCOMM::Config commConfig 
     {
-        embot::os::Priority::high44,
+        pcomm,
         impl->_config.comm.stacksize,
         50*embot::core::time1millisec,
         impl->_canagentcore,
@@ -170,7 +180,7 @@ void embot::app::bldc::theApplication::Impl::justbeforeSchedulerStart(embot::os:
     // we start control
     embot::app::bldc::theCTRL::Config ctrlConfig 
     {
-        embot::os::Priority::high45,
+        pctrl,
         impl->_config.ctrl.stacksize,
         1*embot::core::time1millisec,
         impl->_canagentcore,

--- a/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theCOMMcanicc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theCOMMcanicc.cpp
@@ -103,8 +103,8 @@ struct embot::app::bldc::theCOMM::Impl
     embot::app::msg::BUS mcBUS2use {embot::app::msg::BUS::none};
     
     embot::app::LEDwaveT<64> ledwavemcBUSnone {100*embot::core::time1millisec, 30, std::bitset<64>(0b0101010101)};   
-    embot::app::LEDwaveT<64> ledwavemcBUScan {100*embot::core::time1millisec, 20, std::bitset<64>(0b0101)};
-    embot::app::LEDwaveT<64> ledwavemcBUSicc {100*embot::core::time1millisec, 10, std::bitset<64>(0b01)};
+    embot::app::LEDwaveT<64> ledwavemcBUScan {250*embot::core::time1millisec, 10, std::bitset<64>(0b0101)};
+    embot::app::LEDwaveT<64> ledwavemcBUSicc {250*embot::core::time1millisec, 10, std::bitset<64>(0b01)};
     
     bool acceptMCmessage(const embot::app::bldc::MSG &msg);
     void locktoBUS(const embot::app::bldc::MSG &msg);
@@ -383,16 +383,18 @@ bool embot::app::bldc::theCOMM::Impl::acceptMCmessage(const embot::app::bldc::MS
     {
         r = false;
     }
-    
+#if defined(COMM_BUS_LOCKED_AT_FIRST_MC_RECEPTION)
     if((embot::app::msg::BUS::none != mcBUS2use) && (msg.location.getbus() != mcBUS2use))
     {
         r = false;
     }
-       
+#else
+#endif
+
     return r;
 }
 
-
+#if defined(COMM_BUS_LOCKED_AT_FIRST_MC_RECEPTION)
 void embot::app::bldc::theCOMM::Impl::locktoBUS(const embot::app::bldc::MSG &msg)
 {    
     if(embot::app::msg::BUS::none == mcBUS2use)
@@ -401,6 +403,24 @@ void embot::app::bldc::theCOMM::Impl::locktoBUS(const embot::app::bldc::MSG &msg
        embot::app::theLEDmanager::getInstance().get(embot::hw::LED::one).wave((embot::app::msg::typeofBUS::CAN == embot::app::msg::bus_to_type(mcBUS2use)) ? (&ledwavemcBUScan) : (&ledwavemcBUSicc));
     }
 }
+#else
+void embot::app::bldc::theCOMM::Impl::locktoBUS(const embot::app::bldc::MSG &msg)
+{
+    // we lock to bus in case of unicast messages of MC only
+    bool isUnicast = (embot::prot::can::frame2destination(msg.frame) == _tCOMMcanaddress); // _tCOMMcanaddress is both icc or can address 
+    bool isMCpolling = (embot::prot::can::Clas::pollingMotorControl == embot::prot::can::frame2clas(msg.frame));
+    
+    // and if the bus is different from the one we are locked now.
+    // surely nobody must send a unicast mc polling over CAN to this board when we it uses icc
+    auto b = msg.location.getbus();
+    
+    if((true == isUnicast) && (true == isMCpolling) && (b != mcBUS2use))
+    {
+       mcBUS2use = b;
+       embot::app::theLEDmanager::getInstance().get(embot::hw::LED::one).wave((embot::app::msg::typeofBUS::CAN == embot::app::msg::bus_to_type(mcBUS2use)) ? (&ledwavemcBUScan) : (&ledwavemcBUSicc));
+    }
+}
+#endif
 
 void embot::app::bldc::theCOMM::Impl::tCOMM_OnRXmessage(embot::os::Thread *t, embot::os::EventMask eventmask, void *param, const embot::app::bldc::MSG &msg, std::vector<embot::app::bldc::MSG> &outframes)
 {   
@@ -412,7 +432,15 @@ void embot::app::bldc::theCOMM::Impl::tCOMM_OnRXmessage(embot::os::Thread *t, em
     else if(true == acceptMCmessage(msg))
     {
         locktoBUS(msg);
+#if defined(COMM_BUS_LOCKED_AT_FIRST_MC_RECEPTION)
         embot::app::bldc::theMSGbroker::getInstance().add(embot::app::bldc::theMSGbroker::Direction::INP, msg);
+#else        
+        if(msg.location.getbus() == mcBUS2use)
+        {
+            // is such a way i filter out the MC CAN periodic that the host sends to the other boards (in case i am attached to CAN)
+            embot::app::bldc::theMSGbroker::getInstance().add(embot::app::bldc::theMSGbroker::Direction::INP, msg);
+        }
+#endif        
     }
 
     if(false == _tCOMMtmpCANframes.empty())

--- a/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theCOMMcanicc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theCOMMcanicc.cpp
@@ -102,7 +102,7 @@ struct embot::app::bldc::theCOMM::Impl
     // others
     embot::app::msg::BUS mcBUS2use {embot::app::msg::BUS::none};
     
-    embot::app::LEDwaveT<64> ledwavemcBUSnone {100*embot::core::time1millisec, 30, std::bitset<64>(0b0101010101)};   
+    embot::app::LEDwaveT<64> ledwavemcBUSnone {100*embot::core::time1millisec, 30, std::bitset<64>(0b0101010101010101)};   
     embot::app::LEDwaveT<64> ledwavemcBUScan {250*embot::core::time1millisec, 10, std::bitset<64>(0b0101)};
     embot::app::LEDwaveT<64> ledwavemcBUSicc {250*embot::core::time1millisec, 10, std::bitset<64>(0b01)};
     

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_SERVICE.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_SERVICE.cpp
@@ -53,6 +53,11 @@ the ICC or the CAN mapping depending on the bus type
 
 namespace embot::app::eth::mc::messaging::receiver {
     
+//#define PRINT_MSG_FROM_ACTUATOR    
+
+#if defined(PRINT_MSG_FROM_ACTUATOR)    
+    char dbgstr[128] = {0};
+#endif    
   
     bool getentityindex(const embot::app::msg::Location &source, uint8_t &index)
     {
@@ -109,7 +114,10 @@ namespace embot::app::eth::mc::messaging::receiver {
             motor->status.basic.mot_velocity = msg.info.velocity;
             motor->status.basic.mot_position = msg.info.position;
             MController_update_motor_odometry_fbk_can(motorindex, (void*)msg.info.payload);      
-            
+#if defined(PRINT_MSG_FROM_ACTUATOR)
+            std::snprintf(dbgstr, sizeof(dbgstr), "from %s, st1: cu %d, ve %d, po %d", msg.source.to_string().c_str(), msg.info.current, msg.info.velocity, msg.info.position);  
+            embot::core::print(dbgstr);            
+#endif            
             return ok; 
         } 
         
@@ -125,7 +133,10 @@ namespace embot::app::eth::mc::messaging::receiver {
             }
             
             MController_update_motor_state_fbk(motorindex, (void*)msg.info.payload);
-
+#if defined(PRINT_MSG_FROM_ACTUATOR)
+            std::snprintf(dbgstr, sizeof(dbgstr), "from %s, st2: cmo %d, qef %x, pwm %d, flt %x",  msg.source.to_string().c_str(), msg.info.controlmode, msg.info.qencflags, msg.info.pwmfeedback, msg.info.motorfaultflags);  
+            embot::core::print(dbgstr);  
+#endif
             return ok; 
         } 
         

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.cpp
@@ -170,6 +170,7 @@ namespace embot { namespace hw { namespace motor {
     bool s_hw_isOvercurrent(MOTOR h);
     uint32_t s_hw_get32bit2FOCstyleFaultMask(MOTOR h);
     float s_hw_getVin();
+    float s_hw_getCin();
     
     result_t init(MOTOR h, const Config &cfg)
     {
@@ -396,12 +397,7 @@ namespace embot { namespace hw { namespace motor {
 
     float getCIN()
     {
-        // TODO: not yet implemented
-        float c {0.0};
-        
-        //c = analogCin() * 0.001;
-        return c;
-        
+        return s_hw_getCin();        
     }
     
 // in here is the part for low level hw of the boards (amc2c or amcbldc)
@@ -544,6 +540,11 @@ namespace embot { namespace hw { namespace motor {
     {
         return embot::hw::analog::getVin();
     }
+    
+    float s_hw_getCin()
+    {
+        return embot::hw::analog::getCin();
+    }    
 
 #elif defined(STM32HAL_BOARD_AMCBLDC)
     
@@ -681,10 +682,25 @@ namespace embot { namespace hw { namespace motor {
         return motorhal_get_faultmask();
     }
     
-    float s_hw_getVin(){
+    float s_hw_getVin()
+    {
+#if defined(EMBOT_ENABLE_hw_analog_ish)        
         // Return Vin in Volts
         return analogVin() * 0.001;
+#else
+        return 18.0f;
+#endif        
     }
+    
+    float s_hw_getCin()
+    {
+#if defined(EMBOT_ENABLE_hw_analog_ish)         
+        return analogCin() * 0.001;
+#else
+        return 1.0f;
+#endif        
+    } 
+      
     
 #else
     #error define a board

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
@@ -107,6 +107,9 @@ namespace embot { namespace hw { namespace motor {
     };        
     result_t setPWM(MOTOR h, const PWMperc &p);
     
+    // the following getVIN() and getCIN()  are about the power supply of the board. 
+    // so far we keep them in embot::hw::motor and we enable proper code w/ them w/ EMBOT_ENABLE_hw_analog_ish
+    // if EMBOT_ENABLE_hw_analog_ish is undefined getVIN() returns 18.0 and getCIN() returns 1.0
     // Return Vin in Volts
     float getVIN();
 

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.uvoptx
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.uvoptx
@@ -729,7 +729,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -1105,7 +1105,7 @@
       <OPTFL>
         <tvExp>0</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -7445,7 +7445,7 @@
 
   <Group>
     <GroupName>board-amc2c-V1A0</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.uvprojx
+++ b/emBODY/eBcode/arch-arm/libs/lowlevel/stm32hal/proj/stm32hal.h7.uvprojx
@@ -15212,7 +15212,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>


### PR DESCRIPTION
This PR fixes the ICC communication mode between the `amc` and `amc2c` board that was not correctly working.

**In details**

The ICC introduced in https://github.com/robotology/icub-firmware/pull/474 has stopped working. Only the CAN is working. That is probably due to recent additions to the features of the `amc2c` board that further reduce its idle time and prevent teh ICC communication mode to work effectively because the reduced CPU time is used by other threads. The ICC requires a tight handshaking between the CM7 (amc) and teh CM4 (amc2c) because for each communication a thread on each core is locked until teh other unlocks teh shared resource.

CAN is less demanding as it uses a HW peripheral.

The solution was to rise the priority of the COMM thread in the `amc2c` as well as the IRQ priority of the HSEM interrupt handler.

This PR also contains some other changes:
- enabling / disabling of reading of the Vin power supply voltage by measn of a BSP macro;
- improvement of the use of either ICC or CAN commnication. Now the  ICC or CAN mode can be switched across two launches of YRI (as long as you change teh xml files) w/out restarting the board.
 
**Tests**

I have tested the change on the lego setup and it works.
Tested also on ergoCub SN002. It works.

**Linked PRs**

The binaries.