### PR TITLE
dspic33f non standard short summation fixed (current filter bug).

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          38
+#define FW_VERSION_BUILD          39
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -955,12 +955,12 @@ void __attribute__((__interrupt__, no_auto_psv)) _DMA0Interrupt(void)
     static long Iacc = 0; // current accumulator for average
     static char cntr = 0;
     // extremal values
-    static int Imax1 = 0x8000; 
-    static int Imin1 = 0x7FFF;
-    static int Imax2 = 0x8000;
-    static int Imin2 = 0x7FFF;
-    static int Imax3 = 0x8000;
-    static int Imin3 = 0x7FFF;
+    static long Imax1 = -1000000; 
+    static long Imin1 =  1000000;
+    static long Imax2 = -1000000;
+    static long Imin2 =  1000000;
+    static long Imax3 = -1000000;
+    static long Imin3 =  1000000;
     
     if (I2Tdata.IQMeasured <= Imin1) // find the lowest value
     {
@@ -1010,8 +1010,8 @@ void __attribute__((__interrupt__, no_auto_psv)) _DMA0Interrupt(void)
         VqFbk = __builtin_divsd(Vacc,20);
         
         Iacc = Vacc = 0;
-        Imax1 = Imax2 = Imax3 = 0x8000;
-        Imin1 = Imin2 = Imin3 = 0x7FFF;
+        Imax1 = Imax2 = Imax3 = -1000000;
+        Imin1 = Imin2 = Imin3 =  1000000;
     }
 
     //

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c
@@ -102,8 +102,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _T3Interrupt(void)
 // and to perform encoder turn count
 {
     extern volatile long VqRef;
+    extern volatile long IqFbk;
 
     VqRef = 0;
+    IqFbk = 0;
 
     I2Tdata.IQMeasured = 0;
     I2Tdata.IDMeasured = 0;


### PR DESCRIPTION
The 2FOC dspic33f processor doesn't respect the C standard for integer promotion in summation with short type: instead of promoting the result to long and truncating it if assigned to a short type, it truncates the result in any case. Fixed and tested on SN 0001. Added current feedback reset when the motor drive is disabled.