### PR TITLE
Runtime configuration of encoder port in the `amc` board

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 10},
-            {2024, Month::Oct, Day::twentyeight, 16, 00}
+            {2, 11},
+            {2024, Month::Oct, Day::twentynine, 11, 15}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -71,11 +71,11 @@ struct embot::app::eth::theEncoderReader::Impl
     static constexpr size_t max_number_of_encoders { 2 * max_number_of_jomos }; 
 
     
-    typedef struct
+    struct jomoconfig_t
     {
         eOmc_encoder_descriptor_t   encoder1des;
         eOmc_encoder_descriptor_t   encoder2des;
-    } jomoconfig_t;
+    };
 
     struct ImplConfig
     {
@@ -95,11 +95,13 @@ struct embot::app::eth::theEncoderReader::Impl
     
     std::array<std::array<embot::app::eth::encoder::experimental::RawValueEncoder, 2>, max_number_of_jomos> rawvalues {};
     
-    typedef struct
+    struct eOencoderProperties_t
     {
         eOmc_encoder_descriptor_t *descriptor;
         embot::app::eth::encoder::v1::valueInfo *valueinfo;
-    } eOencoderProperties_t;
+        eOencoderProperties_t() = default;
+        eOencoderProperties_t(eOmc_encoder_descriptor_t *d, embot::app::eth::encoder::v1::valueInfo *v) : descriptor(d), valueinfo(v) {}
+    };
     
     constexpr static const char s_eobj_ownname[] = "theEncoderReader";
     
@@ -136,6 +138,19 @@ private:
     eOipv4port_t hostport {6666};
     char sss[512] = {0};
 #endif
+
+
+    // port is a uint8_t taken by eOmc_encoder_descriptor_t::port
+    embot::hw::ENCODER port2encoder(uint8_t port)
+    {
+        // marco.accame on 29 oct 2024: for now it is simple .... 
+        // on the amc we have port equal only to eobrd_port_amc_J5_X1 / X2 / X3 = 0 / 1 / 2
+        // and we want them to be mapped onto embot::hw::ENCODER::one / two / three = 0 / 1 / 2 
+        // so .... if we have an amc and port is 0, 1, or 2 we just do a static_cast<>
+        // for other boards to come (amcfoc, etc) the port will have the same values 0, 1, 2 so that 
+        // it is easy to convert w/ a static_cast<>
+        return static_cast<embot::hw::ENCODER>(port);        
+    }
     
 };
 
@@ -232,16 +247,19 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
 
 bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
 {
-    eo_errman_Trace(eo_errman_GetHandle(), "::Activate()", s_eobj_ownname);
+//    eo_errman_Trace(eo_errman_GetHandle(), "::Activate()", s_eobj_ownname);
+    bool ret {true};
     
     if((nullptr == config.carrayofjomodes))
     {
-        return false;
+        ret = false;
+        return ret;
     } 
 
     if(eo_constarray_Size(config.carrayofjomodes) > max_number_of_jomos)
     {
-        return false;
+        ret = false;
+        return ret;
     }
 
     EOconstarray* carray = eo_constarray_Load(reinterpret_cast<EOconstarray*>(config.carrayofjomodes));
@@ -285,62 +303,43 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
                 default:
                 {
                     // unsupported encoder
-                    return eores_NOK_unsupported;
+                    ret = false;
                 } break;
             }
             
-            // 2. configure and initialize SPI encoders
-            switch(_implconfig.jomo_cfg[i].encoder1des.port)
+            // 2. configure and initialize SPI encoder
+            
+            embot::hw::ENCODER enc = port2encoder(_implconfig.jomo_cfg[i].encoder1des.port);
+            embot::hw::result_t r = embot::hw::encoder::init(enc, cfg);
+            if(embot::hw::resOK != r)
             {
-                case eobrd_port_amc_J5_X1:
-                {
-                    embot::hw::encoder::init(embot::hw::ENCODER::one, cfg);
-                } break;
-                
-                case eobrd_port_amc_J5_X2:
-                {
-                    embot::hw::encoder::init(embot::hw::ENCODER::two, cfg);
-                }  break;
-                
-                case eobrd_port_amc_J5_X3:
-                {
-                    embot::hw::encoder::init(embot::hw::ENCODER::three, cfg);
-                } break;
-                
-                default:
-                {
-                    // error invalid SPI
-                    return eores_NOK_generic;
-                } break;
+                ret = false;
             }
+            
         }
     }
+    
+    if(false == ret)
+    {
+        Deactivate();      
+    }
         
-    _actived = true;
+    _actived = ret;
       
-    return true;
+    return _actived;
 }
 
 bool embot::app::eth::theEncoderReader::Impl::Deactivate()
 {
-    eo_errman_Trace(eo_errman_GetHandle(), "::Deactivate()", s_eobj_ownname);
+//    eo_errman_Trace(eo_errman_GetHandle(), "::Deactivate()", s_eobj_ownname);
     
-    if(false == _actived)
-    {
-        return true;
-    }
+    _implconfig.numofjomos = 0;
+    embot::hw::encoder::deinit(embot::hw::ENCODER::one);
+    embot::hw::encoder::deinit(embot::hw::ENCODER::two);
+    embot::hw::encoder::deinit(embot::hw::ENCODER::three);
+    _actived = false;
     
-    if((resOK == embot::hw::encoder::deinit(embot::hw::ENCODER::one)) &&
-       (resOK == embot::hw::encoder::deinit(embot::hw::ENCODER::two)) &&
-       (resOK == embot::hw::encoder::deinit(embot::hw::ENCODER::three)))
-    {
-        _implconfig.numofjomos = 0;
-        _actived = false;
-        
-        return true;
-    }
-    
-    return false;
+    return _actived;
 }
 
 bool embot::app::eth::theEncoderReader::Impl::StartReading()
@@ -348,6 +347,7 @@ bool embot::app::eth::theEncoderReader::Impl::StartReading()
     //eo_errman_Trace(eo_errman_GetHandle(), "::Start()", s_eobj_ownname);
     
     // start the encoder reading
+    // marco.accame on 29 oct 2024: maybe we can read just the configured ones. 
     embot::hw::encoder::startRead(embot::hw::ENCODER::one);
     embot::hw::encoder::startRead(embot::hw::ENCODER::two);
     embot::hw::encoder::startRead(embot::hw::ENCODER::three);
@@ -362,23 +362,22 @@ bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth
     {   // nothing to do because we dont have it
         return true;
     }
-    
-    embot::hw::ENCODER e = static_cast<embot::hw::ENCODER>(jomo);
-    if(e >= embot::hw::ENCODER::maxnumberof)
+
+    if(jomo >= _implconfig.numofjomos)
     {
         return false;
     }
     
-    eOencoderProperties_t encProp[2] = {nullptr};
+    constexpr size_t numOfEncodersPerJoint {2};
     
-    encProp[0].descriptor = &_implconfig.jomo_cfg[jomo].encoder1des;
-    encProp[0].valueinfo = &primary;
-    
-    encProp[1].descriptor = &_implconfig.jomo_cfg[jomo].encoder2des;
-    encProp[1].valueinfo = &secondary;
-    
-    for(uint8_t i=0; i<2; i++)
+    eOencoderProperties_t encProp[numOfEncodersPerJoint] = { 
+        {&_implconfig.jomo_cfg[jomo].encoder1des, &primary}, 
+        {&_implconfig.jomo_cfg[jomo].encoder2des, &secondary }
+    };
+        
+    for(uint8_t i=0; i<numOfEncodersPerJoint; i++)
     {   // for each of the two encoders ....
+        
         eOencoderProperties_t prop = encProp[i]; 
         uint16_t errorparam = 0;
         
@@ -408,12 +407,13 @@ bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth
         switch(prop.descriptor->type)
         {
             // they are: eomc_enc_aea3, eomc_enc_aea, eomc_enc_amo, eomc_enc_spichainof2,
-            //           eomc_enc_spichainof3, eomc_enc_qenc, eomc_enc_absanalog, eomc_enc_mais
+            //           eomc_enc_spichainof3, eomc_enc_qenc, eomc_enc_absanalog, eomc_enc_mais            
+            // however, in here we support (so far) only: aea and aea3
                        
             case eomc_enc_aea:
-            {               
+            {                               
+                embot::hw::ENCODER e = port2encoder(prop.descriptor->port);
                 
-                // if(hal_res_OK == hal_spiencoder_get_value((hal_spiencoder_t)prop.descriptor->port, &spiRawValue, &flags))
                 if(resOK == (rr = embot::hw::encoder::getValue(e, spiRawValue/*, &diagn*/)))                
                 {   // ok, the hal reads correctly
                     if(true == isValidValue_AEA(spiRawValue, prop.valueinfo->errortype))
@@ -447,9 +447,9 @@ bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth
             
             
             case eomc_enc_aea3:
-            {
-                               
-                // if(hal_res_OK == hal_spiencoder_get_value((hal_spiencoder_t)prop.descriptor->port, &spiRawValue, &flags))
+            {                         
+                embot::hw::ENCODER e = port2encoder(prop.descriptor->port);  
+                
                 if(resOK == (rr = embot::hw::encoder::getValue(e, spiRawValue/*, &diagn*/)))                
                 {   // ok, the hal reads correctly
                     if(true == isValidValue_AEA3(spiRawValue, prop.valueinfo->errortype))


### PR DESCRIPTION
This PR adds full runtime configuration of the encoder port in the `amc` board.

In the `amc` board, the object `theEncoderReader` so far has used the encoder plugged in port `J5_X1` for the first joint (and in general `J5_Xi` for the i-th joint) irrespectively of what is written in the xml file.

We noticed that when @SanLordKevin and I tested `yri `on the `lego setup` (xml files in [here](https://github.com/robotology/robots-configuration/tree/devel/experimentalSetups/lego_setup_amc_advfoc)) with a change of the port of the encoder for the first joint. If we used `J5_X2` or `J5_X3` for the first and only joint then `yri` did not work.

On `ergoCub` this problem does not happen because all the ports are used in order.

Nevertheless that is a problem to be fixed.

So, this PR fixes it.

There is an associated PR for the binary:
- https://github.com/robotology/icub-firmware-build/pull/169


This change affects only the `amc` and has been extensively tested on the `lego setup` and can be safely merged.
