### PR TITLE
CRC errors detection in `amc` board: support

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2022 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
@@ -11,7 +10,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 #include "embot_hw_bsp.h"
-
 
 // --------------------------------------------------------------------------------------------------------------------
 // - external dependencies
@@ -41,7 +39,6 @@ using namespace embot::core::binary;
 #include "embot_hw_bsp_amc_config.h"
 
 
-
 // - support map: begin of embot::hw::eth
 
 #include "embot_hw_eth.h"
@@ -49,17 +46,17 @@ using namespace embot::core::binary;
 
 #if   !defined(EMBOT_ENABLE_hw_eth)
 
-namespace embot { namespace hw { namespace eth { namespace bsp {
+namespace embot::hw::eth::bsp {
     
     
-}}}}
+}
 
 #else   // EMBOT_ENABLE_hw_eth
 
 #include "ipal_hal_eth_stm32h7.h"
 #include "embot_hw_chip_KSZ8563.h"
     
-namespace embot { namespace hw { namespace eth { namespace bsp {
+namespace embot::hw::eth::bsp {
                
     #if   defined(STM32HAL_BOARD_AMC)
     
@@ -160,7 +157,7 @@ namespace embot { namespace hw { namespace eth { namespace bsp {
             embot::hw::chip::KSZ8563::PORT::three
         };
         static embot::hw::chip::KSZ8563::MIBdata data {};
-        ethswitch->read(ports[embot::core::tointegral(phy)], mibs[embot::core::tointegral(e)], data);
+        ethswitch->readCRC(ports[embot::core::tointegral(phy)], mibs[embot::core::tointegral(e)], data);
         
         return data.value();
     }
@@ -174,7 +171,7 @@ namespace embot { namespace hw { namespace eth { namespace bsp {
         return thebsp;
     }
               
-}}}} // namespace embot { namespace hw { namespace eth { namespace bsp {
+} // namespace embot::hw::eth::bsp {
     
 
     #if defined(HAL_ETH_MODULE_ENABLED)

--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
@@ -146,9 +146,10 @@ namespace embot::hw::eth::bsp {
             return 0;
         }  
                 
-        static constexpr embot::hw::chip::KSZ8563::MIB mibs[1] =
+        static constexpr embot::hw::chip::KSZ8563::MIB mibs[2] =
         {
-            embot::hw::chip::KSZ8563::MIB::RxCRCerror
+            embot::hw::chip::KSZ8563::MIB::RxCRCerror,
+            embot::hw::chip::KSZ8563::MIB::RxUnicast
         };
         static constexpr embot::hw::chip::KSZ8563::PORT ports[3] =
         {
@@ -157,7 +158,7 @@ namespace embot::hw::eth::bsp {
             embot::hw::chip::KSZ8563::PORT::three
         };
         static embot::hw::chip::KSZ8563::MIBdata data {};
-        ethswitch->readCRC(ports[embot::core::tointegral(phy)], mibs[embot::core::tointegral(e)], data);
+        ethswitch->readMIB(ports[embot::core::tointegral(phy)], mibs[embot::core::tointegral(e)], data);
         
         return data.value();
     }

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -152,7 +152,7 @@ void embot::app::eth::theETHmonitor::Impl::startup(embot::os::Thread *t, void *p
 }
 
 void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *p)
-{
+{  
 	embot::app::eth::theETHmonitor::Impl *impl = reinterpret_cast<embot::app::eth::theETHmonitor::Impl*>(p);
 	
 	eOerrmanDescriptor_t errdes = {0};
@@ -169,12 +169,13 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 	}
 	
 	embot::core::Time nowTime = embot::core::now();
-	
+	uint64_t applstate = (eobool_true == eom_emsrunner_IsRunning(eom_emsrunner_GetHandle())) ? (0x3000000000000000) : (0x1000000000000000);   
+    
+    
+    //check for linkup and linkdown
 	bool link1isup = embot::hw::eth::islinkup(embot::hw::PHY::one); 
 	bool link2isup = embot::hw::eth::islinkup(embot::hw::PHY::two);
-		
-	uint64_t applstate = (eobool_true == eom_emsrunner_IsRunning(eom_emsrunner_GetHandle())) ? (0x3000000000000000) : (0x1000000000000000);   
-
+    
 	if((impl->link1.previsup != link1isup) || ((impl->link2.previsup != link2isup)))
 	{		
 		if(true == link1isup)
@@ -244,10 +245,53 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 
 		impl->lastreportTime = nowTime;
 	}
+    //check for CRC errors
+    if (link1isup)
+    {
+        uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::crc);
+        
+        if(0 != CRC_error_number)
+        {
+        errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_error_rxcrc);
+        errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress    = 0;
+        errdes.par16            = 0;
+        errdes.par64            = applstate | (CRC_error_number & 0xffffffff);    
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
+        }
+    }
+    if (link2isup)
+    {
+
+        uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::crc);
+
+        if(0 != CRC_error_number)
+        {
+        errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_error_rxcrc);
+        errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+        errdes.sourceaddress    = 0;
+        errdes.par16            = 1;
+        errdes.par64            = applstate | (CRC_error_number & 0xffffffff);    
+        eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
+        }
+    }
     
-    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::crc);
-    CRC_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::crc);
+      //test for CRC etc
 //    CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
+//    uint64_t unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
+//    static uint8_t iii=0;
+//    if((iii++)%100)
+//    {   
+//        
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
+//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
+//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
+//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
+//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+//    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -244,6 +244,10 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 
 		impl->lastreportTime = nowTime;
 	}
+    
+    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::crc);
+    CRC_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::crc);
+//    CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -60,24 +60,17 @@ namespace embot::hw::chip {
 
         // the ports are the two PHYs plus the RMII / MII connection
         enum class PORT : uint8_t { one = 0, two = 1, three = 2 };
-//        enum class port_IDs : uint8_t {
-//            KSZ8563_GLOBAL = 0,
-//            KSZ8563_PORT1  = 1,
-//            KSZ8563_PORT2  = 2,
-//            KSZ8563_PORT3  = 3
-//            };
+
         constexpr static size_t numberofPORTs {3};
         // we can read the MIB (Management Information Base) counters for each port
-        enum class MIB : uint8_t { RxCRCerror = 0x06 };
-        enum class REG_MIB : uint8_t { REG_MIB_CSR = 0x0000, REG_MIB_DR  = 0x0004};
+        enum class MIB : uint8_t { RxCRCerror = 0x06, RxUnicast = 0x0C, RxByteCnt = 0x80 , TxByteCnt =0x81};
+        enum class REG_MIB : uint8_t { REG_MIB_CSR = 0x0000, REG_MIB_DR  = 0x0004};  /* 32 bits  - MIB Control and Status Register, 32 bits  - MIB Data Register */
         enum class COMMAND : uint8_t { WRITE = 2, READ  = 3};
         static constexpr uint8_t MIB_CSR_READ_ENABLE_POS = 25;
         static constexpr uint8_t MIB_INDEX_POS = 16;
-        /* Set MIB Index and Enable Read */ 
+        static constexpr uint32_t MIB_CSR_COUNTER_VALID = 1<<25;
+        static constexpr uint32_t MIB_CSR_OVERFLOW = 1<<31;
 
-        static constexpr uint32_t MIB_data_to_send = 0 | (static_cast<uint8_t>(MIB::RxCRCerror) << MIB_INDEX_POS) | (1 << MIB_CSR_READ_ENABLE_POS);
-//        constexpr uint32_t REG_MIB_CSR = 0x0000;			/* 32 bits  - MIB Control and Status Register */
-//        constexpr uint32_t REG_MIB_DR  = 0x0004;			/* 32 bits  - MIB Data Register */
         struct MIBdata
         {
             enum class Size : uint8_t { bits30 = 0, bits36 = 1 };
@@ -101,8 +94,7 @@ namespace embot::hw::chip {
             }
             uint64_t value() const { return (static_cast<uint64_t>(v8) << 32) | v32; }
             
-            
-            
+                
         };
         
         struct PinControl
@@ -142,7 +134,7 @@ namespace embot::hw::chip {
         bool deinit();
                
         bool read(PHY phy, Link &link, embot::core::relTime timeout = 5*embot::core::time1millisec);  
-        bool readCRC(PORT port, MIB mib, MIBdata &data, embot::core::relTime timeout = 5*embot::core::time1millisec);  
+        bool readMIB(PORT port, MIB mib, MIBdata &data, embot::core::relTime timeout = 5*embot::core::time1millisec);  
     private:        
         struct Impl;
         Impl *pImpl;    
@@ -157,10 +149,10 @@ namespace embot::hw::chip {
 
 //#define EMBOT_HW_CHIP_KSZ8563_enable_test   
 #if defined(EMBOT_HW_CHIP_KSZ8563_enable_test)    
-namespace embot { namespace hw { namespace chip {
+namespace embot::hw::chip {
     // it tests the chip and offers an example of use
     bool testof_KSZ8563();
-}}}
+}
 #endif
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -42,7 +42,7 @@ Code listing. Usage of the class
 #endif    
 
 
-namespace embot { namespace hw { namespace chip {
+namespace embot::hw::chip {
     
     class KSZ8563
     {
@@ -60,10 +60,24 @@ namespace embot { namespace hw { namespace chip {
 
         // the ports are the two PHYs plus the RMII / MII connection
         enum class PORT : uint8_t { one = 0, two = 1, three = 2 };
+//        enum class port_IDs : uint8_t {
+//            KSZ8563_GLOBAL = 0,
+//            KSZ8563_PORT1  = 1,
+//            KSZ8563_PORT2  = 2,
+//            KSZ8563_PORT3  = 3
+//            };
         constexpr static size_t numberofPORTs {3};
         // we can read the MIB (Management Information Base) counters for each port
         enum class MIB : uint8_t { RxCRCerror = 0x06 };
-        
+        enum class REG_MIB : uint8_t { REG_MIB_CSR = 0x0000, REG_MIB_DR  = 0x0004};
+        enum class COMMAND : uint8_t { WRITE = 2, READ  = 3};
+        static constexpr uint8_t MIB_CSR_READ_ENABLE_POS = 25;
+        static constexpr uint8_t MIB_INDEX_POS = 16;
+        /* Set MIB Index and Enable Read */ 
+
+        static constexpr uint32_t MIB_data_to_send = 0 | (static_cast<uint8_t>(MIB::RxCRCerror) << MIB_INDEX_POS) | (1 << MIB_CSR_READ_ENABLE_POS);
+//        constexpr uint32_t REG_MIB_CSR = 0x0000;			/* 32 bits  - MIB Control and Status Register */
+//        constexpr uint32_t REG_MIB_DR  = 0x0004;			/* 32 bits  - MIB Data Register */
         struct MIBdata
         {
             enum class Size : uint8_t { bits30 = 0, bits36 = 1 };
@@ -86,6 +100,9 @@ namespace embot { namespace hw { namespace chip {
                 v8 = (Size::bits30 == s) ? (0) : (0x0f & nibble9);
             }
             uint64_t value() const { return (static_cast<uint64_t>(v8) << 32) | v32; }
+            
+            
+            
         };
         
         struct PinControl
@@ -125,14 +142,17 @@ namespace embot { namespace hw { namespace chip {
         bool deinit();
                
         bool read(PHY phy, Link &link, embot::core::relTime timeout = 5*embot::core::time1millisec);  
-        bool read(PORT port, MIB mib, MIBdata &data, embot::core::relTime timeout = 5*embot::core::time1millisec);  
+        bool readCRC(PORT port, MIB mib, MIBdata &data, embot::core::relTime timeout = 5*embot::core::time1millisec);  
     private:        
         struct Impl;
         Impl *pImpl;    
     };
+     
     
     
-}}} // namespace embot { namespace hw { namespace chip {
+    
+    
+} // namespace embot::hw::chip {
 
 
 //#define EMBOT_HW_CHIP_KSZ8563_enable_test   

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
@@ -23,7 +23,7 @@
 
 #endif  
 
-namespace embot { namespace hw { namespace eth {
+namespace embot::hw::eth {
     
     enum class PORT : uint8_t { one = 0, two = 1, three = 2, none = 31, maxnumberof = 3 };
     enum class ERR : uint8_t { crc = 0 };
@@ -52,7 +52,7 @@ namespace embot { namespace hw { namespace eth {
     
     uint64_t getnumberoferrors(embot::hw::PHY phy, ERR e);
     
-}}} // namespace embot { namespace hw { namespace eth {
+} // namespace embot::hw::eth {
     
     
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
@@ -26,8 +26,8 @@
 namespace embot::hw::eth {
     
     enum class PORT : uint8_t { one = 0, two = 1, three = 2, none = 31, maxnumberof = 3 };
-    enum class ERR : uint8_t { crc = 0 };
-    
+    enum class ERR : uint8_t { crc = 0, unicast = 1, RxByteCnt = 2, TxByteCnt = 3};
+
     // standard api
     bool supported(embot::hw::EtH b);    
     bool initialised(embot::hw::EtH b);    


### PR DESCRIPTION
This PR adds support for CRC error detection in `amc` board.

The CRC error status is read through the SPI bus from the ETH switch and if any errors are found, then `theETHmonitor` sends diagnostics messages to `yarprobotinterface`.

So far, test were done using a fake generation of CRC errors and  `yarprobotinterface` correctly displays the diagnostics as follows.

![image](https://github.com/user-attachments/assets/70895dc1-0f78-486b-a10c-f8a1cebb8fe5)



The effective reading from the register must be verified in presence of CRC errors induced in the ETH network. That will be done a later moment.

This change does not affect normal behavior, so it can be safely merged.