### PR TITLE
bugfix `amcfoc` app.yri and eupdater

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_info.cpp
@@ -158,7 +158,7 @@ namespace embot::app::board::amcfoc::cm7::info {
 #define RAMADDR 0x10000000
 #define RAMSIZE 0x00048000
 
-constexpr eEmoduleExtendedInfo_t s_cm4app_info_extended  __attribute__((section(EENV_MODULEINFO_LOADER_AT))) =
+constexpr eEmoduleExtendedInfo_t s_cm7app_info_extended  __attribute__((section(EENV_MODULEINFO_LOADER_AT))) =
 {
     .moduleinfo     =
     {
@@ -223,7 +223,7 @@ void force_placement_of_flashmappedinfo()
 {
     static volatile uint8_t used {0};
         
-    if(s_cm4app_info_extended.moduleinfo.info.entity.type == ee_entity_process)
+    if(s_cm7app_info_extended.moduleinfo.info.entity.type == ee_entity_process)
     {
         used = 1;
     }        
@@ -232,7 +232,7 @@ void force_placement_of_flashmappedinfo()
         used = 2;
     }
     
-    std::memmove(&ss, &s_cm4app_info_extended, sizeof(ss)); 
+    std::memmove(&ss, &s_cm7app_info_extended, sizeof(ss)); 
     std::memmove(&sig, &embot::app::board::amcfoc::cm7::info::signature, sizeof(sig));     
 }
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_info.cpp
@@ -158,7 +158,7 @@ namespace embot::app::board::amcfoc::cm7::info {
 #define RAMADDR 0x10000000
 #define RAMSIZE 0x00048000
 
-constexpr eEmoduleExtendedInfo_t s_cm4app_info_extended = // __attribute__((section(EENV_MODULEINFO_LOADER_AT))) =
+constexpr eEmoduleExtendedInfo_t s_cm4app_info_extended  __attribute__((section(EENV_MODULEINFO_LOADER_AT))) =
 {
     .moduleinfo     =
     {

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/updater/src/eupdater/eupdater-info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/updater/src/eupdater/eupdater-info.cpp
@@ -117,7 +117,7 @@ constexpr eEmoduleExtendedInfo_t eupdater_modinfo_extended  __attribute__((secti
                 .addr   = 0
             },
             .communication  = ee_commtype_eth,  // later on we may also add can1 and can2
-            .name           = "amc eUpdater"
+            .name           = "amc eUpdatr"
         },
         .protocols  =
         {


### PR DESCRIPTION
Fix the position of the application information in the memory of `amcfoc mot app`. 
Resolve a bug in the `eupdater` information.