### PR TITLE
Improvement in 2FOC fw and improved quadrature_encoder diagnostic

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 7},
-            {2024, Month::Jul, Day::four, 13, 47}
+            {2, 8},
+            {2024, Month::Jul, Day::twenty, 14, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          93
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          94
 
 //  </h>version
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          73
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          74
 
 //  </h>version
 
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          4
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          20
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          45
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          94
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          95
 
 //  </h>version
 
@@ -94,11 +94,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          4
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          20
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          42
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
@@ -23,13 +23,21 @@
 
 #include "WatchDog.h"
 
+typedef struct
+{
+    uint16_t total_counter;
+    uint16_t qe_dirty_err_counter;
+    uint16_t qe_index_broken_err_counter;
+    uint16_t qe_phase_broken_err_counter;
+} QEDiagnosticData;
 
+const uint16_t QEDiagnosticMaxCounter = 10* CTRL_LOOP_FREQUENCY_INT;
 typedef union
 {
     struct
     {
         unsigned dirty           :1;
-        unsigned stuck           :1;
+        unsigned stuck           :1; //currently not used
         unsigned index_broken    :1;
         unsigned phase_broken    :1;
         
@@ -150,8 +158,9 @@ struct Motor_hid
     BOOL can_dead;
     BOOL wrong_ctrl_mode;
     
-    uint16_t diagnostics_refresh;
-    uint16_t diagnostics_refresh_warning;
+    uint16_t diagnostics_refresh; //keep for old diagnosic
+    //uint16_t diagnostics_refresh_warning;
+    QEDiagnosticData diagnostic;
     eOmc_motorFaultState_t fault_state_prec;
     eOmc_motorFaultState_t fault_state;
     QEState qe_state;

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/2FOC-V3.X/nbproject/Makefile-genesis.properties
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/2FOC-V3.X/nbproject/Makefile-genesis.properties
@@ -1,5 +1,5 @@
 #
-#Thu May 23 11:01:33 CEST 2024
+#Tue Jul 09 10:08:33 CEST 2024
 default.languagetoolchain.version=1.24
 default.Pack.dfplocation=C\:\\Program Files\\Microchip\\MPLABX\\v6.15\\packs\\Microchip\\dsPIC33F-GP-MC_DFP\\1.3.64
 conf.ids=default

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/2FOC-V3.X/nbproject/private/private.xml
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/2FOC-V3.X/nbproject/private/private.xml
@@ -3,22 +3,37 @@
     <editor-bookmarks xmlns="http://www.netbeans.org/ns/editor-bookmarks/2" lastBookmarkId="0"/>
     <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
         <group>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/Faults.c</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/ecan.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/traps.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/iCubCanProto_classes.h</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/i2cTsens.h</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/Faults.h</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserTypes.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/ADC.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/System.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/PWM.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/ecan.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/2FOC.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/iCubCanProto_bootloaderMessages.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/i2cTsens.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/Faults.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/DHES.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/ecan.c</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/PWM.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/iCubCanProto_motorControlMessages.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/i2cTsens.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/Faults.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/DCLink.c</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_parser.c</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/System.h</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/ecan.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/ADC.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/iCubCanProtocol.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/iCubCanProto_types.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto_parser.h</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/2FOC.h</file>
+            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/iCubCanProto_analogSensorMessages.h</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c</file>
             <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h</file>
-            <file>file:/C:/Users/jlosi/Workspace/ICUB-FIRM/icub-firmware/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/i2cTsens.c</file>
         </group>
     </open-files>
 </project-private>

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          35
+#define FW_VERSION_BUILD          36
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          26
+#define FW_VERSION_BUILD          35
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h
@@ -37,9 +37,10 @@ volatile extern tQEError gEncoderError;
 #define QE_ELETTR_DEG_PER_REV() (gEncoderConfig.elettr_deg_per_rev)
 
 extern volatile BOOL qe_index_found;
-extern volatile BOOL my_index_found;
-extern volatile BOOL qe_reg_INDX;
+extern volatile BOOL is_qe_index_just_found;
+extern volatile BOOL qe_index_found_debug;
 extern volatile int QE_RESOLUTION;
+
 #define QEIndexFound() qe_index_found
 
 extern void QEinit(int qe_resolution,int motor_num_poles,char use_index);

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h
@@ -37,6 +37,8 @@ volatile extern tQEError gEncoderError;
 #define QE_ELETTR_DEG_PER_REV() (gEncoderConfig.elettr_deg_per_rev)
 
 extern volatile BOOL qe_index_found;
+extern volatile BOOL my_index_found;
+extern volatile BOOL qe_reg_INDX;
 extern volatile int QE_RESOLUTION;
 #define QEIndexFound() qe_index_found
 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/qep.h
@@ -16,6 +16,8 @@ typedef struct
 } EncoderConfig_t;
 volatile extern EncoderConfig_t gEncoderConfig;
 
+volatile extern int gQERawPosition;
+
 typedef union
 {
     struct

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
@@ -139,9 +139,9 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
             bitmask |= ((uint8_t)gEncoderError.dirty) << 2;
             bitmask |= ((uint8_t)gEncoderError.index_broken) << 3;
             payload.w[0]  = gQERawPosition;
-            payload.b[1] = bitmask;
+            payload.b[2] = bitmask;
 
-            msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__DEBUG );
+        msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__DEBUG );
 
             ECANSend(msgid, 3, &payload);
             

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
@@ -103,7 +103,12 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
     }
     else if (MotorConfig.verbose)
     {        
-/*        static int noflood = 0;
+/*      Valegagge: 15 July 2024:
+ *      use the debug message for qe_encoder info instead of for I2C debug info.
+ *      I cannot downsampling the qe info.
+ * 
+ * 
+ *      static int noflood = 0;
         
         extern volatile char I2Cdead;
         extern volatile uint16_t I2Cerrors;
@@ -130,21 +135,20 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
         if(gControlMode != icubCanProto_controlmode_notConfigured)
         {
             uint8_t bitmask = 0;
-            bitmask |= ((uint8_t)qe_reg_INDX);
-            bitmask |= ((uint8_t)my_index_found) << 1;
+            bitmask |= ((uint8_t)qe_index_found_debug) << 1;
             bitmask |= ((uint8_t)gEncoderError.dirty) << 2;
             bitmask |= ((uint8_t)gEncoderError.index_broken) << 3;
             payload.w[0]  = gQERawPosition;
-            //payload.w[1] = gQEElectrDeg;
-            payload.b[2] = bitmask;
+            payload.b[1] = bitmask;
 
             msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__DEBUG );
 
             ECANSend(msgid, 3, &payload);
             
-            gEncoderError.dirty = FALSE;
-            gEncoderError.index_broken = FALSE;
-            my_index_found = FALSE;
+            //commented because I clean the same flags on ICUBCANPROTO_PER_MC_MSG__STATUS sent
+            //gEncoderError.dirty = FALSE; 
+            //gEncoderError.index_broken = FALSE;
+            qe_index_found_debug = FALSE;
         }
     }
     
@@ -189,6 +193,8 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
             msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__STATUS);
 
             ECANSend(msgid, 8, &payload);
+            gEncoderError.dirty = FALSE;
+            gEncoderError.index_broken = FALSE;
         }
 
     }

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
@@ -103,7 +103,7 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
     }
     else if (MotorConfig.verbose)
     {        
-        static int noflood = 0;
+/*        static int noflood = 0;
         
         extern volatile char I2Cdead;
         extern volatile uint16_t I2Cerrors;
@@ -117,6 +117,7 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
         {
             noflood = 0;
             
+           
             payload.w[1] = I2Cerrcode;
             payload.w[2] = I2Cdead;
             payload.w[3] = I2Cerrors;
@@ -124,6 +125,26 @@ extern void CanIcubProtoTrasmitterSendPeriodicData(void)
             msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__DEBUG );
 
             ECANSend(msgid, 8, &payload);
+        }
+ */
+        if(gControlMode != icubCanProto_controlmode_notConfigured)
+        {
+            uint8_t bitmask = 0;
+            bitmask |= ((uint8_t)qe_reg_INDX);
+            bitmask |= ((uint8_t)my_index_found) << 1;
+            bitmask |= ((uint8_t)gEncoderError.dirty) << 2;
+            bitmask |= ((uint8_t)gEncoderError.index_broken) << 3;
+            payload.w[0]  = gQERawPosition;
+            //payload.w[1] = gQEElectrDeg;
+            payload.b[2] = bitmask;
+
+            msgid = CAN_ICUBPROTO_STDID_MAKE_TX(ICUBCANPROTO_CLASS_PERIODIC_MOTORCONTROL, canprototransmitter_bid, ICUBCANPROTO_PER_MC_MSG__DEBUG );
+
+            ECANSend(msgid, 3, &payload);
+            
+            gEncoderError.dirty = FALSE;
+            gEncoderError.index_broken = FALSE;
+            my_index_found = FALSE;
         }
     }
     

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/i2cTsens.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/i2cTsens.c
@@ -247,7 +247,7 @@ int setupI2CTsens(void)
     ODCBbits.ODCB8=1;
     ODCBbits.ODCB9=1;
 
-    I2C1BRG = 196;//393;          // @100kHz; (FCY/FSCL - FCY/1e7) - 1
+    I2C1BRG = 393;//393;          // (511 - limit)77.5kHz (196)200kHz (393)@100kHz; raw value to be set in I2C1BRG = (FCY/FSCL - FCY/1e7) - 1 --> where FCY = micro freq (40MHz) and FSCL = desired i2C clock freq
     I2C1CONbits.I2CEN = 0;        // Disable I2C
     I2C1CONbits.DISSLW = 1;       // Disable slew rate control
     I2C1CONbits.A10M = 0;         // 7-bit slave addr
@@ -398,15 +398,17 @@ I2Ctimeout:
     // I2CEN: I2Cx Enable bit
     I2C1CONbits.I2CEN = 0; // 0 = Disables the I2Cx module. All I2C? pins are controlled by port functions
 
+    // configure the port of the register so that I can write on the pin RB8 of the port --> tristate condition of the pin (high impedance) 
     TRISBbits.TRISB8 = 0;
     RPOR4bits.RP8R = 0;
     ODCBbits.ODCB8 = 1;
 
+    // send 9 clock pulse so that I simulate a clean transmission and I do not restart in the middle of it 
     int c;
     for (c=0; c<=18; ++c)
     {
         PORTBbits.RB8 = c%2;
-        __delay32(400);
+        __delay32(200);  // set to 200 since you are setting the bit value of the port high and low at each cycle 400 when u are using the i2c freq at 100kHz --> because the micro is running at 40MHz so you have 400  cycles each 100kHz --> thus delay need to be changed accordingly to i2c freq 
     }
     
     I2C1CONbits.I2CEN = 1; // 1 = Enables the I2Cx module and configures the SDAx and SCLx pins as serial port pins

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
@@ -16,6 +16,8 @@ volatile BOOL qe_index_found = FALSE;
 volatile BOOL is_qe_index_just_found = FALSE;
 volatile BOOL qe_index_found_debug = FALSE;
 
+volatile int gQERawPosition = 0;
+
 void QEinit(int resolution, int motor_num_poles,char use_index)
 {
     // init the quadrature encoder peripheral
@@ -140,9 +142,9 @@ inline int QEgetPos()
 //                ++POSCNT;
 //        }
 //    }
-    volatile extern int gQERawPosition;
+    
     int poscnt = (int)POSCNT;
-    gQERawPosition= (int)POSCNT;
+    gQERawPosition = (int)POSCNT;
     
     if (QE_USE_INDEX)
     {  

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/qep.c
@@ -13,8 +13,8 @@ int QE_ERR_THR = 0;//144;
 BOOL QE_USE_INDEX = FALSE;
 
 volatile BOOL qe_index_found = FALSE;
-volatile BOOL my_index_found = FALSE;
-volatile BOOL qe_reg_INDX = FALSE;
+volatile BOOL is_qe_index_just_found = FALSE;
+volatile BOOL qe_index_found_debug = FALSE;
 
 void QEinit(int resolution, int motor_num_poles,char use_index)
 {
@@ -146,21 +146,32 @@ inline int QEgetPos()
     
     if (QE_USE_INDEX)
     {  
-        if (qe_index_found)
+        if (qe_index_found) // I found at least one time during calib
         {
             static int poscnt_old = 0;
+            //static int count_QEICONbits_INDX = 0;
             
-            if (QEICONbits.INDX)
+            if( (QEICONbits.INDX) || (is_qe_index_just_found))
             {
                 if (poscnt_old>QE_ERR_THR && poscnt_old<QE_RESOLUTION-QE_ERR_THR)
                 {
                     QE_RISE_WARNING(dirty);
                 }
-                qe_reg_INDX = TRUE;
+                
+                if(is_qe_index_just_found)
+                    is_qe_index_just_found = FALSE;
+                
+                //Here I don't need to adjust the POSCNT value because  
+                // the QE drive resets it automatically when found the index
+                //For the same reason we use poscnt_old and not POSCNT
             }
             else
             {
-                qe_reg_INDX = FALSE;
+                //The threshold 16 can been calculated starting from the max velocity at joint, the gearbox and the resolution and the frequency of 2foc loop
+                
+                /* threashold= (max_velocity_at_joint * gearbox * resolution * period_of2_foc_loop/360)
+                 * since this info are not available in 2foc, we continue to use the value 16 that it has been found experimentally */
+                
                 if (poscnt<-16 || poscnt > QE_RESOLUTION+16)
                 {
                     QE_RISE_WARNING(index_broken);
@@ -171,9 +182,7 @@ inline int QEgetPos()
                     POSCNT = (unsigned int)poscnt;
                 }
             }
-            
-            
-            
+             
             poscnt_old = poscnt;
             
         }   
@@ -188,8 +197,9 @@ void __attribute__((__interrupt__,no_auto_psv)) _QEI1Interrupt(void)
     // disable interrupt
     IEC3bits.QEI1IE = 0;
 
-    qe_index_found = TRUE;
-    my_index_found = TRUE;
+    qe_index_found = TRUE; 
+    is_qe_index_just_found = TRUE;
+    qe_index_found_debug = TRUE;
  
 //    static int simulate_fault = 0;
 //    if (++simulate_fault == 11)


### PR DESCRIPTION
**Improvements of 2foc**:
 - the I2C bus is configured to work with 100KHz speed and has some fixes in the reset procedure. More details [here](https://github.com/icub-tech-iit/study-motor-temperature/issues/20#issuecomment-2165148843). 
 - the rotor/stator calibration procedure is not more HW dependent but can run successfully on different motors. More details [here](https://github.com/robotology/icub-firmware/issues/499#issue-2340436891). 

- the information regarding the quadrature encoder diagnostic has been improved. More detail [here](https://github.com/icub-tech-iit/study-encoders/issues/23#issuecomment-2225012824)

The EMS and the other ETH boards manage the quadrature encoder diagnostic in a more user-friendly way: they count the number of errors instead of downsampling the error rate to make the final user aware of how many errors there are on a given encoder and therefore proceed with the maintenance accordingly.
This change need the change on icub-main also : PR (TBD)

cc @MSECode  