### PR TITLE
Fix/hand skin fix: correct I2C mapping for best cablilng

### DIFF
--- a/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4/application/src/main-appcan.cpp
@@ -18,7 +18,7 @@ constexpr embot::app::theCANboardInfo::applicationInfo applInfo
     embot::prot::can::versionOfAPPLICATION {20, 23, 0},
     embot::prot::can::versionOfCANPROTOCOL {20, 0}
 #else
-    embot::prot::can::versionOfAPPLICATION {1, 23, 0},
+    embot::prot::can::versionOfAPPLICATION {1, 24, 0},
     embot::prot::can::versionOfCANPROTOCOL {2, 0}
 #endif
 };

--- a/emBODY/eBcode/arch-arm/board/mtb4c/application/src/main-appcan.cpp
+++ b/emBODY/eBcode/arch-arm/board/mtb4c/application/src/main-appcan.cpp
@@ -18,7 +18,7 @@ constexpr embot::app::theCANboardInfo::applicationInfo applInfo
     embot::prot::can::versionOfAPPLICATION {22, 0, 0},    
     embot::prot::can::versionOfCANPROTOCOL {20, 0} 
 #else   
-    embot::prot::can::versionOfAPPLICATION {2, 3, 0},    
+    embot::prot::can::versionOfAPPLICATION {2, 4, 0},    
     embot::prot::can::versionOfCANPROTOCOL {2, 0} 
 #endif    
 };

--- a/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theSkin.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/embot_app_application_theSkin.cpp
@@ -64,7 +64,7 @@ constexpr std::uint8_t dotNumberOf = 12;
 constexpr std::uint8_t trgNumberOf = 16; //4 for each sda. This is used in the CAN message forming so it's locked to 16
 uint16_t trianglesOrder[16]  = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};    
 uint16_t origTrianglesOrder[16]  = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}; //consecutive ordergin of triangles used in iCub skin patches
-uint16_t altTrianglesOrder[16]  = {0,4,8,12,16,10,11,13,15,1,2,3,5,6,7,9}; //to reshuffle the triangles on-the-run with the ergoCub hand mapping
+uint16_t altTrianglesOrder[16]  = {0,4,8,12,16,9,10,11,13,15,1,2,3,5,6,7}; //to reshuffle the triangles on-the-run with the ergoCub hand mapping
 
 
 struct TriangleCfg


### PR DESCRIPTION
as per F2F interactions with the cabling guys, I slightly modified the I2C mapping for the `skinType  = 3` case.

this involves both MTB4 and MTB4c thus I also incremented the minor version fo both boards. 

related PR issued on `icub-firmware-build` repo to keep alignment