### PR TITLE
2foc.3.3.38: solves the overcurrent problem

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          37
+#define FW_VERSION_BUILD          38
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/ADC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/ADC.c
@@ -104,8 +104,8 @@ int ADCCalibrateOffset(void)
     long ADCVdcZero = 0;
   
     // Put an 'accettable' value in case of error in the calibration process
-    MeasCurrParm.Offseta = 0x200;
-    MeasCurrParm.Offsetc = 0x200;
+    MeasCurrParm.Offseta = 0;
+    MeasCurrParm.Offsetc = 0;
 
     // Turn on ADC module
     AD1CON1bits.ADON = 1;

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/can_icubProto_trasmitter.c
@@ -57,8 +57,6 @@ extern volatile char IKs;
 
 extern volatile tMotorConfig MotorConfig;
 
-extern volatile int Iafbk;
-extern volatile int Icfbk;
 extern volatile int ElDegfbk;
 extern volatile int iQprot;
 extern volatile int maxCountfbk;


### PR DESCRIPTION
It solves the overcurrent problem by disabling the current sensor gain calibration at startup.