### PR TITLE
Deliver MVP1 for the new calibrator 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/protocol/rop/EoProtocolMC_fun_amc.c
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/protocol/rop/EoProtocolMC_fun_amc.c
@@ -561,6 +561,11 @@ extern void eoprot_fun_UPDT_mc_motor_config_temperaturelimit(const EOnv* nv, con
     
 }
 
+extern void eoprot_fun_UPDT_mc_controller_config(const EOnv* nv, const eOropdescriptor_t* rd)
+{
+    embot::app::eth::theServiceMC::getInstance().process({rd, nv, 0}); 
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition of extern hidden functions 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 20},
-            {2025, Month::Mar, Day::twentyfive, 17, 17}
+            {2, 21},
+            {2025, Month::Mar, Day::twentyeight, 17, 17}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 5, 0, 0},   // application version
+        {3, 6, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::Feb, embot::app::eth::Day::twentyfive, 17, 17}
+        {2025, embot::app::eth::Month::Mar, embot::app::eth::Day::twentyeight, 17, 17}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          103
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          104
 //  </h>version
 
 //  <h> build date
@@ -90,7 +90,7 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        3
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMC_fun_ems4rd.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoprot-callbacks/EoProtocolMC_fun_ems4rd.c
@@ -1579,6 +1579,18 @@ extern void eoprot_fun_UPDT_mc_motor_config_temperaturelimit(const EOnv* nv, con
     }
 }
 
+// -- entity controller
+
+
+// f-marker-begin
+extern void eoprot_fun_UPDT_mc_controller_config(const EOnv* nv, const eOropdescriptor_t* rd)
+{
+    eOmc_controller_config_t *cconfig = (eOmc_controller_config_t*)rd->data;
+    eOprotIndex_t cxx = eoprot_ID2index(rd->id32);
+    
+    MController_set_maintenanceMode(cconfig->enableskiprecalibration);
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 // - definition of extern hidden functions 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -311,7 +311,7 @@ static EOtheMotionController s_eo_themotcon =
     EO_INIT(.id32ofregulars)            NULL,
     
     EO_INIT(.motor_delayer)             { {NULL, NULL, 0}, {NULL, NULL, 0}, {NULL, NULL, 0}, {NULL, NULL, 0} },
-    EO_INIT(.motor_delayer_flags)       0    
+    EO_INIT(.motor_delayer_flags)       0
 };
 
 
@@ -1507,7 +1507,12 @@ extern eOresult_t eo_motioncontrol_Stop(EOtheMotionController *p)
     else //foc, mc4plus, mc4plusmais, and others which use the MControler
     {
         MController_go_idle();
-        MController_deinit();
+        eo_errman_Trace(eo_errman_GetHandle(), "CALLED: MController_go_idle()", s_eobj_ownname);
+        if(!(MController_get_maintenanceMode()))
+        {
+            eo_errman_Trace(eo_errman_GetHandle(), "CALLED: MController_deinit()", s_eobj_ownname);
+            MController_deinit();
+        }
     }
       
     p->service.started = eobool_false;
@@ -1575,6 +1580,10 @@ static const eOmc_motor_t s_motor_default_value =
     0
 }; 
 
+static const eOmc_motor_t s_controller_default_value =
+{   // to simplify we set everything to zero and then we edit eoprot_fun_INIT_mc_controller*() functions
+    0
+}; 
 
 extern void eoprot_fun_INIT_mc_joint_config(const EOnv* nv)
 {
@@ -1606,6 +1615,11 @@ extern void eoprot_fun_INIT_mc_motor_status(const EOnv* nv)
     sta->mc_fault_state = eoerror_code_dummy;
 }
 
+extern void eoprot_fun_INIT_mc_controller_config(const EOnv* nv)
+{
+    eOmc_controller_config_t *cfg = (eOmc_controller_config_t*)eo_nv_RAM(nv);
+    memmove(cfg, &s_controller_default_value.config, sizeof(eOmc_controller_config_t));
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 // - definition of static functions 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          82
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          83
 
 //  </h>version
 
@@ -85,7 +85,7 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        03
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          103
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          104
 
 //  </h>version
 
@@ -94,7 +94,7 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        03
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          25
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          28
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         17
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -446,6 +446,7 @@ void AbsEncoder_invalid(AbsEncoder* o, ae_errortype_t error_type)
         case embot::app::eth::encoder::v1::Error::AKSIM2_GENERIC:
         case embot::app::eth::encoder::v1::Error::AKSIM2_INVALID_DATA:
         case embot::app::eth::encoder::v1::Error::AKSIM2_CLOSE_TO_LIMITS:
+            o->fault_state.bits.data_error = TRUE;
             break;
         
         // all other cases are errors: AEA_PARITY, AEA_CHIP, AEA_READING have their tx_error, chip_error, data_error. all others: are data_error. 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
@@ -96,7 +96,9 @@ struct MController_hid
     // it gets those values of eOmn_serv_type_t that belong to category eomn_serv_category_mc.
     // they are: eomn_serv_MC* 
     // i could use also values of eOmotioncontroller_mode_t but i prefere remove dependancy from EOtheMotionController.h in here
-    eOmn_serv_type_t mcmode; 
+    eOmn_serv_type_t mcmode;
+    
+    BOOL isMaintenanceMode;
 };
 
 
@@ -188,6 +190,8 @@ MController* MController_new(uint8_t nJoints, uint8_t nEncods) //
     {
         o->eos[i] = NEW(uint8_t, MAX_ENCODS_PER_BOARD);
     }
+    
+    o->isMaintenanceMode = FALSE;
     
     MController_init();
 
@@ -1253,6 +1257,16 @@ int32_t MController_get_absEncoder(uint8_t j)
     return AbsEncoder_position(smc->absEncoder+j);
 }
 
+BOOL MController_get_maintenanceMode()
+{
+    return smc->isMaintenanceMode;
+}
+
+void MController_set_maintenanceMode(eObool_t useMaintenanceMode)
+{
+    smc->isMaintenanceMode = (BOOL)(useMaintenanceMode);
+}
+
 void MController_do()
 {    
     for (int s=0; s<smc->nSets; ++s)
@@ -1430,6 +1444,7 @@ static char invert_matrix(float** M, float** I, char n)
 
 void MController_calibrate(uint8_t e, eOmc_calibrator_t *calibrator)
 {
+    if(smc->isMaintenanceMode && (smc->jointSet+smc->e2s[e*smc->multi_encs])->is_calibrated) return;
     JointSet_calibrate(smc->jointSet+smc->e2s[e*smc->multi_encs], e, calibrator);
 }
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.h
@@ -68,6 +68,9 @@ extern void MController_timeout_absEncoder_fbk(uint8_t e);
 
 extern int32_t MController_get_absEncoder(uint8_t j); //
 
+extern BOOL MController_get_maintenanceMode();
+extern void MController_set_maintenanceMode(eObool_t useMaintenanceMode);
+
 extern void MController_do(void); //
 
 extern BOOL MController_set_control_mode(uint8_t j, eOmc_controlmode_command_t control_mode);

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -311,7 +311,7 @@ BOOL Joint_set_control_mode(Joint* o, eOmc_controlmode_command_t control_mode)
     
     if (o->control_mode == eomc_controlmode_notConfigured) return FALSE;  
         
-    if ((o->control_mode == eomc_controlmode_calib) && (control_mode != eomc_controlmode_cmd_force_idle || control_mode != eomc_controlmode_cmd_idle)) return FALSE;     
+    if (o->control_mode == eomc_controlmode_calib) return FALSE;     
     
     if (o->control_mode == eomc_controlmode_hwFault)
     {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -39,6 +39,7 @@
 // - OPAQUE STRUCT    
 #include "Joint_hid.h"
     
+    
 static void Joint_set_inner_control_flags(Joint* o);
 static BOOL Joint_set_pos_ref_in_calib(Joint* o, CTRL_UNITS pos_ref, CTRL_UNITS vel_ref);
 
@@ -310,7 +311,7 @@ BOOL Joint_set_control_mode(Joint* o, eOmc_controlmode_command_t control_mode)
     
     if (o->control_mode == eomc_controlmode_notConfigured) return FALSE;  
         
-    if (o->control_mode == eomc_controlmode_calib) return FALSE;    
+    if ((o->control_mode == eomc_controlmode_calib) && (control_mode != eomc_controlmode_cmd_force_idle || control_mode != eomc_controlmode_cmd_idle)) return FALSE;     
     
     if (o->control_mode == eomc_controlmode_hwFault)
     {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1683,7 +1683,10 @@ static void JointSet_do_wait_calibration(JointSet* o)
             break;
     }
     
-    if (!o->is_calibrated) return;
+    if (!o->is_calibrated) 
+    {
+        return;
+    }
     
     for (int es=0; es<E; ++es)
     {
@@ -1706,6 +1709,7 @@ static void JointSet_do_wait_calibration(JointSet* o)
     }
     
     JointSet_set_control_mode(o, eomc_controlmode_cmd_position);
+   
 }
 
 void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_SERVICE.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_SERVICE.cpp
@@ -665,7 +665,6 @@ namespace embot::app::eth::service::impl::mc {
                     r = true;                
                 } break;  
 
-                
                 // the unmanaged tags
                 case eoprot_tag_mc_motor_wholeitem: // = 0 and never used
                     
@@ -675,7 +674,23 @@ namespace embot::app::eth::service::impl::mc {
                 } break;
             }
             
-        } 
+        }
+        else if(eomc_entity_controller == entity)
+        {
+            switch(static_cast<eOprot_tag_mc_controller_t>(tag))
+            {
+                case eoprot_tag_mc_controller_config:
+                {
+                    // 1
+                    eOmc_controller_config_t *cconfig = reinterpret_cast<eOmc_controller_config_t*>(ropdescriptor.rd->data);
+                    MController_set_maintenanceMode(cconfig->enableskiprecalibration);  
+                } break;
+                default:
+                {    
+                    // add a print that tells that a command is not managed
+                } break;
+            }          
+        }
         
         return r;          
     }  
@@ -891,6 +906,11 @@ extern "C"
     {   // to simplify we set everything to zero and then we edit eoprot_fun_INIT_mc_motor*() functions
         0
     }; 
+    
+    static const eOmc_motor_t s_controller_default_value =
+    {   // to simplify we set everything to zero and then we edit eoprot_fun_INIT_mc_controller*() functions
+        0
+    }; 
 
 
     extern void eoprot_fun_INIT_mc_joint_config(const EOnv* nv)
@@ -921,6 +941,12 @@ extern "C"
         
         // Initialize the fault state to dummy since code zero is assigned to unspecified system error
         sta->mc_fault_state = eoerror_code_dummy;
+    }
+    
+    extern void eoprot_fun_INIT_mc_controller_config(const EOnv* nv)
+    {
+        eOmc_controller_config_t *cfg = (eOmc_controller_config_t*)eo_nv_RAM(nv);
+        memmove(cfg, &s_controller_default_value.config, sizeof(eOmc_controller_config_t));
     }
 
 }


### PR DESCRIPTION
This PR aims at delivering the first version of the new calibrator, which has been thought to allow final users to skip the re-calibration of all the joints on the robots that have been previously calibrated correctly by adding a new group that know holds just a single parameter related to this new function in the file `general.xml` in the robot configuration files.

Related to: https://github.com/robotology/icub-firmware-build/pull/205