### PR TITLE
Fix error for Aksim2 and AMO encoders

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 17},
-            {2025, Month::Feb, Day::seventeen, 17, 13}
+            {2, 18},
+            {2025, Month::Feb, Day::twentyone, 13, 17}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 3, 0, 0},   // application version
+        {3, 4, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::Feb, embot::app::eth::Day::seventeen, 17, 13}
+        {2025, embot::app::eth::Month::Feb, embot::app::eth::Day::twentyone, 13, 17}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          100
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          101
 //  </h>version
 
 //  <h> build date
@@ -90,11 +90,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          79
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          80
 
 //  </h>version
 
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        02
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          100
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          101
 
 //  </h>version
 
@@ -94,11 +94,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        02
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -440,6 +440,13 @@ void AbsEncoder_invalid(AbsEncoder* o, ae_errortype_t error_type)
         case embot::app::eth::encoder::v1::Error::NONE:
             break;
         
+        case embot::app::eth::encoder::v1::Error::AMO_GENERIC:
+        case embot::app::eth::encoder::v1::Error::AKSIM2_GENERIC:
+        case embot::app::eth::encoder::v1::Error::AKSIM2_INVALID_DATA:
+        case embot::app::eth::encoder::v1::Error::AKSIM2_CLOSE_TO_LIMITS:
+        case embot::app::eth::encoder::v1::Error::AKSIM2_CRC_ERROR:
+            break;
+        
         // all other cases are errors: AEA_PARITY, AEA_CHIP, AEA_READING have their tx_error, chip_error, data_error. all others: are data_error. 
         case embot::app::eth::encoder::v1::Error::AEA_PARITY:
             o->fault_state.bits.tx_error = TRUE;


### PR DESCRIPTION
This PR fixes a problem with some missing error cases used in the switch loop that might generate o->fault_state.bits.data_error in fw. Those error cases were not added to the switch since we are managing those differently using diagnostic functions in other section of the code. However, the default case of the switch is returning o->fault_state.bits.data_error, thus this fix was mandatory.

Specifically we are providing a solution to the bug in `AbsEncoder_invalid` where a `swtich-case` loop set different error bits depending on the error passed. However, since the default case sets the fault bit `o->fault_state.bits.data_error`, all the non managed errors make that bit to be set to 1. 
Thus Aksim2 and AMO errors, that are managed by a particular diagnostic, made that bit to be up. Those we need to managed those errors values also here.

Moreover, we are fixing the bug related to this issue: https://github.com/icub-tech-iit/ergocub2-design-upperbody/issues/42 that was caused by non filtering spikes in joint position values when using an Aksim2 encoder. 