### PR TITLE
Added fix for calibration 5

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -39,7 +39,7 @@ namespace embot { namespace app { namespace eth {
         {
             Process::eApplication,
             {2, 14},
-            {2025, Month::Jan, Day::sixteen, 11, 17}
+            {2025, Month::Jan, Day::twentytwo, 16, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,20 +81,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          98
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          99
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2024
+#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          14
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         18
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          77
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          78
 
 //  </h>version
 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          98
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          99
 
 //  </h>version
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -64,7 +64,7 @@ BOOL JointSet_do_wait_calibration_5(JointSet* o)
     
     for (int ms=0; ms<*(o->pN); ++ms)
     {
-        if (!Motor_is_calibrated(o->motor+o->motors_of_set[ms])) 
+        if(Calibration_check(o->motor+o->motors_of_set[ms])) 
         {
             calibrated = FALSE;
             

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -990,6 +990,10 @@ BOOL Motor_is_calibrated(Motor* o) //
     return !(o->not_calibrated);
 }
 
+BOOL Calibration_check(Motor* o)
+{
+    return (o->hardstop_calibdata.u.bits.iscalibrating && !(o->hardstop_calibdata.u.bits.hwlimitreached));
+}
 
 CTRL_UNITS Motor_do_trq_control_EXPERIMENTAL(Motor* o, CTRL_UNITS trq_ref, CTRL_UNITS trq_fbk, CTRL_UNITS motor_vel_icubdeg_sec) //
 {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -68,6 +68,7 @@ extern void Motor_force_idle(Motor* o); //
 
 extern void Motor_motion_reset(Motor *o); //
 extern BOOL Motor_is_calibrated(Motor* o); //
+extern BOOL Calibration_check(Motor* o); //
 extern BOOL Motor_check_faults(Motor* o); //
 extern void Motor_reset(Motor *o);//
 


### PR DESCRIPTION
During tests with the Camozzi linear actuator, we found that calibration 5 fails on EMS/2FOC boards because the 2FOC overwrites the joint calibration state with the state of the QE encoder (related to the stator/rotor calibration).
This PR fixes this behavior, allowing the joint to be calibrated correctly.