### PR TITLE
Adjust lower bound for evaluating battery charge for R1

### DIFF
--- a/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
+++ b/emBODY/eBcode/arch-arm/board/bat/BAT_Rev_B/Src/BAT_B.c
@@ -11,7 +11,7 @@
 
 char Firmware_vers = 1;
 char Revision_vers = 3;
-char Build_number  = 4;
+char Build_number  = 5;
 
 uint32_t vtol=100;  // voltage tolerance for hysteresis
 uint32_t vhyst=0;    // voltage hysteresis
@@ -102,7 +102,7 @@ __IO ITStatus UartReady = RESET;
 #ifdef BAT_B_R1
 uint32_t VTH[7]={23000, 24000, 25000, 26000, 27000, 28000, 29000};   // threshold in mV R1 Battery
 uint16_t Battery_high=4200*7;   // 7s5p battery
-uint16_t Battery_low=3300*7;    // 7s5p battery
+uint16_t Battery_low=3000*7;    // 7s5p battery
 #endif 
 
 #ifdef BAT_B_Generic


### PR DESCRIPTION
As described at this issue: https://github.com/robotology/icub-firmware/issues/513 we have chosen to adjust the lower bound for evaluating the battery charge in R1.
The estimation, however, cannot be consider as perfect since it is based just on the voltage reaching the BAT board and moreover it is linear and not based on a proper coulomb counter, as done by a BMS.


cc: @valegagge @maggia80 