### PR TITLE
Added dummy retargeting for the SYS IO functions

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvoptx
@@ -563,7 +563,7 @@
 
   <Group>
     <GroupName>embot::hw</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
@@ -10,7 +10,6 @@
       <TargetName>amc-icc-osal-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
       <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvoptx
@@ -1993,7 +1993,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP1123199 -O207 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC168000000 -TT168000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO15 -FD20000000 -FC800 -FN1 -FF0STM32F4xx_1024.FLM -FS08000000 -FL0100000 -FP0($$Device:STM32F407IG$CMSIS\Flash\STM32F4xx_1024.FLM)</Name>
+          <Name>-UP2214483 -O207 -S8 -C0 -P00000000 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO65555 -TC168000000 -TT168000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO15 -FD20000000 -FC800 -FN1 -FF0STM32F4xx_1024.FLM -FS08000000 -FL0100000 -FP0($$Device:STM32F407IG$CMSIS\Flash\STM32F4xx_1024.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -2099,7 +2099,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>0</aLwin>
+        <aLwin>1</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -2116,7 +2116,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>1</aSer4>
+        <aSer4>0</aSer4>
         <StkLoc>1</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -2135,12 +2135,6 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
-      <SystemViewers>
-        <Entry>
-          <Name>OS Support\Event Viewer</Name>
-          <WinId>35905</WinId>
-        </Entry>
-      </SystemViewers>
       <DebugDescription>
         <Enable>1</Enable>
         <EnableFlashSeq>0</EnableFlashSeq>
@@ -2153,7 +2147,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2173,7 +2167,7 @@
 
   <Group>
     <GroupName>abslayer-lib</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2229,7 +2223,7 @@
 
   <Group>
     <GroupName>abslayer-cfg</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2321,7 +2315,7 @@
 
   <Group>
     <GroupName>eo-core</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2605,7 +2599,7 @@
 
   <Group>
     <GroupName>eo-core-mee</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2729,7 +2723,7 @@
 
   <Group>
     <GroupName>eo-arm-env</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/proj/ems4rd.diagnostic2ready.uvprojx
@@ -4647,8 +4647,7 @@
       <TargetName>ems-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
-      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
+      <pCCUsed>6220000::V6.22::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvoptx
@@ -1368,7 +1368,7 @@
 
   <Group>
     <GroupName>eo-core-mee</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/proj/mc2plus.diagnostic2ready.uvprojx
@@ -10,8 +10,7 @@
       <TargetName>mc2plus</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
-      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
+      <pCCUsed>6220000::V6.22::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/proj/mc4plus.diagnostic2ready.uvprojx
@@ -10,7 +10,6 @@
       <TargetName>mc4plus-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
       <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>

--- a/emBODY/eBcode/arch-arm/embobj/core/exec/multitask/EOMtheSystem.c
+++ b/emBODY/eBcode/arch-arm/embobj/core/exec/multitask/EOMtheSystem.c
@@ -286,7 +286,77 @@ static EOVtaskDerived* s_eom_gettask(void)
     return(osal_task_extdata_get(p));
 }
 
+#define EOMtheSystem_retarget_SYS_IO
 
+#if defined(EOMtheSystem_retarget_SYS_IO)
+
+#if 0
+in here we retarget the sys io functions. 
+they prevent the hanging of the execution when we use for instance printf(), which we must not do,
+or if we use armclang v6.20 or later. since v6.20 the linker uses ... but lets read the reply from arm:
+
+ > ... since the change [SDCOMP-64440] described in the release note of v6.22 https://developer.arm.com/documentation/109472/6-22/?lang=en
+ > Such a change seems to make armlink to link many additional Arm C/C++ standard lib components like printf, vfprintf or abort etc. 
+ > When your debug session stuck at breakpoint 0xAB, usually it indicates a semihosting issue: https://developer.arm.com/documentation/ka002219/latest/
+
+a quick workaround is to retargeting the system I/O functions as in https://developer.arm.com/documentation/dui0475/m/the-arm-c-and-c---libraries/redefining-target-dependent-system-i-o-functions-in-the-c-library
+
+#endif
+
+// - retargeting of the system I/O functions
+// at first we do that in a dummy way. 
+
+void your_device_write(const unsigned char *buf, unsigned len) {}
+
+#include "rt_sys.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    
+    FILEHANDLE _sys_open(const char *name, int openmode)
+    {
+      return 1; /* everything goes to the same output */
+    }
+    int _sys_close(FILEHANDLE fh)
+    {
+      return 0;
+    }
+    int _sys_write(FILEHANDLE fh, const unsigned char *buf,
+                   unsigned len, int mode)
+    {
+      your_device_write(buf, len);
+      return 0;
+    }
+    int _sys_read(FILEHANDLE fh, unsigned char *buf,
+                  unsigned len, int mode)
+    {
+      return -1; /* not supported */
+    }
+    void _ttywrch(int ch)
+    {
+      const unsigned char c = ch;
+      your_device_write(&c, 1);
+    }
+    int _sys_istty(FILEHANDLE fh)
+    {
+      return 0; /* buffered output */
+    }
+    int _sys_seek(FILEHANDLE fh, long pos)
+    {
+      return -1; /* not supported */
+    }
+    long _sys_flen(FILEHANDLE fh)
+    {
+      return -1; /* not supported */
+    }    
+    
+#ifdef __cplusplus
+}
+#endif
+
+#endif
 
 // --------------------------------------------------------------------------------------------------------------------
 // - end-of-file (leave a blank line after)

--- a/emBODY/eBcode/arch-arm/embot/os/embot_os_rtos.cpp
+++ b/emBODY/eBcode/arch-arm/embot/os/embot_os_rtos.cpp
@@ -1662,7 +1662,9 @@ void operator delete (void* ptr) noexcept
 #endif    
 }
 
-#endif //#if defined(EMBOT_HEAP_PROTECTION_use_OSsupport)
+#endif // #if defined(EMBOT_HEAP_redefine_heapoperators)
+
+
 
 
 // -- C/C++ Standard Library Multithreading Interface


### PR DESCRIPTION
This PR adds retargeting of the system IO functions, so that we can use the armclang compiler with versions > v6.19.

The addition of these functions is required because:
- I noticed that if we used compiler v 6.20 and beyond the applications when debugged stepped in several breakpoints before entering in `main()`. And even worse, when not in debug it did not bootstrap;
- So, we have made sure to use V6.19 and I started an investigation.
- It ended up that it was responsibility of the compiler because (from ARM):
  > ... since the change [SDCOMP-64440] described in the release note of v6.22 https://developer.arm.com/documentation/109472/6-22/?lang=en
  > Such a change seems to make armlink to link many additional Arm C/C++ standard lib components like printf, vfprintf or abort etc. 
  > When your debug session stuck at breakpoint 0xAB, usually it indicates a semihosting issue: https://developer.arm.com/documentation/ka002219/latest/
- told that they would have fixed this:
  > Hi Marco, our compiler team has confirmed this is indeed something we should investigate further and implement some improvement if possible.
- and in the meantime thy suggested as a quick workaround:
  > I know how to get rid of the debug issue caused by the unexpected semihosting. You can implement your own retarget file or use the one provided in the Arm::CMSIS-Compiler pack as described on the page I sent you.


So, in here I add the workaround.

I have added the functions in two existing files files that are used by all the projects, so that we don't need to change a humongous number of projects:
- `EOMtheSystem.c` for the legacy projects (`ems`, ...)
- `embot_hw_sys.cpp` for the `embot` projects.


And I have reverted some projects for the use of the installed compiler version.

I have tested the changes w/ some boards and everything works fine.


