### PR TITLE
Add i2c communication error condition handling

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/Faults.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/Faults.h
@@ -42,7 +42,7 @@ typedef union uSysError
 /*b4*/  unsigned CAN_IsWarnTX:1;              /* can IS in bus warn in tx (exist only one error for rx and tx, so the bits are used together)*/
 /*b5*/  unsigned CAN_IsWarnRX:1;              /* can IS in bus warn in rx*/
 /*b6*/  unsigned OverHeatingFailure:1;        /* overheating failure */
-/*b7*/  unsigned unused4:1;                   /* UNUSED: put here for mad in msg */
+/*b7*/  unsigned I2C_CommFailure:1;           /* I2C communication failure */
 
 
 /********************************************************************************************************/

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          39
+#define FW_VERSION_BUILD          40
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c
@@ -151,8 +151,6 @@ void __attribute__((__interrupt__, no_auto_psv)) _T1Interrupt(void)
   
     if (MotorConfig.has_tsens && isActiveI2CTsens())
     {
-        extern volatile BOOL overheating;
-        
         static int cycle = 0;
         
         if (++cycle>=21)
@@ -161,9 +159,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _T1Interrupt(void)
             
             int err = readI2CTsens(&gTemperature);
             
-            if(err == -21)
+            if((err == -21) && !SysError.I2C_CommFailure)
             {
-                overheating = TRUE;
+                SysError.I2C_CommFailure = TRUE;
+                FaultConditionsHandler();
             }
             else if (!err)
             {     
@@ -174,10 +173,9 @@ void __attribute__((__interrupt__, no_auto_psv)) _T1Interrupt(void)
                 else if (gTemperature < gTemperatureLimit)
                 {
                     gTemperatureOverheatingCounter = 0;
-                    overheating = FALSE;
                 }
             }
-            if (((gTemperatureOverheatingCounter > 100)  || overheating) && !SysError.OverHeatingFailure)
+            if ((gTemperatureOverheatingCounter > 100) && !SysError.OverHeatingFailure)
             {
                 SysError.OverHeatingFailure = TRUE;
                 FaultConditionsHandler();


### PR DESCRIPTION
This PR introduces the fix of rising the correct error bit of the `SystemError` bitmask when the 2foc i2c bus cannot read any temperature values coming from the tdb board for more than 10 consecutive seconds. This basically fix the previous way of handling the error where we were using the same error message for managing 2 different conditions: this one and the the actual overheating error, i.e. when the temperature read is over a threshold set.
This update of the 2foc fw aligns with the the updates already developed and merged made on the ems fw and on the sw side in `icub-main` available here: https://github.com/robotology/icub-firmware-build/pull/192