### PR TITLE
Boards `mtb4` and `mtb4c`: skin on the 5-th finger finally supported

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
@@ -17,7 +17,7 @@ constexpr embot::app::theCANboardInfo::applicationInfo applInfo
 #if defined(CUSTOMIZATION_MTB4_FOR_TLR)
     embot::prot::can::versionOfAPPLICATION {20, 21, 0},
     embot::prot::can::versionOfCANPROTOCOL {20, 0}
-#elseif defined(USE_FIFTH_I2C)
+#elif defined(USE_FIFTH_I2C)
     embot::prot::can::versionOfAPPLICATION {51, 22, 0},
     embot::prot::can::versionOfCANPROTOCOL {2, 0}
 #else

--- a/emBODY/eBcode/arch-arm/board/mtb4c/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4c/application/src/main-appcan.cpp
@@ -17,7 +17,10 @@ constexpr embot::app::theCANboardInfo::applicationInfo applInfo
 #if defined(CUSTOMIZATION_MTB4_FOR_TLR) 
     embot::prot::can::versionOfAPPLICATION {22, 0, 0},    
     embot::prot::can::versionOfCANPROTOCOL {20, 0} 
-#else    
+#elif defined(USE_FIFTH_I2C)
+    embot::prot::can::versionOfAPPLICATION {52, 2, 0},
+    embot::prot::can::versionOfCANPROTOCOL {2, 0}
+#else   
     embot::prot::can::versionOfAPPLICATION {2, 2, 0},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0} 
 #endif    

--- a/emBODY/eBcode/arch-arm/board/mtb4c/bsp/embot_hw_bsp_mtb4c.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4c/bsp/embot_hw_bsp_mtb4c.cpp
@@ -657,7 +657,8 @@ namespace embot { namespace hw { namespace multisda {
         { SCK0_GPIO_Port, SCK0_Pin, nullptr },
         // sda
         {{  
-            { SDA0_GPIO_Port, SDA0_Pin, nullptr }, { SDA1_GPIO_Port, SDA1_Pin, nullptr }, { SDA2_GPIO_Port, SDA2_Pin, nullptr }, { SDA3_GPIO_Port, SDA3_Pin, nullptr }            
+//            { SDA0_GPIO_Port, SDA0_Pin, nullptr }, { SDA1_GPIO_Port, SDA1_Pin, nullptr }, { SDA2_GPIO_Port, SDA2_Pin, nullptr }, { SDA3_GPIO_Port, SDA3_Pin, nullptr }            
+            { SDA0_GPIO_Port, SDA0_Pin, nullptr }, { SDA1_GPIO_Port, SDA1_Pin, nullptr }, { SDA2_GPIO_Port, SDA2_Pin, nullptr }, { SDA3_GPIO_Port, SDA3_Pin, nullptr } , {GPIOC, GPIO_PIN_0, nullptr } /*as an alternative use the definitiin from cubeMX in main.h   */
         }}
     };
     

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theSkin.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theSkin.cpp
@@ -262,20 +262,22 @@ bool embot::app::application::theSkin::Impl::configtriangles(const embot::prot::
         }
         
         // we process shift and cdcoffset even if we have enabled == false ... as the old mtb3 application does
-        if(trianglesOrder[i] >= triangles_max_num){        
+        if(trianglesOrder[i] >= triangles_max_num)
+        {        
             triangles.config5th[trianglesOrder[i]-triangles_max_num].shift = triangleconfigcommand.shift;
             if(triangles.config5th[trianglesOrder[i]-triangles_max_num].cdcoffset != triangleconfigcommand.cdcOffset)
-                {
-                    triangles.config5th[trianglesOrder[i]-triangles_max_num].cdcoffset = triangleconfigcommand.cdcOffset;
-                    ad7147_set_cdcoffset(trianglesOrder[i], triangles.config5th[trianglesOrder[i]-triangles_max_num].cdcoffset);         
-                }    
+            {
+                triangles.config5th[trianglesOrder[i]-triangles_max_num].cdcoffset = triangleconfigcommand.cdcOffset;
+                ad7147_set_cdcoffset(trianglesOrder[i], triangles.config5th[trianglesOrder[i]-triangles_max_num].cdcoffset);         
+            }    
         }
         else
         {
-            triangles.config[i].shift = triangleconfigcommand.shift;        
-            if(triangles.config[i].cdcoffset != triangleconfigcommand.cdcOffset){                              
-                triangles.config[i].cdcoffset = triangleconfigcommand.cdcOffset;
-                ad7147_set_cdcoffset(i, triangles.config[i].cdcoffset);         
+            triangles.config[trianglesOrder[i]].shift = triangleconfigcommand.shift;        
+            if(triangles.config[trianglesOrder[i]].cdcoffset != triangleconfigcommand.cdcOffset)
+            {                              
+                triangles.config[trianglesOrder[i]].cdcoffset = triangleconfigcommand.cdcOffset;
+                ad7147_set_cdcoffset(trianglesOrder[i], triangles.config[trianglesOrder[i]].cdcoffset);         
             }
         }
     }


### PR DESCRIPTION
### Description of activities

The work here is a follow up of a previous [PR](https://github.com/robotology/icub-firmware/pull/506) which showed some bugs.
namely, we:
- fix of CDC offset mapping
- aligned application versions when macro `USE_FIFTH_I2C` is defined


The combined effect of these two PRs is:

- the pin connected to the fifth `I2C` channel is activated **by default**
- the project **as is** compiles and gives a **fully compatible binary file** with the previous version reading only 4 I2C channels
- to use the **fifth finger** e.g. in `ergocub` class robots, we need:
  - open the project under `....\boards\mtbX\application\proj` (X = 4 or 4c depending on the used board)
  - check the right version of comnpiler is selected (should be so) i.e. **6.19**
  - open `project options` and in the `C/C++` tab, define the `USE_FIFTH_I2C` macro
  - compile and eventually rename the binary file to distinguish it
  - at this point the binary file is ready to be flashed on the desired board, with either a programmer or the `FirmwareUpdater` tool
  - the correctness of operation can be checked from the version number which is offset by 50 wrt the _official_ one
  - the configuration files are already aligned to this on `ergocubSN001` on which the tests were done
    - the configuration may be summarized as: 
    - turn off all triangles with cdcoffset = 2200
    - turn on only triangles 0 to 4 with cdcoffset = 0000

