### PR TITLE
Feature/publish encoder raw values

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 9},
-            {2024, Month::Oct, Day::twentyone, 14, 00}
+            {2, 10},
+            {2024, Month::Oct, Day::twentyeight, 16, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          194
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          95
 
 //  </h>version
 
@@ -89,13 +89,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          4
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          39
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          94
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          194
 
 //  </h>version
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
@@ -137,6 +137,11 @@
     {
         return eores_NOK_generic;
     }
+    
+    extern eOresult_t eo_encoderreader_GetRaw(EOtheEncoderReader *p, uint8_t jomo, eOencoderreader_RawValuesOfJomo_t *rawValuesArray)
+    {
+        return eores_NOK_generic;
+    }
 
 
     
@@ -569,6 +574,28 @@ extern eOresult_t eo_encoderreader_Scale(EOtheEncoderReader* p, uint8_t jomo, eO
     }
     
     return r;    
+}
+
+extern eOresult_t eo_encoderreader_GetRaw(EOtheEncoderReader *p, uint8_t jomo, eOencoderreader_RawValuesOfJomo_t *rawValuesArray)
+{
+    if(NULL == p)
+    {
+        return(eores_NOK_nullpointer);
+    }
+    
+    if(eobool_false == s_eo_theencoderreader.service.active)
+    {   // nothing to do because we dont have it
+        return(eores_OK);
+    }   
+
+    if(jomo >= eOappEncReader_jomos_maxnumberof)
+    {
+        return(eores_NOK_generic);
+    }
+
+    eOresult_t res = eo_appEncReader_GetRawValue(s_eo_theencoderreader.reader, jomo, rawValuesArray); 
+    
+    return(res);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.h
@@ -106,6 +106,27 @@ typedef enum
     eo_encreader_pos_any = 14,
     eo_encreader_pos_none = 15   
 } eOencoderreader_Position_t;    
+
+
+// The following enum and structs are the correspondent to the the ones in 
+// embot::app::eth::encoder::experimental in embot_app_eth_Encoder.h
+
+// enum for the maximum number of jomo components
+enum { eOencoderreader_maxnumberofencoderperjomo = 3 };
+
+// raw data for single component, raw value and diagnostic
+typedef struct
+{
+    int32_t val;
+    int32_t diagnInfo;
+} eOencoderreader_RawValueEncoder_t; 
+
+// struct for raw data and validity flag for entire jomo
+typedef struct
+{
+    eOencoderreader_RawValueEncoder_t rawvalues[eOencoderreader_maxnumberofencoderperjomo];
+    bool areValidReadings[eOencoderreader_maxnumberofencoderperjomo];
+} eOencoderreader_RawValuesOfJomo_t;
    
 // - declaration of extern public variables, ...deprecated: better using use _get/_set instead ------------------------
 // empty-section
@@ -143,6 +164,8 @@ extern eOmc_encoder_t eo_encoderreader_GetType(EOtheEncoderReader* p, uint8_t jo
 
 extern eOresult_t eo_encoderreader_Scale(EOtheEncoderReader* p, uint8_t jomo, eOencoderreader_Position_t position, eOencoderreader_Scaler *scaler);
 
+// Correlated to IFreader
+extern eOresult_t eo_encoderreader_GetRaw(EOtheEncoderReader *p, uint8_t jomo, eOencoderreader_RawValuesOfJomo_t *rawValuesArray);
 
 /** @}            
     end of group eo_EOtheEncoderReader

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -71,7 +71,6 @@
 
 #include "EOtheMotionController_hid.h"
 
-
 #if defined(EOTHESERVICES_disable_theMotionController)
 
     // provide empty implementation, so that we dont need to change the caller of the API
@@ -1620,8 +1619,9 @@ extern void eoprot_fun_INIT_mc_motor_status(const EOnv* nv)
  */
 static eOresult_t s_eo_motioncontrol_updatedPositionsFromEncoders(EOtheMotionController *p)
 {
-
     eOresult_t res = eores_OK;
+    
+    eOmc_joint_status_t *jstatus = NULL;
     
     // wait for the encoders for some time
     for (uint8_t i=0; i<30; ++i)
@@ -1662,6 +1662,17 @@ static eOresult_t s_eo_motioncontrol_updatedPositionsFromEncoders(EOtheMotionCon
             res = eores_NOK_generic;
         }
         
+        embot::app::eth::encoder::experimental::RawValuesOfJomo rawValsArray = {};
+            
+        embot::app::eth::theEncoderReader::getInstance().GetRaw(i, rawValsArray);
+
+        if(NULL != (jstatus = eo_entities_GetJointStatus(eo_entities_GetHandle(), i)))
+        {
+            jstatus->addinfo.multienc[0] = rawValsArray.rawvalues[0].val;
+            jstatus->addinfo.multienc[1] = rawValsArray.rawvalues[1].val;
+            jstatus->addinfo.multienc[2] = rawValsArray.rawvalues[0].diagnInfo;
+            
+        }
     } 
     
     embot::app::eth::theEncoderReader::getInstance().Diagnostics_Tick();

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -1669,7 +1669,7 @@ static eOresult_t s_eo_motioncontrol_updatedPositionsFromEncoders(EOtheMotionCon
         if(NULL != (jstatus = eo_entities_GetJointStatus(eo_entities_GetHandle(), i)))
         {
             jstatus->addinfo.multienc[0] = rawValsArray.rawvalues[0].val;
-            jstatus->addinfo.multienc[1] = rawValsArray.rawvalues[1].val;
+            //jstatus->addinfo.multienc[1] = rawValsArray.rawvalues[1].val; for now do not update the raw value for the motor encoder since we are adding to it the raw planned target --> see lines 292..294 in Joint.c
             jstatus->addinfo.multienc[2] = rawValsArray.rawvalues[0].diagnInfo;
             
         }

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          74
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          75
 
 //  </h>version
 
@@ -83,11 +83,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          20
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          95
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          96
 
 //  </h>version
 
@@ -92,11 +92,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          20
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.h
@@ -93,6 +93,9 @@ extern eOresult_t eo_appEncReader_UpdatedMaisConversionFactors(EOappEncReader *p
 extern eOresult_t eo_appEncReader_UpdatedHallAdcConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor);
 extern eOresult_t eo_appEncReader_UpdatedHallAdcOffset(EOappEncReader *p, uint8_t jomo, int32_t offset);
 
+// IFreader
+extern eOresult_t eo_appEncReader_GetRawValue(EOappEncReader *p, uint8_t jomo, eOencoderreader_RawValuesOfJomo_t *rawValuesArray);
+
 /** @}            
     end of group eo_app_encodersReader
  **/

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
@@ -139,6 +139,7 @@ struct EOappEncReader_hid
     eOappEncReader_hallAdc_conversionData_t hallAdcConversionData;
     eo_appEncReader_amodiag_t               amodiag;
     eOappEncReader_Aksim2_DiagnosticError_Counters_t aksim2DiagnerrorCounters;
+    eOencoderreader_RawValuesOfJomo_t       genericEncoderRawData[eOappEncReader_jomos_maxnumberof];
 }; 
 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
@@ -1461,6 +1461,7 @@ void MController_get_joint_state(int j, eOmc_joint_status_t* joint_state)
      Joint_get_state(j_ptr, j, joint_state);
 #endif
     
+    /**
     AbsEncoder* enc_ptr = smc->absEncoder + j*smc->multi_encs;
     
     for (int k=0; k<smc->multi_encs; ++k)
@@ -1468,7 +1469,7 @@ void MController_get_joint_state(int j, eOmc_joint_status_t* joint_state)
         joint_state->addinfo.multienc[k] = AbsEncoder_position(enc_ptr++);
         //joint_state->addinfo.multienc[k] = count;
     }
-    
+    */
 
 }
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -288,7 +288,10 @@ void Joint_update_status_reference(Joint* o)
         default:
             ;
     }
-
+    
+    // Debug for temporary adding the raw planned target position to the motor encoder value which
+    o->eo_joint_ptr->status.addinfo.multienc[1] = (int32_t)Trajectory_get_target_position(&(o->trajectory));
+    //ends here
 }
 
 static void Joint_send_debug_message(const char *message, uint8_t jid, uint16_t par16, uint64_t par64)

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.h
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.h
@@ -56,10 +56,10 @@ namespace embot { namespace app { namespace eth {
         bool Scale(const embot::app::eth::encoder::v1::Target &target, const embot::app::eth::encoder::v1::Scaler &scaler) override;
     
         // experimental::IFreader
-        bool read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value) override;
-    
-        bool raw(uint8_t jomo, embot::app::eth::encoder::v1::Position pos, embot::app::eth::encoder::experimental::Value &value);
-    
+        bool GetRaw(uint8_t jomo, embot::app::eth::encoder::experimental::RawValuesOfJomo &rawValuesArray) override;
+        bool GetRawSingle(uint8_t jomo, embot::app::eth::encoder::experimental::Position pos, embot::app::eth::encoder::experimental::RawValueEncoder &rawValue) override;
+        
+        
         void log();
         
     private:

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReaderLegacy.cpp
@@ -44,8 +44,9 @@ struct embot::app::eth::theEncoderReader::Impl
     bool Scale(const embot::app::eth::encoder::v1::Target &target, const embot::app::eth::encoder::v1::Scaler &scaler);
     
     // advanced
-    bool read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value);
-
+    bool GetRaw(uint8_t jomo, embot::app::eth::encoder::experimental::RawValuesOfJomo &rawValuesArray);
+    bool GetRawSingle(uint8_t jomo, embot::app::eth::encoder::experimental::Position pos, embot::app::eth::encoder::experimental::RawValueEncoder &rawValue);
+    
 };
 
 
@@ -113,12 +114,16 @@ bool embot::app::eth::theEncoderReader::Impl::Scale(const embot::app::eth::encod
     return eores_OK == eo_encoderreader_Scale(eo_encoderreader_GetHandle(), target.jomo, static_cast<eOencoderreader_Position_t>(embot::core::tointegral(target.pos)), &sca);
 }
 
-bool embot::app::eth::theEncoderReader::Impl::read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value)
+bool embot::app::eth::theEncoderReader::Impl::GetRaw(uint8_t jomo, embot::app::eth::encoder::experimental::RawValuesOfJomo &rawValuesArray)
 {
-    value.raw = 0x123456789A;
-    value.error = embot::app::eth::encoder::experimental::Error::NONE;
+    eOencoderreader_RawValuesOfJomo_t *rvja = reinterpret_cast<eOencoderreader_RawValuesOfJomo_t*>(&rawValuesArray);
     
-    return true;
+    return eores_OK == eo_encoderreader_GetRaw(eo_encoderreader_GetHandle(), jomo, rvja);
+}
+
+bool embot::app::eth::theEncoderReader::Impl::GetRawSingle(uint8_t jomo, embot::app::eth::encoder::experimental::Position pos, embot::app::eth::encoder::experimental::RawValueEncoder &rawValue)
+{
+    return eores_OK;
 }
 
 
@@ -195,12 +200,15 @@ bool embot::app::eth::theEncoderReader::Scale(const embot::app::eth::encoder::v1
     return pImpl->Scale(target, scaler);
 }
 
-bool embot::app::eth::theEncoderReader::read(const embot::app::eth::encoder::experimental::Target &target, embot::app::eth::encoder::experimental::Value &value)
+bool embot::app::eth::theEncoderReader::GetRaw(uint8_t jomo, embot::app::eth::encoder::experimental::RawValuesOfJomo &rawValuesArray)
 {
-    return pImpl->read(target, value);
+    return pImpl->GetRaw(jomo, rawValuesArray);
 }
 
-
+bool embot::app::eth::theEncoderReader::GetRawSingle(uint8_t jomo, embot::app::eth::encoder::experimental::Position pos, embot::app::eth::encoder::experimental::RawValueEncoder &rawValue)
+{
+    return pImpl->GetRawSingle(jomo, pos, rawValue);
+}
 // - end-of-file (leave a blank line after)----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
This PR add some fw to enable the publication of the raw values of joint encoders and save them in the `multienc` array.
It's related to:
- https://github.com/robotology/robometry/pull/190
- https://github.com/robotology/icub-main/pull/983