### PR TITLE
Runtime configuration of diagnostics related to the RX-DO-TX phases

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 6},
-            {2024, Month::Jun, Day::thirteen, 14, 45}
+            {2, 7},
+            {2024, Month::Jul, Day::four, 13, 47}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
@@ -10,7 +10,8 @@
       <TargetName>amc-icc-osal-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
+      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          92
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          93
 
 //  </h>version
 
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          4
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          41
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          39
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMN_fun_ems4rd.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMN_fun_ems4rd.c
@@ -79,7 +79,7 @@
 // - declaration of static functions
 // --------------------------------------------------------------------------------------------------------------------
 
-static void s_eoprot_ep_mn_fun_apply_config(uint32_t period, uint16_t rxtime, uint16_t dotime, uint16_t txtime, uint8_t txratedivider);
+static void s_eoprot_ep_mn_fun_apply_config(uint32_t period, uint16_t rxtime, uint16_t dotime, uint16_t txtime, uint8_t txratedivider, eOmn_appl_config_logging_t *logging);
 
 static void s_eoprot_ep_mn_fun_apply_config_txratedivider(uint8_t txratedivider);
 
@@ -599,7 +599,7 @@ extern void eoprot_fun_UPDT_mn_appl_config(const EOnv* nv, const eOropdescriptor
         cfg->txratedivider = 1;
     }
     
-    s_eoprot_ep_mn_fun_apply_config(cfg->cycletime, cfg->maxtimeRX, cfg->maxtimeDO, cfg->maxtimeTX, cfg->txratedivider);   
+    s_eoprot_ep_mn_fun_apply_config(cfg->cycletime, cfg->maxtimeRX, cfg->maxtimeDO, cfg->maxtimeTX, cfg->txratedivider, &cfg->logging);   
 }
 
 
@@ -1267,7 +1267,7 @@ static void s_eoprot_ep_mn_fun_apply_config_txratedivider(uint8_t txratedivider)
     eom_emsrunner_Set_TXdecimationFactor(eom_emsrunner_GetHandle(), txratedivider);    
 }
 
-static void s_eoprot_ep_mn_fun_apply_config(uint32_t period, uint16_t rxtime, uint16_t dotime, uint16_t txtime, uint8_t txratedivider)
+static void s_eoprot_ep_mn_fun_apply_config(uint32_t period, uint16_t rxtime, uint16_t dotime, uint16_t txtime, uint8_t txratedivider, eOmn_appl_config_logging_t *logging)
 {
     eOprotID32_t id32 = eoprot_ID_get(eoprot_endpoint_management, eoprot_entity_mn_appl, 0, eoprot_tag_mn_appl_status);
     eOmn_appl_status_t *status = (eOmn_appl_status_t*)eoprot_variable_ramof_get(eoprot_board_localboard, id32);
@@ -1287,6 +1287,9 @@ static void s_eoprot_ep_mn_fun_apply_config(uint32_t period, uint16_t rxtime, ui
     eom_emsrunner_SetTiming(eom_emsrunner_GetHandle(), &timing); 
     
     eom_emsrunner_Set_TXdecimationFactor(eom_emsrunner_GetHandle(), txratedivider);    
+    
+
+    eom_emsrunner_SetReport(eom_emsrunner_GetHandle(), logging);
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -1988,7 +1988,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z14 -C0 -M1 -T1</Name>
+          <Name>-L200 -Z18 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -2026,47 +2026,27 @@
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>this</ItemText>
+          <ItemText>periodreport,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>pos</ItemText>
+          <ItemText>offsetreport,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>2</count>
           <WinNumber>1</WinNumber>
-          <ItemText>destinations</ItemText>
+          <ItemText>stats,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>3</count>
           <WinNumber>1</WinNumber>
-          <ItemText>payloads</ItemText>
+          <ItemText>offset2use,0x0A</ItemText>
         </Ww>
         <Ww>
           <count>4</count>
           <WinNumber>1</WinNumber>
-          <ItemText>command</ItemText>
-        </Ww>
-        <Ww>
-          <count>5</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>this</ItemText>
-        </Ww>
-        <Ww>
-          <count>6</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>cf</ItemText>
-        </Ww>
-        <Ww>
-          <count>7</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>jomodes-&gt;actuator.gen.location</ItemText>
-        </Ww>
-        <Ww>
-          <count>8</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>o-&gt;motor[k].mlocation</ItemText>
+          <ItemText>periodreport</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -2119,7 +2099,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -3997,7 +3977,7 @@
 
   <Group>
     <GroupName>eo-protocol-cfg-callbacks</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -2869,7 +2869,7 @@
 
   <Group>
     <GroupName>eo-emsappl</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -3997,7 +3997,7 @@
 
   <Group>
     <GroupName>eo-protocol-cfg-callbacks</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -4647,7 +4647,8 @@
       <TargetName>ems-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
+      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          72
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          73
 
 //  </h>version
 
@@ -83,13 +83,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          4
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          43
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          45
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
@@ -10,7 +10,8 @@
       <TargetName>mc2plus</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
+      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          93
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          94
 
 //  </h>version
 
@@ -92,11 +92,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          4
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          42
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
@@ -10,7 +10,8 @@
       <TargetName>mc4plus-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
+      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
+      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSappl.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSappl.c
@@ -177,7 +177,7 @@ extern EOMtheEMSappl * eom_emsappl_Initialise(const eOemsappl_cfg_t *emsapplcfg)
         return(&s_emsappl_singleton);
     }
     
-    char str[64];
+    char str[96];
     snprintf(str, sizeof(str), "inside _Initialise()");
     eo_errman_Trace(eo_errman_GetHandle(), str, s_eobj_ownname);  
       

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner.h
@@ -160,6 +160,8 @@ extern eObool_t eom_emsrunner_CycleHasJustTransmittedRegulars(EOMtheEMSrunner *p
 
 extern eOresult_t eom_emsrunner_SetTiming(EOMtheEMSrunner *p, const eOemsrunner_timing_t *timing);
 
+extern eOresult_t eom_emsrunner_SetReport(EOMtheEMSrunner *p, eOmn_appl_config_logging_t *logging);
+
 extern uint64_t eom_emsrunner_Get_IterationNumber(EOMtheEMSrunner *p);
 
 extern eOreltime_t eom_emsrunner_Get_Period(EOMtheEMSrunner *p);

--- a/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/ctrloop/EOMtheEMSrunner_hid.h
@@ -117,6 +117,7 @@ struct EOMtheEMSrunner_hid
     uint8_t                     txcan2frames;
     eOemsrunner_cycletiming_t   cycletiming;
     eObool_t                    isrunning;
+    eOmn_appl_config_logging_t  logging;
 };
 
 


### PR DESCRIPTION
This PR introduces the runtime configuration via xml files of the diagnostics associated to the execution loop.
In particular, it will be possible to:
- enable / disable the diagnostics about execution overflow of the RX, DO and TX phases. The default is enabled.
- enable / disable the diagnostics about statistics of the  RX, DO and TX phases. It will be reported minimum, average and maximum durations of the phases over a period configurable between 1 and 600 seconds. The default is disabled.

