### PR TITLE
Fix error management for aksim2 joint

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 19},
-            {2025, Month::Mar, Day::seven, 8, 00}
+            {2, 20},
+            {2025, Month::Mar, Day::twentyfive, 17, 17}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 4, 0, 0},   // application version
+        {3, 5, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::Feb, embot::app::eth::Day::twentyone, 13, 17}
+        {2025, embot::app::eth::Month::Feb, embot::app::eth::Day::twentyfive, 17, 17}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,20 +81,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          102
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          103
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
 //  <o> day             <1-31>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          0
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          81
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          82
 
 //  </h>version
 
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        03
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          06
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          102
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          103
 
 //  </h>version
 
@@ -94,11 +94,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        03
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          06
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         10
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          00
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          17
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -424,7 +424,9 @@ void AbsEncoder_invalid(AbsEncoder* o, ae_errortype_t error_type)
     if (o->state.bits.not_configured) return;
     
     if (o->state.bits.not_calibrated) return;
-
+    
+    if (error_type == embot::app::eth::encoder::v1::Error::AKSIM2_CRC_ERROR) return;
+    
     if (o->invalid_cnt > ENCODER_INVALID_LIMIT)
     {
         o->hardware_fault = TRUE;
@@ -444,7 +446,6 @@ void AbsEncoder_invalid(AbsEncoder* o, ae_errortype_t error_type)
         case embot::app::eth::encoder::v1::Error::AKSIM2_GENERIC:
         case embot::app::eth::encoder::v1::Error::AKSIM2_INVALID_DATA:
         case embot::app::eth::encoder::v1::Error::AKSIM2_CLOSE_TO_LIMITS:
-        case embot::app::eth::encoder::v1::Error::AKSIM2_CRC_ERROR:
             break;
         
         // all other cases are errors: AEA_PARITY, AEA_CHIP, AEA_READING have their tx_error, chip_error, data_error. all others: are data_error. 


### PR DESCRIPTION
This PR solves a problem we had with Aksim2 encoders due to the fact that their diagnostic is managed differently from all other encoders and the error risen need to be filtered accordingly without making the AbsEncoder class managing them.
This problem generated only on our bench setup, which uses joints that mount an `Aksim2` encoder.
Briefly what was happening is that if the number of errors for the aksim was over a specific threshold we were always getting an hw fault at the joint, without knowing the reason due to the fact that now error message was transmitted. 
The source of the error is related to these lines of code: https://github.com/robotology/icub-firmware/blob/master/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c#L418-L464
as in detail to this id condition: https://github.com/robotology/icub-firmware/blob/master/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c#L428-L431.
Thus due to the facts that:
1. With Aksim2 encoder we manage the errors and their diagnostic is a specific way because of the high number of crc error
2. A generic error is sent when a certain general threshold is overcome

we were having the joint in fault without knowing the specific reason while reading from  `Aksim2` encoders. 

Related to: https://github.com/robotology/icub-firmware-build/pull/204
Update ems v3.103, mc4plus v3.103, mc2plus v3.82, amc v2.20, amc2c v3.5.0