### PR TITLE
MTB4/c implementation of 5th I2C line can be switched runtime with CAN message

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4/application/proj/mtb4-application-v6.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/proj/mtb4-application-v6.uvoptx
@@ -754,7 +754,7 @@
 
   <Group>
     <GroupName>embot-core</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -882,7 +882,7 @@
 
   <Group>
     <GroupName>embot-app-protocol</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/mtb4/application/proj/mtb4-application-v6.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/proj/mtb4-application-v6.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32L433RCTx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.2.0</PackID>
-          <PackURL>http://www.keil.com/pack</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.5.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x0000C000) IRAM2(0x10000000,0x00004000) IROM(0x08000000,0x00040000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -880,8 +880,8 @@
         <TargetCommonOption>
           <Device>STM32L433RCTx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.2.0</PackID>
-          <PackURL>http://www.keil.com/pack</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.5.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x0000C000) IRAM2(0x10000000,0x00004000) IROM(0x08000000,0x00040000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -1202,7 +1202,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register</MiscControls>
-              <Define>USE_STM32HAL STM32HAL_BOARD_MTB4 STM32HAL_DRIVER_V1D3 ENABLE_FAPreader USE_FIFTH_I2C</Define>
+              <Define>USE_STM32HAL STM32HAL_BOARD_MTB4 STM32HAL_DRIVER_V1D3 ENABLE_FAPreader dUSE_FIFTH_I2C</Define>
               <Undefine></Undefine>
               <IncludePath>..\src-plus;..\..\..\..\..\..\eBcode\arch-arm\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\eBcode\arch-arm\libs\midware\eventviewer\api;..\..\..\..\..\..\eBcode\arch-arm\embobj\core\exec\multitask;..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\..\eBcode\arch-arm\libs\lowlevel\stm32hal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\eBcode\arch-arm\embot\app;..\..\..\..\..\..\eBcode\arch-arm\embot\i2h;..\..\..\..\..\..\eBcode\arch-arm\embot\hw;..\..\..\..\..\..\eBcode\arch-arm\embot\os;..\..\..\..\..\..\eBcode\arch-arm\embot;..\src\others;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\bsp</IncludePath>
             </VariousControls>

--- a/emBODY/eBcode/arch-arm/board/mtb4/application/proj/mtb4-application-v6.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/proj/mtb4-application-v6.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32L433RCTx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.7.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.2.0</PackID>
+          <PackURL>http://www.keil.com/pack</PackURL>
           <Cpu>IRAM(0x20000000,0x0000C000) IRAM2(0x10000000,0x00004000) IROM(0x08000000,0x00040000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -873,15 +873,15 @@
       <TargetName>mtb4-v1D3</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6190000::V6.19::.\armclang-r6p19-00rel0</pArmCC>
-      <pCCUsed>6190000::V6.19::.\armclang-r6p19-00rel0</pCCUsed>
+      <pArmCC>6190000::V6.19::ARMCLANG</pArmCC>
+      <pCCUsed>6190000::V6.19::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32L433RCTx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.7.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.2.0</PackID>
+          <PackURL>http://www.keil.com/pack</PackURL>
           <Cpu>IRAM(0x20000000,0x0000C000) IRAM2(0x10000000,0x00004000) IROM(0x08000000,0x00040000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -1202,7 +1202,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls>-Wno-pragma-pack -Wno-deprecated-register</MiscControls>
-              <Define>USE_STM32HAL STM32HAL_BOARD_MTB4 STM32HAL_DRIVER_V1D3 ENABLE_FAPreader</Define>
+              <Define>USE_STM32HAL STM32HAL_BOARD_MTB4 STM32HAL_DRIVER_V1D3 ENABLE_FAPreader USE_FIFTH_I2C</Define>
               <Undefine></Undefine>
               <IncludePath>..\src-plus;..\..\..\..\..\..\eBcode\arch-arm\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\eBcode\arch-arm\libs\midware\eventviewer\api;..\..\..\..\..\..\eBcode\arch-arm\embobj\core\exec\multitask;..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\..\eBcode\arch-arm\libs\lowlevel\stm32hal\api;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\eBcode\arch-arm\embot\app;..\..\..\..\..\..\eBcode\arch-arm\embot\i2h;..\..\..\..\..\..\eBcode\arch-arm\embot\hw;..\..\..\..\..\..\eBcode\arch-arm\embot\os;..\..\..\..\..\..\eBcode\arch-arm\embot;..\src\others;..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\embot\app\skeleton;..\..\..\..\embot\prot\can;..\..\bsp</IncludePath>
             </VariousControls>

--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
@@ -15,13 +15,13 @@
 constexpr embot::app::theCANboardInfo::applicationInfo applInfo
 {
 #if defined(CUSTOMIZATION_MTB4_FOR_TLR)
-    embot::prot::can::versionOfAPPLICATION {20, 21, 0},
+    embot::prot::can::versionOfAPPLICATION {20, 23, 0},
     embot::prot::can::versionOfCANPROTOCOL {20, 0}
 #elif defined(USE_FIFTH_I2C)
-    embot::prot::can::versionOfAPPLICATION {51, 22, 0},
+    embot::prot::can::versionOfAPPLICATION {51, 23, 0},
     embot::prot::can::versionOfCANPROTOCOL {2, 0}
 #else
-    embot::prot::can::versionOfAPPLICATION {1, 22, 0},
+    embot::prot::can::versionOfAPPLICATION {1, 23, 0},
     embot::prot::can::versionOfCANPROTOCOL {2, 0}
 #endif
 };

--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/others/I2C_Multi_SDA.c
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/others/I2C_Multi_SDA.c
@@ -996,7 +996,7 @@ void StartI2CMaster(unsigned char Channel) {
 #warning marco.accame: why param input is not used?
 void SetSdaReg(i2c_sda_num_t sdaNum, unsigned char input) 
 {    
-    if(sdaNum < 4)
+    if(sdaNum < 5)
     {       
         LL_GPIO_SetPinMode(props.sda[sdaNum].stmport, props.sda[sdaNum].stmpin, LL_GPIO_MODE_INPUT);
     }
@@ -1005,7 +1005,7 @@ void SetSdaReg(i2c_sda_num_t sdaNum, unsigned char input)
 
 void SetValReg(i2c_sda_num_t sdaNum, unsigned char val) 
 {
-    if(sdaNum < 4)
+    if(sdaNum < 5)
     {   // because val=0 -> GPIO_PIN_RESET else -> GPIO_PIN_SET
         HAL_GPIO_WritePin(props.sda[sdaNum].stmport, props.sda[sdaNum].stmpin, (0==val) ? (GPIO_PIN_RESET) : (GPIO_PIN_SET));        
     }

--- a/emBODY/eBcode/arch-arm/board/mtb4c/application/proj/mtb4c-application-v6.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/mtb4c/application/proj/mtb4c-application-v6.uvoptx
@@ -532,7 +532,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/mtb4c/application/proj/mtb4c-application-v6.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/mtb4c/application/proj/mtb4c-application-v6.uvprojx
@@ -16,8 +16,8 @@
         <TargetCommonOption>
           <Device>STM32L452RCIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.7.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.5.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IRAM2(0x10000000,0x00008000) IROM(0x08000000,0x00040000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
@@ -903,8 +903,8 @@
         <TargetCommonOption>
           <Device>STM32L452RCIx</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32L4xx_DFP.2.7.0</PackID>
-          <PackURL>https://www.keil.com/pack/</PackURL>
+          <PackID>Keil.STM32L4xx_DFP.2.5.0</PackID>
+          <PackURL>http://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x20000000,0x00020000) IRAM2(0x10000000,0x00008000) IROM(0x08000000,0x00040000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>

--- a/emBODY/eBcode/arch-arm/board/mtb4c/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4c/application/src/main-appcan.cpp
@@ -18,10 +18,10 @@ constexpr embot::app::theCANboardInfo::applicationInfo applInfo
     embot::prot::can::versionOfAPPLICATION {22, 0, 0},    
     embot::prot::can::versionOfCANPROTOCOL {20, 0} 
 #elif defined(USE_FIFTH_I2C)
-    embot::prot::can::versionOfAPPLICATION {52, 2, 0},
+    embot::prot::can::versionOfAPPLICATION {52, 3, 0},
     embot::prot::can::versionOfCANPROTOCOL {2, 0}
 #else   
-    embot::prot::can::versionOfAPPLICATION {2, 2, 0},    
+    embot::prot::can::versionOfAPPLICATION {2, 3, 0},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0} 
 #endif    
 };

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theSkin.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theSkin.cpp
@@ -63,9 +63,11 @@ std::uint16_t dbg = 0;
 constexpr std::uint8_t dotNumberOf = 12;
 constexpr std::uint8_t trgNumberOf = 16; //4 for each sda. This is used in the CAN message forming so it's locked to 16
 #ifdef USE_FIFTH_I2C 
-    uint16_t trianglesOrder[16]  = {0,4,8,12,16,1,2,3,5,6,7,9,10,11,13,14};
+    uint16_t trianglesOrder[16]  = {0,4,8,12,16,10,11,13,15,1,2,3,5,6,7,9};
 #else
-    constexpr std::uint16_t trianglesOrder[16]  = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
+    uint16_t trianglesOrder[16]  = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
+    uint16_t altTrianglesOrder[16]  = {0,4,8,12,16,10,11,13,15,1,2,3,5,6,7,9}; //to reshuffle the triangles on-the-run
+
 #endif
 
 struct TriangleCfg

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.cpp
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.cpp
@@ -266,7 +266,13 @@ namespace embot { namespace prot { namespace can { namespace analog { namespace 
             {
                 info.skintype = SkinType::withTemperatureCompensationV2;
             } break;
-                       
+            
+            case static_cast<std::uint8_t>(SkinType::ergoHand):
+            {
+                info.skintype = SkinType::ergoHand;
+//                trianglesOrder = altTrianglesOrder; 
+            } break;
+                      
             default:
             {
                 info.skintype = SkinType::none;

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.h
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.h
@@ -348,7 +348,7 @@ namespace embot { namespace prot { namespace can { namespace analog { namespace 
     {
         public:
             
-        enum class SkinType { withTemperatureCompensation = 0, palmFingerTip = 1, withoutTempCompensation = 2, testmodeRAW = 7, withTemperatureCompensationV2 = 8, none = 254, ergoHand = 16 };
+        enum class SkinType { withTemperatureCompensation = 0, palmFingerTip = 1, withoutTempCompensation = 2, testmodeRAW = 7, withTemperatureCompensationV2 = 8, none = 254, ergoHand = 3};
                         
         struct Info
         { 

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.h
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_analog_polling.h
@@ -348,7 +348,7 @@ namespace embot { namespace prot { namespace can { namespace analog { namespace 
     {
         public:
             
-        enum class SkinType { withTemperatureCompensation = 0, palmFingerTip = 1, withoutTempCompensation = 2, testmodeRAW = 7, withTemperatureCompensationV2 = 8, none = 254 };
+        enum class SkinType { withTemperatureCompensation = 0, palmFingerTip = 1, withoutTempCompensation = 2, testmodeRAW = 7, withTemperatureCompensationV2 = 8, none = 254, ergoHand = 16 };
                         
         struct Info
         { 


### PR DESCRIPTION
main feats introduced

- a new skintype is added with `type = 3` to deal with switching of triangle reshuffle
- all the part dealing with the compensation is updated. 
- the compensation also takes care of the two different types of boards used in ergoCub hand i.e. 
  - the fingertips, which need no temperature drift correction
  - the palm, which may need it.
sending a CAN message `4D` with firts byte equal to 3 enables the 5th I2C remappijng to peruse the triangles with Id >15 and include them in the CAN stream

tested with CANREAL and ESD CAN tool. 

TBD: implementation of CAN mesg forming in the EMS