### PR TITLE
Update diagnostic for aksim2

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 4},
-            {2024, Month::May, Day::twentyseven, 15, 24}
+            {2, 5},
+            {2024, Month::Jun, Day::ten, 14, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          90
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          91
 
 //  </h>version
 
@@ -91,9 +91,9 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          70
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          71
 
 //  </h>version
 
@@ -83,13 +83,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          27
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          39
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          91
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          92
 
 //  </h>version
 
@@ -92,13 +92,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        5
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          27
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          10
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          34
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
@@ -115,6 +115,17 @@ typedef struct
 } eo_appEncReader_amodiag_t;
 
 
+// structure defined for counting the errors related to aksim2 encoder
+typedef struct
+{
+    uint16_t encoder_error_crc_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t encoder_error_invalid_data_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t encoder_error_close_to_limit_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t encoder_error_hal_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t encoder_error_total_timer_counter[eOappEncReader_jomos_maxnumberof];
+    
+} eOappEncReader_Aksim2_DiagnosticError_Counters_t;
+
 struct EOappEncReader_hid
 {
     eObool_t                                initted;
@@ -127,6 +138,7 @@ struct EOappEncReader_hid
     float                                   maisConversionFactors[eOappEncReader_jomos_maxnumberof];
     eOappEncReader_hallAdc_conversionData_t hallAdcConversionData;
     eo_appEncReader_amodiag_t               amodiag;
+    eOappEncReader_Aksim2_DiagnosticError_Counters_t aksim2DiagnerrorCounters;
 }; 
 
 


### PR DESCRIPTION
This PR modifies slightly the diagnostic of the aksim2 encoder.
We are not sending the error each time an error bit is risen for the specific jomo but instead we increase a counter at each loop (which occurs at every 1ms) and then we send all the specific errors on the askim2 per each jomo one time every 10 seconds (for now - this value can be changed if needed). 
Then, on the diagnostic on the high level we print how many error per type and per jomo we got during those 10 seconds.

Diagnostic has been updated accordingly to https://github.com/robotology/icub-main/pull/968
