### PR TITLE
Diagnostics for ETH link (up/down) for the `amc` board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 8},
-            {2024, Month::Jul, Day::twenty, 14, 00}
+            {2, 9},
+            {2024, Month::Oct, Day::twentyone, 14, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -19,6 +19,12 @@
 
 #include "embot_os.h"
 #include "embot_os_rtos.h"
+#include "embot_hw_eth.h"
+#include "embot_app_eth_theErrorManager.h"
+#include "embot_os_theScheduler.h"
+#include "EOtheErrorManager.h"
+#include "EoError.h"
+#include "EOMtheEMSrunner.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 // - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
@@ -26,6 +32,8 @@
 
 struct embot::app::eth::theETHmonitor::Impl
 {
+		constexpr static char objectname[] = "theETHmonitor"; 
+	
     Config _config {};
     bool _initted {false};
     
@@ -40,6 +48,25 @@ struct embot::app::eth::theETHmonitor::Impl
     bool set(const embot::core::Callback &tkr);
     bool tick();
     
+		
+		struct linkinfo
+		{   
+			bool previsup {false};
+			embot::core::Time changedTime {0};
+		}; 
+		
+		linkinfo link1 {};
+		linkinfo link2 {};
+		
+		
+//		bool prevlink1isup {false};    
+		//bool  prevlink2isup {false};
+	
+		embot::core::Time lastreportTime {0};
+//		embot::core::Time link1changedTime {0};
+//		embot::core::Time link2changedTime {0};
+		
+		
 
     static void startup(embot::os::Thread *t, void *p);  
     static void onperiod(embot::os::Thread *t, void *p);  
@@ -82,6 +109,22 @@ bool embot::app::eth::theETHmonitor::Impl::initialise(const Config &config)
         onperiod,
         "tETHmonitor"
     };
+		
+		
+		
+//		prevlink1isup = false;    
+//		 prevlink2isup = false;
+	
+		lastreportTime = embot::core::now();
+//		link1changedTime = embot::core::now();
+//		link2changedTime = embot::core::now();
+		
+	
+		link1.previsup = false;
+		link1.changedTime = embot::core::now();
+		
+		link2.previsup = false;
+		link2.changedTime = embot::core::now();
        
         
     // create the periodic thread 
@@ -128,9 +171,66 @@ void embot::app::eth::theETHmonitor::Impl::startup(embot::os::Thread *t, void *p
 
 void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *p)
 {
-    embot::app::eth::theETHmonitor::Impl *impl = reinterpret_cast<embot::app::eth::theETHmonitor::Impl*>(p);
+	embot::app::eth::theETHmonitor::Impl *impl = reinterpret_cast<embot::app::eth::theETHmonitor::Impl*>(p);
+	
+	embot::core::Time nowTime = embot::core::now();
+	
+	bool link1isup = false;    
+	bool link2isup = false;
 
-    // add in here all the code for eth monitoring
+	link1isup = embot::hw::eth::islinkup(embot::hw::PHY::one); 
+	link2isup = embot::hw::eth::islinkup(embot::hw::PHY::two); 
+	
+	uint64_t applstate = (eobool_true == eom_emsrunner_IsRunning(eom_emsrunner_GetHandle())) ? (0x3000000000000000) : (0x1000000000000000);   
+	
+	
+	
+	if((impl->link1.previsup != link1isup) || ((impl->link2.previsup != link2isup)))
+	{      
+		if(impl->link1.previsup != link1isup)
+		{        
+			impl->link1.changedTime = nowTime;
+		}
+		if(impl->link2.previsup != link2isup)
+		{        
+			impl->link2.changedTime = nowTime;
+		}
+		
+//		if defined(MESSAGING_DEBUG_PRINT){
+		std::string msg = std::string("ETH link 1 (J6) is ") + (link1isup ? "UP" : "DOWN") + ", ETH link 2 (J7) is " + (link2isup ? "UP" : "DOWN");
+        
+		embot::app::eth::theErrorManager::getInstance().trace(msg, {"onperiod(): change link status: ",     
+						embot::os::theScheduler::getInstance().scheduled()});
+//		}						   
+	}
+	
+	if(nowTime - impl->lastreportTime >= impl->_config.reportOKperiod)
+	{
+		embot::core::Time delta1 = embot::core::TimeFormatter(nowTime - impl->link1.changedTime).to_seconds();
+		embot::core::Time delta2 = embot::core::TimeFormatter(nowTime - impl->link2.changedTime).to_seconds();
+		
+		std::string msg = std::string("ETH link 1 (J6) is ") + (link1isup ? "UP" : "DOWN")+ " by " +std::to_string(delta1) +" seconds, " +  
+											std::string("ETH link 2 (J7) is ") + (link2isup ? "UP" : "DOWN")+ " by " +std::to_string(delta2) +" seconds";
+		
+		embot::app::eth::theErrorManager::getInstance().trace(msg, {"onperiod(): report OK period: ",     
+						embot::os::theScheduler::getInstance().scheduled()});
+					
+			//TO DO emit
+		
+		embot::app::eth::theErrorManager::Descriptor errdescr {};
+		errdescr.code = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_justverified);
+		errdescr.sourcedevice = eo_errman_sourcedevice_localboard;	
+		errdescr.sourceaddress = 0;
+//		errdescr.par16 = ;
+		errdescr.par64 = applstate; /// attention if error rxcrc, this shuld be modified
+						
+		//embot::app::eth::theErrorManager::getInstance().emit(embot::app::eth::theErrorManager::Severity::error, {objectname, t}, errdescr, msg);    
+
+		impl->lastreportTime = nowTime;
+	}
+
+	impl->link1.previsup = link1isup;
+	impl->link2.previsup = link2isup;
 }
 
 


### PR DESCRIPTION
Implemented the communication of the link up and down status using the `EOtheErrorManager.c`.
The code has been written to mimic the code already present on the application of the `ems004`.

Related PR:
- https://github.com/robotology/icub-firmware-build/pull/166
