### PR TITLE
Added setpoint reference timeouts to PWM, current and torque.

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 25},
-            {2025, Month::Jul, Day::three, 13, 13}
+            {2, 26},
+            {2025, Month::Jul, Day::twentyfour, 12, 12}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -90,11 +90,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          12
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,7 +81,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          105
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          106
 //  </h>version
 
 //  <h> build date
@@ -90,11 +90,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          2
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          16
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          16
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,7 +75,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          84
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          85
 
 //  </h>version
 
@@ -85,11 +85,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          2
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          15
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          12
 //  </h>build date
 
 // </h>Info 

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          105
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          106
 
 //  </h>version
 
@@ -94,11 +94,11 @@ extern "C" {
 //  <o> month           <1-12>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        7
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          2
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          24
 //  <o> hour            <0-23>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         12
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          16
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          12
 
 //  </h>build date
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
@@ -88,11 +88,13 @@ typedef enum {
 #define TICKS_PER_REVOLUTION      65536
 #define TICKS_PER_HALF_REVOLUTION 32768
 #define ENCODER_QUANTIZATION      16
-    
-#define VELOCITY_CMD_TIMEOUT      100 // cycles
-#define TORQUE_CMD_TIMEOUT        100 // cycles
-#define TORQUE_SENSOR_TIMEOUT     100 // cycles
-#define ENCODER_TIMEOUT            50 // cycles
+
+#define TRQ_SENSOR_TIMEOUT     100 // cycles
+
+#define VEL_CMD_TIMEOUT        100 // cycles
+#define PWM_CMD_TIMEOUT        100 // cycles
+#define CUR_CMD_TIMEOUT        100 // cycles
+#define TRQ_CMD_TIMEOUT        100 // cycles
 
 #define CAN_ALIVE_TIMEOUT  50
 #define CTRL_REQ_TIMEOUT   50

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -609,6 +609,12 @@ extern void Joint_clear_faults(Joint* o)
 {
     o->fault_state_prec.bitmask = 0;
     o->fault_state.bitmask = 0;
+    
+    WatchDog_rearm(&o->vel_ref_wdog);
+    WatchDog_rearm(&o->trq_ref_wdog);
+    WatchDog_rearm(&o->pwm_ref_wdog);
+    WatchDog_rearm(&o->cur_ref_wdog);
+    WatchDog_rearm(&o->trq_fbk_wdog);
 }
 
 int8_t Joint_check_limits(Joint* o)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -510,13 +510,13 @@ BOOL Joint_check_faults(Joint* o)
     if (o->fault_state.bitmask != o->fault_state_prec.bitmask)
     {        
         static eOerrmanDescriptor_t descriptor = {0};
+        descriptor.par16 = o->ID;
         descriptor.par64 = 0;
         descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
         descriptor.sourceaddress = 0;
                     
         if (o->fault_state.bits.torque_sensor_timeout && !o->fault_state_prec.bits.torque_sensor_timeout)
         {   
-            descriptor.par16 = o->ID;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_axis_torque_sens);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -530,7 +530,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.torque_ref_timeout && !o->fault_state_prec.bits.torque_ref_timeout)
         {   
-            descriptor.par16 = eoerror_value_MC_ref_timeout_torque;
+            descriptor.par64 = eoerror_value_MC_ref_timeout_torque;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_ref_setpoint_timeout);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -544,7 +544,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.current_ref_timeout && !o->fault_state_prec.bits.current_ref_timeout)
         {   
-            descriptor.par16 = eoerror_value_MC_ref_timeout_current;
+            descriptor.par64 = eoerror_value_MC_ref_timeout_current;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_ref_setpoint_timeout);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -558,7 +558,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.pwm_ref_timeout && !o->fault_state_prec.bits.pwm_ref_timeout)
         {   
-            descriptor.par16 = eoerror_value_MC_ref_timeout_pwm;
+            descriptor.par64 = eoerror_value_MC_ref_timeout_pwm;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_ref_setpoint_timeout);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -572,7 +572,6 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.hard_limit_reached && !o->fault_state_prec.bits.hard_limit_reached)
         {   
-            descriptor.par16 = o->ID;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_joint_hard_limit);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -509,13 +509,14 @@ BOOL Joint_check_faults(Joint* o)
         
     if (o->fault_state.bitmask != o->fault_state_prec.bitmask)
     {        
+        static eOerrmanDescriptor_t descriptor = {0};
+        descriptor.par64 = 0;
+        descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
+        descriptor.sourceaddress = 0;
+                    
         if (o->fault_state.bits.torque_sensor_timeout && !o->fault_state_prec.bits.torque_sensor_timeout)
         {   
-            static eOerrmanDescriptor_t descriptor = {0};
             descriptor.par16 = o->ID;
-            descriptor.par64 = 0;
-            descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
-            descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_axis_torque_sens);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -529,11 +530,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.torque_ref_timeout && !o->fault_state_prec.bits.torque_ref_timeout)
         {   
-            static eOerrmanDescriptor_t descriptor = {0};
             descriptor.par16 = eoerror_value_MC_ref_timeout_torque;
-            descriptor.par64 = 0;
-            descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
-            descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_ref_setpoint_timeout);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -547,11 +544,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.current_ref_timeout && !o->fault_state_prec.bits.current_ref_timeout)
         {   
-            static eOerrmanDescriptor_t descriptor = {0};
             descriptor.par16 = eoerror_value_MC_ref_timeout_current;
-            descriptor.par64 = 0;
-            descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
-            descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_ref_setpoint_timeout);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -565,11 +558,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.pwm_ref_timeout && !o->fault_state_prec.bits.pwm_ref_timeout)
         {   
-            static eOerrmanDescriptor_t descriptor = {0};
             descriptor.par16 = eoerror_value_MC_ref_timeout_pwm;
-            descriptor.par64 = 0;
-            descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
-            descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_ref_setpoint_timeout);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             
@@ -583,11 +572,7 @@ BOOL Joint_check_faults(Joint* o)
         
         if (o->fault_state.bits.hard_limit_reached && !o->fault_state_prec.bits.hard_limit_reached)
         {   
-            static eOerrmanDescriptor_t descriptor = {0};
             descriptor.par16 = o->ID;
-            descriptor.par64 = 0;
-            descriptor.sourcedevice = eo_errman_sourcedevice_localboard;
-            descriptor.sourceaddress = 0;
             descriptor.code = eoerror_code_get(eoerror_category_MotionControl, eoerror_value_MC_joint_hard_limit);
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &descriptor);
             

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -379,6 +379,17 @@ BOOL JointSet_do_check_faults(JointSet* o)
     
     BOOL fault = FALSE;
     o->external_fault = FALSE;
+
+//            //timeout = TRUE;
+//            fault = TRUE;
+//            eOerrmanDescriptor_t errdes = {0};
+//                    
+//            errdes.code             = errorcode;
+//            errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+//            errdes.sourceaddress    = o->joint[o->joints_of_set[k]].ID;
+//            errdes.par16            = controlmode;
+//            errdes.par64            = 0;
+//            eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
     
     for (int k=0; k<N; ++k)
     {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -379,17 +379,6 @@ BOOL JointSet_do_check_faults(JointSet* o)
     
     BOOL fault = FALSE;
     o->external_fault = FALSE;
-
-//            //timeout = TRUE;
-//            fault = TRUE;
-//            eOerrmanDescriptor_t errdes = {0};
-//                    
-//            errdes.code             = errorcode;
-//            errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-//            errdes.sourceaddress    = o->joint[o->joints_of_set[k]].ID;
-//            errdes.par16            = controlmode;
-//            errdes.par64            = 0;
-//            eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, NULL, &errdes);
     
     for (int k=0; k<N; ++k)
     {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
@@ -100,6 +100,10 @@ typedef union
     {
         uint8_t torque_sensor_timeout:1;
         uint8_t hard_limit_reached:1;
+        uint8_t velocity_ref_timeout:1;
+        uint8_t pwm_ref_timeout:1;
+        uint8_t current_ref_timeout:1;
+        uint8_t torque_ref_timeout;
     } bits;
         
     uint8_t bitmask;
@@ -175,7 +179,10 @@ struct Joint_hid
     CTRL_UNITS Kadmitt;
     
     WatchDog trq_fbk_wdog;
+    WatchDog trq_ref_wdog;
     WatchDog vel_ref_wdog;
+    WatchDog pwm_ref_wdog;
+    WatchDog cur_ref_wdog;
     
 #if defined(MC_use_embot_app_mc_Trajectory)    
     embot::app::mc::Trajectory *traj {nullptr};

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog.c
@@ -34,6 +34,7 @@
 
 void WatchDog_init(WatchDog* o)
 {
+    o->min_timer = 1000000000;
     o->timer = 0;
     o->base_time = 0;
 }
@@ -51,15 +52,27 @@ void WatchDog_new(uint8_t n)
 void WatchDog_set_base_time_msec(WatchDog* o, uint32_t base_time_msec)
 {
     o->base_time = (base_time_msec*(uint32_t)CTRL_LOOP_FREQUENCY)/1000;
+    o->min_timer = o->base_time;
+    o->timer = o->base_time;
 }
 
 void WatchDog_rearm(WatchDog* o)
 {
+    if (o->timer < o->min_timer)
+    {
+        o->min_timer = o->timer;
+    }
+        
     o->timer = o->base_time;
 }
 
 void WatchDog_rearm_from(WatchDog* o, uint32_t from)
 {
+    if (o->timer < o->min_timer)
+    {
+        o->min_timer = o->timer;
+    }
+    
     o->timer = from;
 }
 
@@ -70,6 +83,8 @@ void Watchdog_disarm(WatchDog* o)
 
 BOOL WatchDog_check_expired(WatchDog* o)
 {
+    if (!o->base_time) return FALSE;
+    
     if (o->timer)
     {
         --o->timer;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/WatchDog_hid.h
@@ -13,6 +13,7 @@
 
 struct WatchDog_hid
 {
+    uint32_t min_timer;
     uint32_t timer;
     uint32_t base_time;
 };


### PR DESCRIPTION
If a watchdog expires, the joint is put in stiff position mode. The torque feedback timeout behaviour changes from go to hardware fault to switch to stiff position mode.