### PR TITLE
On switch current control, the target current has the value of the current before the switch

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          101
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          102
 //  </h>version
 
 //  <h> build date
@@ -90,11 +90,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          21
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         13
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -667,6 +667,15 @@ BOOL JointSet_set_control_mode(JointSet* o, eOmc_controlmode_command_t control_m
         { 
             Joint_set_control_mode(o->joint+o->joints_of_set[k], control_mode_cmd);
         }
+        
+        if(eomc_controlmode_cmd_current == control_mode_cmd)
+        {
+            for (int k=0; k<N; ++k)
+            { 
+                Joint_set_cur_ref(o->joint+o->joints_of_set[k], Motor_get_IqqFbk_avg(o->motor+o->motors_of_set[k]));
+                Joint_update_status_reference(o->joint+o->joints_of_set[k]);
+            }
+        }
         break;
     }    
     default:

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.c
@@ -314,6 +314,8 @@ void Motor_init(Motor* o) //
     o->sensorless_torque = FALSE;
     o->torque_estimator.initialize();
 #endif
+
+    o->mv_avg.init(100, 0);
 }
 
 void Motor_config(Motor* o, uint8_t ID, eOmc_motor_config_t* config) //
@@ -1211,11 +1213,19 @@ void Motor_get_state(Motor* o, eOmc_motor_status_t* motor_status)
     }
 }
 
+
+extern int32_t Motor_get_IqqFbk_avg(Motor* o)
+{
+return o->mv_avg.getAvg();
+}
+
+
 void Motor_update_odometry_fbk_can(Motor* o, CanOdometry2FocMsg* can_msg) //
 {
     WatchDog_rearm(&o->can_2FOC_alive_wdog);
     
     o->Iqq_fbk = can_msg->current;
+    o->mv_avg.calculateAvg(o->Iqq_fbk);
     
     o->vel_raw_fbk = can_msg->velocity*1000;
     o->vel_fbk = o->vel_raw_fbk/o->GEARBOX;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -104,6 +104,8 @@ extern BOOL Motor_is_running(Motor* o);
 
 extern BOOL Motor_is_motor_joint_fault_over(Motor* o);
 
+extern int32_t Motor_get_IqqFbk_avg(Motor* o);
+
 //BOOL Motor_clear_ext_fault(Motor *o);
 
 ////////////////////////////////////////////////////////////////////////////

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
@@ -84,6 +84,64 @@ typedef struct //HardStopCalibData
     
 } HardStopCalibData;
 
+////first order moving average
+//constexpr float NUM_SAMPLE_MOV_AVERAGE = 100.0;
+//constexpr float FACTOR_A = 1.0/NUM_SAMPLE_MOV_AVERAGE;
+//constexpr float FACTOR_B = 1.0 - FACTOR_A;
+//typedef struct 
+//{
+//    float
+//}moving_avarage;
+
+class MovingAverage
+{
+    private:
+        float numSampl;
+        float coeff_1;
+        float coeff_2;
+        float filterValue;
+        bool completed;
+        int count;
+    public:
+        MovingAverage() = delete;
+        MovingAverage(float numberOfSample):
+                numSampl(numberOfSample),
+                coeff_1(1.0/numSampl),
+                coeff_2(1- coeff_1),
+                completed(false),
+                count(0){;}
+                    
+                    
+        MovingAverage(float numberOfSample, float firstValue):
+                numSampl(numberOfSample), 
+                filterValue(firstValue),
+                coeff_1(1.0/numSampl),
+                coeff_2(1- coeff_1),
+                completed(false),
+                count(0){;}
+                    
+        float calculateAvg(float sample)
+        {
+            filterValue = coeff_1 * sample + coeff_2 * filterValue;
+            //count++;
+            return(filterValue);
+        }
+        
+        float getAvg(void){return filterValue;}
+        
+        bool isCompleted() {return completed;}
+        
+        void init(float numberOfSample, float firstValue)
+        {
+            numSampl= numberOfSample;
+            filterValue= firstValue;
+            coeff_1= 1.0/numSampl;
+            coeff_2 = 1- coeff_1;
+            completed = false;
+            count = 0;
+        }
+};
+
 struct Motor_hid
 {
     // the location of the hw actuator that host the motor. it can hold: 
@@ -144,6 +202,7 @@ struct Motor_hid
     int32_t Iqq_fbk;
     int32_t Iqq_ovl;
     int32_t Iqq_err;
+    int32_t Iqq_fbk_mean;
     
     CTRL_UNITS trq_max;
     CTRL_UNITS trq_ref;
@@ -180,6 +239,7 @@ struct Motor_hid
     WatchDog can_2FOC_alive_wdog;
     uint8_t can_motor_config[7];
     //BOOL outOfLimitsSignaled;
+    MovingAverage mv_avg={100,0};
 
 #if defined(SENSORLESS_TORQUE)
     float torque;


### PR DESCRIPTION
This PR has the aim to fix the behavior explained here: https://github.com/robotology/icub-firmware/issues/554.

In a few words, now on the current control switch, the embedded control mode sets as target the value of the current before the switching instead of zero.

This new behavior helps when the robot is standing up and the walking-control application switches from position to current by preventing the robot falls.

This fw has been tested on the robot and setup.


