### PR TITLE
2FOC PWM_MAX increased to 96%.

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/UserParms.h
@@ -17,7 +17,7 @@
 
 //#define UDEF_CURRENT_MAX 4000 // 4 A
 #define UDEF_SPEED_MAX  32767
-#define UDEF_PWM_MAX    25600 // 800*32 = 80%
+#define UDEF_PWM_MAX    30720 // 32000*(96/100) = 96%
 #define VOLT_REF_SHIFT 5 // for a PWM resolution of 1000
 
 //

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          40
+#define FW_VERSION_BUILD          42
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -197,7 +197,7 @@ volatile int iQerror_old = 0;
 volatile int iDerror_old = 0;
 volatile int iQprot = 0;
 
-static const int PWM_MAX = 8*PWM_50_DUTY_CYC/10; // = 80%
+static const int PWM_MAX = (24*PWM_50_DUTY_CYC)/25; // = 96%
 
 volatile int gMaxCurrent = 0;
 volatile long sI2Tlimit = 0;
@@ -1081,7 +1081,7 @@ void DisableAuxServiceTimer()
 void DriveInit()
 // Perform drive SW/HW init
 {
-    pwmInit(PWM_50_DUTY_CYC, DDEADTIME, PWM_MAX /*pwm max = 80%*/);
+    pwmInit(PWM_50_DUTY_CYC, DDEADTIME, PWM_MAX /*pwm max = 96%*/);
     
     // setup and perform ADC offset calibration in MeasCurrParm.Offseta and MeasCurrParm.Offsetc
     ADCDoOffsetCalibration();

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/PWM.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/PWM.c
@@ -87,7 +87,7 @@ void __attribute__((__interrupt__,no_auto_psv)) _FLTA1Interrupt(void)
 
 void pwmSetMax(short pwm_max)
 {
-    if (pwm_max < (PWM_50_DUTY_CYCLE*9)/10) PWM_MAX = pwm_max;
+    if (pwm_max <= (PWM_50_DUTY_CYCLE*24)/25) PWM_MAX = pwm_max;
 }
 
 char pwmON(void)


### PR DESCRIPTION
When the maximum pwm was increased to 96%, there was still another check at lower level. Fixed.

Version increased to 3.3.42