### PR TITLE
Fix diagnostic for AEA encoder and calibration type 10

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 12},
-            {2024, Month::Oct, Day::thirthyone, 13, 25}
+            {2, 13},
+            {2024, Month::Dec, Day::two, 18, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          95
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          96
 
 //  </h>version
 
@@ -89,11 +89,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          02
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -1645,14 +1645,14 @@ static eOresult_t s_eo_motioncontrol_updatedPositionsFromEncoders(EOtheMotionCon
         return(eores_NOK_timeout);
     }
     
-    // read the encoders        
+    // read the encoders 
     for(uint8_t i=0; i<p->numofjomos; i++)
     {       
         embot::app::eth::encoder::v1::valueInfo encoder1valueinfo {};
         embot::app::eth::encoder::v1::valueInfo encoder2valueinfo {};
 
         embot::app::eth::theEncoderReader::getInstance().Read(i, encoder1valueinfo, encoder2valueinfo);
-                   
+        
         if(eores_OK != s_eo_motioncontrol_updatePositionFromEncoder(i, &encoder1valueinfo))
         {
             res = eores_NOK_generic;
@@ -1669,7 +1669,7 @@ static eOresult_t s_eo_motioncontrol_updatedPositionsFromEncoders(EOtheMotionCon
         if(NULL != (jstatus = eo_entities_GetJointStatus(eo_entities_GetHandle(), i)))
         {
             jstatus->addinfo.multienc[0] = rawValsArray.rawvalues[0].val;
-            //jstatus->addinfo.multienc[1] = rawValsArray.rawvalues[1].val; for now do not update the raw value for the motor encoder since we are adding to it the raw planned target --> see lines 292..294 in Joint.c
+            jstatus->addinfo.multienc[1] = rawValsArray.rawvalues[1].val;
             jstatus->addinfo.multienc[2] = rawValsArray.rawvalues[0].diagnInfo;
             
         }

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          75
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          76
 
 //  </h>version
 
@@ -83,11 +83,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          02
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 //  </h>build date

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          96
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          97
 
 //  </h>version
 
@@ -92,11 +92,11 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          02
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
 //  <o> minute          <0-59>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/CalibrationHelperData.h
@@ -41,7 +41,7 @@ typedef struct // CableCalib
 
 typedef struct // HardStopCalib
 {
-	  int32_t pwm;       // [2FOC PWM units] (-32000 : +32000) = (-100% : +100%)
+	int32_t pwm;       // [2FOC PWM units] (-32000 : +32000) = (-100% : +100%)
     int32_t zero;      // [icubdegrees]
     int32_t space_thr; // [icubdegrees]  
     int32_t time_thr;  // [milliseconds]

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -626,7 +626,7 @@ BOOL JointSet_do_wait_calibration_10(JointSet* o)
         }
         else
         {
-            if (AbsEncoder_is_hard_stop_calibrating(encoder))
+            if (AbsEncoder_is_hard_stop_calibrating(encoder) && (!encoder->state.bits.not_initialized))
             {
                 Motor_set_pwm_ref(o->motor+m, o->motor[m].calib_pwm);
         

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -288,10 +288,6 @@ void Joint_update_status_reference(Joint* o)
         default:
             ;
     }
-    
-    // Debug for temporary adding the raw planned target position to the motor encoder value which
-    o->eo_joint_ptr->status.addinfo.multienc[1] = (int32_t)Trajectory_get_target_position(&(o->trajectory));
-    //ends here
 }
 
 static void Joint_send_debug_message(const char *message, uint8_t jid, uint16_t par16, uint64_t par64)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1920,8 +1920,8 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             {
                 o->hard_stop_calib.zero = calibrator->params.type10.calibrationZero;
                 o->hard_stop_calib.pwm = calibrator->params.type10.pwmlimit;
-                o->hard_stop_calib.space_thr = 12000; // we can make them configurable (probably not needed)
-                o->hard_stop_calib.time_thr = 1000;   // we can make them configurable (probably not needed)
+                o->hard_stop_calib.space_thr = 1000; // we can make them configurable (probably not needed)
+                o->hard_stop_calib.time_thr = 200;   // we can make them configurable (probably not needed)
                 AbsEncoder_still_check_reset(o->absEncoder+e);
                 AbsEncoder_start_hard_stop_calibrate(o->absEncoder+e, calibrator->params.type10.calibrationZero);
             }


### PR DESCRIPTION
This PR solves issue related to calibration type 10 for joints that use AMO encoders.
Moreover we solve the diagnostic problem related to AEA encoders described here: https://github.com/robotology/icub-firmware/issues/533

Precisely, it brings the following improvements and fixes:
- abs encoder diagnostic is  now more general
- calibration type 10 timing and pipeline is now more robust, making the joint always reaching the hard-stop position correctly, if it ends before the calibration timeout. 

Tests done on the robot are collected here:
- https://github.com/robotology/icub-firmware/issues/537

The issues that interested the AMO encoders and the calibration type 10 are collected here:
-  https://github.com/icub-tech-iit/study-encoders/issues/21


It is related to:
- https://github.com/robotology/icub-firmware-shared/pull/102
- https://github.com/robotology/icub-main/pull/998
- https://github.com/robotology/icub-firmware-build/pull/174