### PR TITLE
Work on update of AMO encoder diagnostic

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 16},
-            {2025, Month::Jan, Day::thirty, 11, 15}
+            {2, 17},
+            {2025, Month::Feb, Day::seventeen, 17, 13}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 2, 0, 0},   // application version
+        {3, 3, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::Jan, embot::app::eth::Day::thirty, 11, 15}
+        {2025, embot::app::eth::Month::Feb, embot::app::eth::Day::seventeen, 17, 13}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,20 +81,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          99
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          100
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        1
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          78
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          79
 
 //  </h>version
 
@@ -83,13 +83,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        01
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        02
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          99
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          100
 
 //  </h>version
 
@@ -92,13 +92,13 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        01
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        02
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          22
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
@@ -126,6 +126,17 @@ typedef struct
     
 } eOappEncReader_Aksim2_DiagnosticError_Counters_t;
 
+// structure defined for counting the errors related to amo encoder
+typedef struct
+{
+    uint16_t status0_poorlevel_clipping_master_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t status0_poorlevel_clipping_nonius_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t status1_CRC_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t status1_i2C_communication_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t status1_period_consistency_warning_counter[eOappEncReader_jomos_maxnumberof];
+    uint16_t status1_eccessive_signal_freq_counter[eOappEncReader_jomos_maxnumberof];
+} eOappEncReader_Amo_DiagnosticError_Counters_t;
+
 struct EOappEncReader_hid
 {
     eObool_t                                initted;
@@ -139,6 +150,7 @@ struct EOappEncReader_hid
     eOappEncReader_hallAdc_conversionData_t hallAdcConversionData;
     eo_appEncReader_amodiag_t               amodiag;
     eOappEncReader_Aksim2_DiagnosticError_Counters_t aksim2DiagnerrorCounters;
+    eOappEncReader_Amo_DiagnosticError_Counters_t amoDiagnerrorCounters;
     eOencoderreader_RawValuesOfJomo_t       genericEncoderRawData[eOappEncReader_jomos_maxnumberof];
 }; 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -383,7 +383,6 @@ BOOL JointSet_do_check_faults(JointSet* o)
             encoder_fault = TRUE;
         }
     }
-    //if an encoder of this set is in fault ten set hw fault on each joint of this set.
     if(encoder_fault)
     {
         for (int k=0; k<N; ++k)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -894,6 +894,12 @@ BOOL Motor_check_faults(Motor* o) //
             fault_state.bits.OverHeatingFailure = FALSE;
         }
         
+        if (o->fault_state.bits.I2C_CommFailure && !o->fault_state_prec.bits.I2C_CommFailure)
+        {
+            Motor_send_error(o->ID, eoerror_value_MC_motor_tdb_not_reading, 0);
+            fault_state.bits.I2C_CommFailure = FALSE;
+        }
+        
 //        #define CAN_GENERIC_ERROR 0x00003D00
 //        
 //        if ((o->fault_state.bitmask & CAN_GENERIC_ERROR) && ((o->fault_state.bitmask & CAN_GENERIC_ERROR) != (o->fault_state_prec.bitmask & CAN_GENERIC_ERROR)))
@@ -946,15 +952,6 @@ static void Motor_raise_fault_overcurrent(Motor* o)
     hal_motor_disable(static_cast<hal_motor_t>(o->motorlocation.adr));
     
     o->fault_state.bits.OverCurrentFailure = TRUE;
-    
-    o->control_mode = icubCanProto_controlmode_hwFault;
-}
-
-static void Motor_raise_fault_overheating(Motor* o)
-{
-    hal_motor_disable(static_cast<hal_motor_t>(o->motorlocation.adr));
-    
-    o->fault_state.bits.OverHeatingFailure = TRUE;
     
     o->control_mode = icubCanProto_controlmode_hwFault;
 }


### PR DESCRIPTION
This PR updates AMO encoder diagnostic so that it might be easier for a user to identify the error and fix errors for overheating and i2c comm failure even if now we still send the old error message even when we loose i2c communication on the TDB and update fw versions