### PR TITLE
`yarprobotinterface` recognize better `amc` and `amcfoc`

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theHandler.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theHandler.cpp
@@ -1325,12 +1325,12 @@ extern void eoprot_fun_INIT_mn_appl_status(const EOnv* nv)
     status.txdecimationfactor = embot::app::eth::theHandler_EOMtheEMSrunner_Config.defaultTXdecimationfactor;
     
     // name
-    static const char * nn[] = {"amc"};
+    static const char * nn[] = {"amcfoc"};
     memcpy(status.name, nn, std::min(sizeof(status.name), sizeof(nn)));
        
     // curr state
     status.currstate = applstate_config;
-    status.boardtype = eobrd_ethtype_amc;
+    status.boardtype = eobrd_ethtype_amcfoc;
     
 
     // set it

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theHandler.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theHandler.cpp
@@ -1325,12 +1325,21 @@ extern void eoprot_fun_INIT_mn_appl_status(const EOnv* nv)
     status.txdecimationfactor = embot::app::eth::theHandler_EOMtheEMSrunner_Config.defaultTXdecimationfactor;
     
     // name
+#if defined(STM32HAL_BOARD_AMC)
+    static const char * nn[] = {"amc"};
+#elif defined(STM32HAL_BOARD_AMCFOC_2CM4)
     static const char * nn[] = {"amcfoc"};
+#endif
     memcpy(status.name, nn, std::min(sizeof(status.name), sizeof(nn)));
        
     // curr state
     status.currstate = applstate_config;
+#if defined(STM32HAL_BOARD_AMC)
+    status.boardtype = eobrd_ethtype_amc;
+#elif defined(STM32HAL_BOARD_AMCFOC_2CM4)
     status.boardtype = eobrd_ethtype_amcfoc;
+#endif
+    
     
 
     // set it


### PR DESCRIPTION
`yarprobotinterface` recognize better `amc` and `amcfoc`.

This change allows the boards to reply to `yri` w/ the type of board they are.