### PR TITLE
 fix AMC compilation: v2.19 date:7th Mar 2025 08:00AM

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -39,7 +39,7 @@ namespace embot { namespace app { namespace eth {
         {
             Process::eApplication,
             {2, 19},
-            {2025, Month::Mar, Day::six, 11, 00}
+            {2025, Month::Mar, Day::seven, 8, 00}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -151,7 +151,7 @@ namespace embot::hw::encoder {
         else
         {
             //this error message is onl for debugging on keil
-            embot::app::eth::theErrorManager::getInstance().emit(embot::app::eth::theErrorManager::Severity::error, {}, {}, "encoder type not supported");        
+            embot::core::print("encoder type not supported");
             return resNOK;
         }
         


### PR DESCRIPTION
I realized that the AMC project in the current devel branch (last commit is a21b827251daf3fc910f458893cc89be443f653f) doesn't compile.

### Detail of the issue
After a f2f alignment with @SanLordKevin and @MSECode we noticed that PR #570 raised the problem: in the PR #570 the include `#include "embot_app_eth_theErrorManager.h"` has been removed from the file `emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp` because it inserts a dependency from embot::app. in addition the AMC_BLDC board hasn't the encoder enabled as you can see from the [bsp configuration](https://github.com/robotology/icub-firmware/blob/a21b827251daf3fc910f458893cc89be443f653f/emBODY/eBcode/arch-arm/board/amcbldc/bsp/embot_hw_bsp_amcbldc_config.h#L20). 


Since the same file (`emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp`) is included in AMC project, where instead the encoder is enabled, the compilation failed.

 ### Solution
We agreed that the `embot::hw` namespace should not have a dependency from `embot::app`. So we remove the include `embot_app_eth_theErrorManager.h` file and substitute the print with the one provided by the embot::core namespace. 

>[!Note]
> I didn't bump the AMC version, for this small fix but just updated the date: `7th Mar 2025 08:00AM`

cc @marcoaccame 