### PR TITLE
Fix AksIM2 diagnostic display

### DIFF
--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
@@ -736,29 +736,31 @@ extern eOresult_t eo_appEncReader_GetValue(EOappEncReader *p, uint8_t jomo, eOen
                         
                         s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_hal_counter[jomo] = 0;
                     }
-                    if(s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_invalid_data_counter[jomo] > 0)
+                    else
                     {
-                        errdes.code        = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_encoder_invalid_value);
-                        errdes.par64      |= s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_invalid_data_counter[jomo];
-                        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
-                        
-                        s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_invalid_data_counter[jomo] = 0;
-                    }
-                    if(s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_close_to_limit_counter[jomo] > 0)
-                    {
-                        errdes.code        = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_encoder_close_to_limits);
-                        errdes.par64      |= s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_close_to_limit_counter[jomo];
-                        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
-                        
-                        s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_close_to_limit_counter[jomo] = 0;
-                    }
-                    if(s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_crc_counter[jomo] > 0)
-                    {
-                        errdes.code        = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_encoder_crc);
-                        errdes.par64      |= s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_crc_counter[jomo];
-                        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
-                        
-                        s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_crc_counter[jomo] = 0;
+                        if(s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_invalid_data_counter[jomo] > 0)
+                        {
+                            errdes.code        = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_encoder_invalid_value);
+                            errdes.par64      |= s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_invalid_data_counter[jomo];
+                            eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
+                            
+                            s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_invalid_data_counter[jomo] = 0;
+                        }
+                        if(s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_close_to_limit_counter[jomo] > 0)
+                        {
+                            errdes.code        = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_encoder_close_to_limits);
+                            errdes.par64      |= s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_close_to_limit_counter[jomo];
+                            eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
+                            
+                            s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_close_to_limit_counter[jomo] = 0;
+                        }
+                        if(s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_crc_counter[jomo] > 0)
+                        {
+                            errdes.code        = eoerror_code_get(eoerror_category_HardWare, eoerror_value_HW_encoder_crc);
+                            errdes.par64      |= s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_crc_counter[jomo];
+                            eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
+                        }    
+                            s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_crc_counter[jomo] = 0;
                     }
                     
                     s_eo_theappencreader.aksim2DiagnerrorCounters.encoder_error_total_timer_counter[jomo] = 0;


### PR DESCRIPTION
Hello everyone,
With this PR I would like to merge a modified version of  `EOappEncodersReader.c`, specifically in the lines reported [here](https://github.com/robotology/icub-firmware/blob/devel/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c#L722-L766).
This modification is done to avoid sending multiple error messages (invalid data, invalid crc, close to limits warning) when the encoder is retrieved as `disconnected`.
The test was performed by simply removing the AksIM2 connector from the EMS board and looking at the `yarprobotinterface` output.

The code shows the following output:
```bash
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=267s 275m 291u :  MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. (Joint=three_encoders_joint (NIB=0), encoderPort=0)
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=272s 276m 291u :  MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. (Joint=three_encoders_joint (NIB=0), encoderPort=0)
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=275s 746m 214u :  HW - encoder: not connected (Joint=three_encoders_joint (NIB=0) Number of error in 10 seconds is: 10001)
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=277s 277m 291u :  MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. (Joint=three_encoders_joint (NIB=0), encoderPort=0)
[DEBUG] yarprobotinterface running happily
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=282s 278m 291u :  MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. (Joint=three_encoders_joint (NIB=0), encoderPort=0)
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=285s 747m 214u :  HW - encoder: not connected (Joint=three_encoders_joint (NIB=0) Number of error in 10 seconds is: 10001)
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=287s 279m 291u :  MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. (Joint=three_encoders_joint (NIB=0), encoderPort=0)
[ERROR] from BOARD 10.0.1.1 (three-encoders-setup) time=292s 280m 291u :  MC: AEA encoder invalid data. Hardware problem in the magnetic position sensor of the joint caused invalid position readings. (Joint=three_encoders_joint (NIB=0), encoderPort=0)
```
Only one part of the output is reported as the `yarprobotinterface' shows this repetitive pattern.
Once the encoder is reconnected, the errors are handled as before. For more information, see the linked issue [here](https://github.com/robotology/icub-firmware/issues/547).