### PR TITLE
Towards the `amcfoc`: cleanup of `embot::hw`

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_button.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_button.cpp
@@ -45,7 +45,29 @@
 
 
 using namespace std;
+    
+#if !defined(EMBOT_ENABLE_hw_button)
+    
+namespace embot::hw::button {    
+    
+    bool supported(BTN btn)
+    { return false; }        
+    bool initialised(BTN btn)
+    { return false; }        
+    result_t init(BTN btn, const Config &cfg)
+    { return resNOK; }        
+    const Config & config(BTN btn)
+    {
+        static constexpr Config c {};
+        return c;
+    }             
+    bool pressed(BTN btn)
+    { return false; }    
+    void onexti(BTN btn) {}    
+    
+}
 
+#elif defined(EMBOT_ENABLE_hw_button)
 
 // --------------------------------------------------------------------------------------------------------------------
 // - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
@@ -276,7 +298,7 @@ namespace embot { namespace hw { namespace button {
 }}} // namespace embot { namespace hw { namespace button 
 
 
-
+#endif // #elif defined(EMBOT_ENABLE_hw_button)
 
     
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
@@ -43,8 +43,6 @@
 
 using namespace std;
 
-using namespace std;
-
 
 // --------------------------------------------------------------------------------------------------------------------
 // - refactored in july-october 2020 by marco.accame to handle: 
@@ -310,6 +308,12 @@ std::uint8_t can::inputqueuesize(embot::hw::CAN p)
             
 }
 
+// TODO: Temporary workaround in order validate this feature without affecting the other CAN baords
+#if defined(STM32HAL_BOARD_AMC) | defined(STM32HAL_BOARD_AMC2CM4) | defined(STM32HAL_BOARD_AMCFOC_2CM4) | defined(STM32HAL_BOARD_AMCFOC_1CM7)
+    #warning see how to make this option more general and not only dependent of boards amc or amc2cm4 or ...
+    
+    #define TEMPORARY_WORKAROUND_FOR_H7_master   
+#endif    
 
 result_t can::transmit(embot::hw::CAN p)
 {
@@ -319,7 +323,7 @@ result_t can::transmit(embot::hw::CAN p)
     } 
     
     // TODO: Temporary workaround in order validate this feature without affecting the other CAN baords
-#ifdef STM32HAL_BOARD_AMC
+#if defined(TEMPORARY_WORKAROUND_FOR_H7_master)
     if(true == tx_IRQisEnabled(p))
     {
         // marco.accame on 17 aug 2022: if the TX is already ongoing, we dont want to start it again
@@ -427,8 +431,7 @@ static void can::s_tx_start(embot::hw::CAN p)
     // protect Qtx: i disable tx interrupt but i keep info if it was enabled, so that at the end i re-enable it
     volatile bool isTXenabled = tx_IRQdisable(p);
            
-    // TODO: Temporary workaround in order validate this feature without affecting the other CAN baords
-#ifdef STM32HAL_BOARD_AMC
+#if defined(TEMPORARY_WORKAROUND_FOR_H7_master)
     if(true == isTXenabled)
     {
         //static volatile uint32_t inhere {0};

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.cpp
@@ -171,17 +171,14 @@ private:
     bool writeinpage(ADR adr, const embot::core::Data &data);
     bool initpincontrol();
     bool deinitpincontrol();
-};    
+};  
+
 
 bool embot::hw::chip::M95512DF::Impl::initpincontrol()
 {
-//    static constexpr embot::hw::gpio::Config cfg 
-//    {
-//        embot::hw::gpio::Mode::OUTPUTpushpull,
-//        embot::hw::gpio::Pull::nopull,
-//        embot::hw::gpio::Speed::veryhigh
-//    };
-
+    // marco.accame it may be that any of nHOLD, nW or nS are mapped into the dummy GPIO value {}. 
+    // it is the case of the amcfoc board where nW and nHOLD are attached to ground and VCC  
+    // even in such a case it is safe to use the embot::hw::gpio:: functions because they nothing when the GPIO is {}. 
     if(true == _config.pincontrol.config.isvalid())
     {
         // marco.accame: cube-mx sets the value of the pin before initialization,

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.h
@@ -91,7 +91,7 @@ namespace embot { namespace hw { namespace chip {
         static constexpr size_t pagelength {128};
         
         struct PinControl
-        {   // contains: chip select, write protection and hold (see page 2 of [1])
+        {   // contains: chip select, write protection and hold (see page 2 of [1]). if in the PCB they are not attached to a GPIO use dummy value {}
             embot::hw::GPIO nS {}; 
             embot::hw::GPIO nW {};
             embot::hw::GPIO nHOLD {}; 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -54,6 +54,9 @@ namespace embot { namespace hw { namespace encoder {
 
 #else
 
+#include "embot_hw_chip_AS5045.h"
+#include "embot_hw_chip_MA730.h"
+
 namespace embot { namespace hw { namespace encoder {
     
     // initialised mask

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder_bsp.h
@@ -11,9 +11,6 @@
 #define __EMBOT_HW_ENCODER_BSP_H_
 
 
-#include "embot_hw_chip_AS5045.h"
-#include "embot_hw_chip_MA730.h"
-
 namespace embot { namespace hw { namespace encoder {
     
     struct nonePROP

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.cpp
@@ -51,35 +51,35 @@ using namespace embot::hw;
 namespace embot { namespace hw { namespace eth {
 
 #if 0
-    bool supported(ETH b)
+    bool supported(EtH b)
     { return false; }
-    bool initialised(ETH b)
+    bool initialised(EtH b)
     { return false; }
-    result_t init(ETH b, const Config &config)
+    result_t init(EtH b, const Config &config)
     { return resNOK; }
-    result_t deinit(ETH b)
+    result_t deinit(EtH b)
     { return resNOK; }
      
-    bool isbusy(embot::hw::ETH b, embot::core::relTime timeout, embot::core::relTime &remaining) 
+    bool isbusy(embot::hw::EtH b, embot::core::relTime timeout, embot::core::relTime &remaining) 
     { return false; }  
     // blocking      
-    result_t read(embot::hw::ETH b, embot::core::Data &destination, embot::core::relTime timeout) 
+    result_t read(embot::hw::EtH b, embot::core::Data &destination, embot::core::relTime timeout) 
     { return resNOK; } 
-    result_t write(embot::hw::ETH b, const embot::core::Data &source, embot::core::relTime timeout) 
+    result_t write(embot::hw::EtH b, const embot::core::Data &source, embot::core::relTime timeout) 
     { return resNOK; }  
     // non blocking
-    result_t read(embot::hw::ETH b, embot::core::Data &destination, const embot::core::Callback &oncompletion)
+    result_t read(embot::hw::EtH b, embot::core::Data &destination, const embot::core::Callback &oncompletion)
     { return resNOK; }
-    result_t write(embot::hw::ETH b, const embot::core::Data &source, const embot::core::Callback &oncompletion)
+    result_t write(embot::hw::EtH b, const embot::core::Data &source, const embot::core::Callback &oncompletion)
     { return resNOK; }  
 
 #endif
 
-    bool supported(ETH b)
+    bool supported(embot::hw::EtH b)
     { return false; }
-    bool initialised(ETH b)
+    bool initialised(embot::hw::EtH b)
     { return false; }
-    result_t init(ETH b)
+    result_t init(embot::hw::EtH b)
     { return resNOK; }
     
     ipal_result_t ipal_init(ipal_hal_eth_cfg_t *cfg)
@@ -145,7 +145,7 @@ namespace embot { namespace hw { namespace eth {
     }
 
     
-//    result_t deinit(ETH b)
+//    result_t deinit(EtH b)
 //    {       
 //        if(false == initialised(b))
 //        {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth_bsp.h
@@ -21,11 +21,12 @@
 
 namespace embot { namespace hw { namespace eth { namespace bsp {
     
-#if   defined(HAL_ETH_MODULE_ENABLED)        
+#if defined(HAL_ETH_MODULE_ENABLED)        
     using ETH_Handle = ETH_HandleTypeDef;
     using ETH_Device = ETH_TypeDef;
 #else
     using ETH_Handle = void;
+    using ETH_Device = void;
 #endif
  
 #if 1 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_icc_ltr.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_icc_ltr.cpp
@@ -462,15 +462,21 @@ namespace embot::hw::icc::ltr::test {
     void tick(const std::string &str) {}
     
 #else
-        
+    #undef TEST_ICC_WITH_PRINTER    
     void init(DIR dir)
     {
+#if defined(TEST_ICC_WITH_PRINTER)        
         embot::hw::icc::printer::test::init(dir);
+#else        
+#endif        
     }
     
     void tick(const std::string &str)
     {
+#if defined(TEST_ICC_WITH_PRINTER)        
         embot::hw::icc::printer::test::tick(str);
+#else        
+#endif          
     }
 
 #endif    

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor.h
@@ -39,6 +39,19 @@ namespace embot { namespace hw { namespace motor {
         
     using fpOnCurrents = void (*)(void *owner, const Currents * const currents);
     
+#if 0    
+    struct PhaseCurrents
+    {
+        float v1 {0};
+        float v2 {0};
+        float v3 {0};
+        constexpr PhaseCurrents() = default;
+        constexpr PhaseCurrents(float c1, float c2, float c3) : v1(c1), v2(c2), v3(c3) {}        
+    };
+    
+    using OnPhaseCurrents = void (*)(MOTOR h, const PhaseCurrents * const phasecurrents, void *owner);
+#endif
+    
     // so far Config is an aggregate of the configuration values we need. 
     // we may need to add more along the way, so better having them organised in a struct    
     struct Config
@@ -90,7 +103,9 @@ namespace embot { namespace hw { namespace motor {
     // values of encoders and hall sensors can be read if(true == initialised(h))
     result_t getencoder(embot::hw::MOTOR h, Position &position);         
     result_t gethallstatus(embot::hw::MOTOR h, HallStatus &hs);
-     
+#if 0    
+    float angle(embot::hw::MOTOR h);
+#endif     
     // not used so far, so we keep it out                     
     // result_t gethallcounter(embot::hw::MOTOR h, Position &position);   
           

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.cpp
@@ -1,0 +1,268 @@
+
+/*
+ * Copyright (C) 2021 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_motor.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_bsp_config.h"
+#include "embot_hw_motor_bsp.h"
+
+#include <cstring>
+#include <vector>
+
+#include "embot_core_binary.h"
+#include "embot_hw_sys.h"
+
+#if defined(USE_STM32HAL)
+    #include "stm32hal.h"
+#else
+    #warning this implementation is only for stm32hal
+#endif   
+  
+
+using namespace embot::hw;
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+#if !defined(EMBOT_ENABLE_hw_motor)
+
+namespace embot::hw::motor::bldc {
+
+    bool supported(MOTOR h) { return false; }
+    bool initialised(MOTOR h) { return false; }
+    
+    bool init(MOTOR h, const Config &config) { return false; } 
+    bool configure(embot::hw::MOTOR h, const Config &config) { return false; }   
+    bool enable(MOTOR h, bool on) { return false; }    
+    bool enabled(MOTOR h) { return false; } 
+    bool fault(MOTOR h, bool on) { return false; }        
+    bool faulted(MOTOR h) { return false; }    
+    bool set(MOTOR m, const OnCurrents &oncurrents) { return false; }    
+    HallStatus hall(MOTOR m) { return 0; }     
+    Angle angle(MOTOR m, Encoder enc) { return false; }     
+    bool set(MOTOR m, const PWMs &pwms) { return false; }     
+    Voltage powersupply(MOTOR m) { return false; } 
+    
+} // namespace embot::hw::motor::bldc {
+
+#elif defined(EMBOT_ENABLE_hw_motor)
+
+#if defined(STM32HAL_BOARD_AMC2C) || defined(STM32HAL_BOARD_AMC1CM7) || defined(STM32HAL_BOARD_AMC2CM4)
+    #include "motorhal.h"  
+#elif defined(STM32HAL_BOARD_AMCFOC_1CM7)
+    #include "embot_hw_motor_adc.h"  
+    #include "embot_hw_motor_enc.h"  
+    #include "embot_hw_motor_hall.h"  
+    #include "embot_hw_motor_pwm.h"  
+#endif    
+
+
+
+
+namespace embot::hw::motor::bldc {
+   
+    bool supported(MOTOR m)
+    {
+        return embot::hw::motor::supported(m);
+    }
+    
+    bool initialised(MOTOR m)
+    {
+        return embot::hw::motor::initialised(m);
+    }    
+    
+    
+    bool init(MOTOR m, const Config &cfg)
+    { 
+        embot::hw::motor::Config c { 
+            cfg.enc_resolution,
+            cfg.pwm_num_polar_couples,
+            cfg.pwm_hall_offset,         
+            cfg.has_quad_enc,
+            cfg.pwm_has_hall_sens,
+            cfg.pwm_swapBC
+        };
+        
+        return (resOK == embot::hw::motor::init(m, c)) ? true : false;
+    }
+  
+    
+    bool configure(MOTOR m, const Config&cfg)
+    {
+        embot::hw::motor::Config c { 
+            cfg.enc_resolution,
+            cfg.pwm_num_polar_couples,
+            cfg.pwm_hall_offset,         
+            cfg.has_quad_enc,
+            cfg.pwm_has_hall_sens,
+            cfg.pwm_swapBC
+        };
+        
+        return (resOK == embot::hw::motor::configure(m, c)) ? true : false;
+    }     
+ 
+       
+    bool enable(MOTOR m, bool on)
+    {
+        return (resOK == embot::hw::motor::enable(m, on)) ? true : false;                     
+    }    
+
+    bool enabled(MOTOR m)
+    {
+        return embot::hw::motor::enabled(m);
+    }
+        
+    
+    bool fault(MOTOR m, bool on)
+    {        
+        return (resOK == embot::hw::motor::fault(m, on)) ? true : false;
+    } 
+
+    bool faulted(MOTOR m)
+    {
+        return embot::hw::motor::faulted(m);
+    }
+    
+    bool set(MOTOR m, const embot::hw::motor::bldc::OnCurrents &oncurrents)
+    {
+        bool r { false};       
+        r = embot::hw::motor::adc::set(m, oncurrents);
+        return r;        
+    }
+
+    HallStatus hall(MOTOR m)
+    {
+        HallStatus ha {0};
+        embot::hw::motor::gethallstatus(m, ha);
+        return ha;
+    }
+
+    bool set(MOTOR m, const PWM3 &pwm)
+    {
+        return (resOK == embot::hw::motor::setPWM(m, {pwm.u, pwm.v, pwm.w})) ? true : false;
+    }
+  
+    
+    Angle angle(MOTOR m, Encoder enc)
+    {
+        Angle a = (enc == Encoder::hall) ? 0 : 1;
+        
+        //return  embot::hw::motor::hall::angle(h);
+        
+        return a;        
+    }
+    
+    
+    
+       
+//    result_t setCallbackOnCurrents(MOTOR h, fpOnCurrents callback, void *owner)
+//    {
+//        return s_hw_setCallbackOnCurrents(h, callback, owner);
+//    }
+//    
+//    bool set1(MOTOR h, OnPhaseCurrents onphasecurrents, void *owner)
+//    {
+//         return s_hw_setOnPhaseCurrents(h, onphasecurrents, owner);
+//    }
+//    
+    Voltage powersupply(MOTOR m)
+    {
+        return embot::hw::motor::getVIN();
+    }
+
+    
+// in here is the part for low level hw of the boards (amc2c or amcbldc)
+      
+    
+#if defined(STM32HAL_BOARD_AMC2C) || defined(STM32HAL_BOARD_AMC1CM7) || defined(STM32HAL_BOARD_AMC2CM4) || defined(STM32HAL_BOARD_AMCFOC_1CM7)
+    
+   
+
+//    Position s_hw_getencoder(MOTOR h)
+//    {
+//        Position p {0};
+//        if(true == embot::hw::motor::enc::isstarted())
+//        {
+//           p = embot::hw::motor::enc::getvalue();
+//        }
+//        else if(true == embot::hw::motor::hall::isstarted())
+//        {
+//           p = embot::hw::motor::hall::getangle();
+//        }
+//        return p;
+//    }
+
+
+        
+//    HallStatus s_hw_gethallstatus(MOTOR h)
+//    {       
+//        return  embot::hw::motor::hall::getstatus();
+//    }
+
+     
+
+//    result_t s_hw_setpwmUVWperc(MOTOR h, const PWMperc &p)
+//    {   
+//        embot::hw::motor::pwm::setperc(p.a, p.b, p.c);        
+//        return resOK;
+//    }  
+    
+   
+   
+    
+//    bool s_hw_setOnPhaseCurrents(MOTOR h, OnPhaseCurrents onphasecurrents,  void *owner)
+//    {
+//        if((nullptr == onphasecurrents))
+//        {
+//            return false;
+//        }      
+//        
+//        //embot::hw::motor::adc::OnMotorCurrents cbk {reinterpret_cast<embot::hw::motor::adc::OnMotorCurrents::Action>(onphasecurrents), owner};
+//        embot::hw::motor::adc::OnMotorPhaseCurrents cbk1 {onphasecurrents, owner};
+//        embot::hw::motor::adc::set1(h, cbk1);
+//        return true;           
+//    }
+      
+
+#elif defined(STM32HAL_BOARD_AMCBLDC)
+    
+    #error add implentation for amcbldc  
+    
+#else
+    #error define a board
+#endif    
+    
+    
+ 
+} // namespace embot::hw::motor::bldc {
+
+
+
+#endif // #elif defined(EMBOT_ENABLE_hw_motor)
+ 
+
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.h
@@ -1,0 +1,140 @@
+
+
+/*
+ * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_HW_MOTOR_BLDC_H_
+#define __EMBOT_HW_MOTOR_BLDC_H_
+
+#include "embot_core.h"
+#include "embot_hw.h"
+#include "embot_hw_types.h"
+
+#include "embot_hw_motor.h"
+
+
+namespace embot::hw::motor::bldc {
+        
+    constexpr uint8_t MAXnumber {2};
+    
+    using Current = float; // in [A]
+    struct Currents 
+    {
+        Current u {0};
+        Current v {0};
+        Current w {0};
+        constexpr Currents() = default;
+        constexpr Currents(float v1, float v2, float v3) : u(v1), v(v2), w(v3) {}            
+    };
+    
+    
+    struct PWM3 
+    {
+        using Percentage = float; // in range [0.0, 100.0]
+        Percentage u {0.0};
+        Percentage v {0.0};
+        Percentage w {0.0};
+        constexpr PWM3() = default;
+        constexpr PWM3(float v1, float v2, float v3) : u(v1), v(v2), w(v3) {}
+        constexpr bool isvalid() const { 
+            bool positive = (u>=0) && (v>=0) && (w>=0); bool less100 = (u<=100) && (v<=100) && (w<=100);
+            return positive && less100;
+        }
+    };  
+
+    struct OnCurrents
+    {
+        using Action = void (*)(MOTOR m, const Currents * const currs, void *owner);
+        
+        MOTOR motor {MOTOR::none};        
+        Action action {nullptr};
+        void *owner {nullptr};
+        
+        constexpr OnCurrents() = default;
+        constexpr OnCurrents(MOTOR m, Action a, void *o) : motor(m), action(a), owner(o) {}
+            
+        void load(MOTOR m, Action a, void *o) { motor = m; action = a; owner = o; } 
+       // void load(const OnCurrents &obj) { motor = obj.motor; action = obj.action; owner = obj.owner; }    
+        bool isvalid() const { return (nullptr != action); }
+        void execute(const Currents * const curs) const
+        { 
+            if(isvalid()) { action(motor, curs, owner); } 
+        }          
+    };
+
+    using Voltage = float; // in range [V]  
+    
+    // HallStatus uses bits 2, 1, 0 to keep status of {HALL1, HALL2, HALL3}
+    using HallStatus = std::uint8_t;
+    
+    using Angle = float; // in [degrees]
+    
+    enum class Encoder : uint8_t { hall = 0, quadenc = 1 };
+    
+    struct Config
+    {
+        int16_t enc_resolution {0}; 
+        uint8_t pwm_num_polar_couples {0}; 
+        uint16_t pwm_hall_offset {0};         
+        bool has_quad_enc {false};
+        bool pwm_has_hall_sens {false};
+        bool pwm_swapBC {false};
+        
+        constexpr Config() = default;         
+        constexpr Config(int16_t er, uint8_t pc, uint16_t ho, bool hqe, bool hhs, bool spbc) 
+            : enc_resolution(er), pwm_num_polar_couples(pc), pwm_hall_offset(ho), 
+              has_quad_enc(hqe), pwm_has_hall_sens(hhs), pwm_swapBC(spbc)  {} 
+        constexpr bool isvalid() const { 
+            bool KO = (0 == enc_resolution) && (0 == pwm_num_polar_couples) && (0 == pwm_hall_offset);
+            return !KO; 
+        }
+    };
+    
+    // functions
+
+    bool supported(embot::hw::MOTOR m);     
+    bool initialised(embot::hw::MOTOR m);
+
+    // it prepares the low level HW and if config.isvalid() it also configures the HW w/ its content
+    bool init(embot::hw::MOTOR m, const Config &config); 
+    
+    // is to be called after init() and if config.isvalid() it configures the HW w/ its content.
+    bool configure(embot::hw::MOTOR m, const Config &config);     
+
+    // it enables on/off the motor. this function is effective only if initialised(h) is true  
+    bool enable(MOTOR m, bool on);
+    bool enabled(MOTOR m); 
+
+    // it faults on/off the motor. this function is effective also before the call of init() as long as supported(h) is true                  
+    bool fault(MOTOR m, bool on);
+    bool faulted(MOTOR m); 
+        
+    // it imposes the callback of reception of currents for a given motor.
+    // it typically gets the motor position and applies PWMs properly rotated
+    bool set(MOTOR m, const embot::hw::motor::bldc::OnCurrents &oncurrents);
+    
+//    bool hall(MOTOR m, HallStatus &hall);
+
+    HallStatus hall(MOTOR m);
+    
+    Angle angle(MOTOR m, Encoder enc);
+    
+    bool set(MOTOR m, const PWM3 &pwm);
+    
+    Voltage powersupply(MOTOR m);
+    
+} // namespace embot::hw::motor::bldc {
+    
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+
+

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_multisda_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_multisda_bsp.h
@@ -22,8 +22,7 @@ namespace embot { namespace hw { namespace multisda {
              
     struct PROP
     {
-        constexpr static std::uint8_t numberof = 5; // SD NSDA HERE
-//        constexpr static std::uint8_t numberof = 4; // SD NSDA HERE
+        constexpr static std::uint8_t numberof = 5; 
         embot::hw::gpio::PROP clk {};
         std::array<const embot::hw::gpio::PROP, numberof> sda;
         constexpr PROP() = default;

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_sys.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_sys.cpp
@@ -338,9 +338,14 @@ namespace embot::hw::sys::DRIVER {
     uint64_t _uniqueid()
     {
         uint64_t r = 0;
-#if defined(STM32H7)    
+#if defined(STM32H7)
+#if defined(CORE_CM7)        
         r = HAL_GetUIDw0() | static_cast<uint64_t>(HAL_GetUIDw1()) << 32;
         r += HAL_GetUIDw2();
+#else
+        r = 1234;
+        #warning the call of HAL_GetUIDw0() on the H7 CM4 makes it crash
+#endif
 #endif    
         return r;  
     }

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_testpoint.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_testpoint.cpp
@@ -59,14 +59,25 @@ using namespace embot::hw;
 
 #if !defined(EMBOT_ENABLE_hw_testpoint)
 
-namespace embot { namespace hw { namespace testpoint {
+namespace embot::hw::testpoint {
     
-    #error fill it
-}}}
+    bool supported(embot::hw::TESTPOINT testpoint)
+    { return false; }
+    bool initialised(embot::hw::TESTPOINT testpoint)
+    { return false; }        
+    result_t init(embot::hw::TESTPOINT testpoint)       
+    { return resNOK; }     
+    result_t on(embot::hw::TESTPOINT testpoint)       
+    { return resNOK; }  
+    result_t off(embot::hw::TESTPOINT testpoint)       
+    { return resNOK; }  
+    result_t toggle(embot::hw::TESTPOINT testpoint)       
+    { return resNOK; }  
+}
 
 #else
 
-namespace embot { namespace hw { namespace testpoint {
+namespace embot::hw::testpoint {
 
     // initialised mask
     static std::uint32_t initialisedmask = 0;
@@ -155,7 +166,7 @@ namespace embot { namespace hw { namespace testpoint {
     }
     
     
-}}} // namespace embot { namespace hw { namespace testpoint
+} // namespace embot::hw::testpoint {
 
 
 #endif //#if defined(EMBOT_ENABLE_hw_testpoint)

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_timer.cpp
@@ -318,7 +318,11 @@ void hal_error_handler()
 #if defined(STM32HAL_STM32L4) && (STM32HAL_DRIVER_VERSION >= 0x190)
     Error_Handler();
 #elif defined(STM32HAL_STM32H7)
-    Error_Handler();
+    for(;;)
+    {
+        static volatile uint32_t x {0};
+        x++;        
+    } // Error_Handler();
 #endif
 }
  


### PR DESCRIPTION
In building up the projects for the `amcfoc`, I needed cleanup of some code. 

This PR does some cleanup of some `embot::hw` files so that compilation is OK even when some `EMBOT_ENABLE_hw_xxx` macros are not defined. That is needed to compile the first demo projects of `amcfoc` at an early stage when the full HW support is not ready yet.

Moreover, I added `embot::hw::motor::bldc` in draft form so that it supports two motors and does not touch the  `embot::hw::motor` files used by `amcbldc` and `amc2c`.

This PR does not affect the existing projects and can ne safely merged.