### PR TITLE
MC controller: reverted move of calibration in Calibration.c

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvoptx
@@ -628,7 +628,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1143,14 +1143,13 @@
       <TargetName>appl-icc-ulpro</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pArmCC>6220000::V6.22::ARMCLANG</pArmCC>
-      <pCCUsed>6220000::V6.22::ARMCLANG</pCCUsed>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -2232,7 +2231,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.3.1.1</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/amc2c-main2.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/amc2c-main2.cpp
@@ -22,7 +22,7 @@ constexpr embot::app::bldc::theApplication::Config cfg
 
 int main(void)
 {
-    for(;;){};
+    embot::app::bldc::theApplication::getInstance().start(cfg);
 }
 
 

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_theMBD.h
@@ -13,7 +13,7 @@
 
 
 #include <memory>
-
+#include <vector>
 #include "embot_core.h"
 #include "embot_app_bldc.h"
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.h
@@ -20,10 +20,21 @@
 #define MC_CALIBRATORS_H___
 
 #include "JointSet.h"
-#include "EoMotionControl.h"
 
-extern void Calibrator_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator);
-extern void Calibrator_do_wait_calibration(JointSet* o);
+
+#include "EOemsControllerCfg.h"
+
+
+extern BOOL JointSet_do_wait_calibration_3(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_5(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_8(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_9(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_10(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_11(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_12(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_13(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_14(JointSet* o);
+extern BOOL JointSet_do_wait_calibration_mixed(JointSet* o); //calib type 6 and 7
 
 
  

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
@@ -156,8 +156,7 @@ typedef enum {
 
 // - declaration of extern public functions ---------------------------------------------------------------------------
 
-static const CTRL_UNITS DEG2ICUB = 65536.0f/360.0f;
-static const CTRL_UNITS ICUB2DEG = 360.0f/65536.0f;
+
 
 #endif  // include guard
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -32,6 +32,7 @@
 #include "EOtheMemoryPool.h"
 #include "EOemsControllerCfg.h"
 #include "EOtheErrorManager.h"
+#include "EOtheEntities.h"
 #include "EoError.h"
 #if defined(USE_EMBOT_theServices) 
 //#warning USE_EMBOT_theServices is defined
@@ -54,23 +55,10 @@
 #include "Calibrators.h"
 #include <cmath>
 
-
-// static functions
-
 static void JointSet_set_inner_control_flags(JointSet* o);
-static void JointSet_do_vel_control(JointSet* o);
-static void JointSet_do_current_control(JointSet* o);
-static void JointSet_do_off(JointSet* o);
 
-static void JointSet_do_wait_calibration(JointSet* o);
-
-#if defined(MOVE_JointSet_calib_functions_to_Calibrator)
-#else
-#error DONT use it in here anymore
-static eoas_pos_ROT_t JointSet_calib14_ROT2pos_ROT(eOmc_calib14_ROT_t rot);
-#endif
-
-// public functions
+static const CTRL_UNITS DEG2ICUB = 65536.0f/360.0f;
+static const CTRL_UNITS ICUB2DEG = 360.0f/65536.0f;
 
 JointSet* JointSet_new(uint8_t n) //
 {
@@ -444,6 +432,10 @@ BOOL JointSet_do_check_faults(JointSet* o)
     return fault;
 }
 
+static void JointSet_do_vel_control(JointSet* o);
+static void JointSet_do_current_control(JointSet* o);
+static void JointSet_do_off(JointSet* o);
+static eoas_pos_ROT_t JointSet_calib14_ROT2pos_ROT(eOmc_calib14_ROT_t rot);
 
 void JointSet_do_control(JointSet* o)
 {
@@ -467,6 +459,7 @@ void JointSet_do_control(JointSet* o)
     }
 }
 
+static void JointSet_do_wait_calibration(JointSet* o);
 
 void JointSet_do(JointSet* o)
 {
@@ -835,9 +828,6 @@ static CTRL_UNITS wrap180(CTRL_UNITS x)
     return x;
 }
 
-#if defined(MOVE_JointSet_calib_functions_to_Calibrator)
-#else
-#error DONT use it in here anymore
 static eoas_pos_ROT_t JointSet_calib14_ROT2pos_ROT(eOmc_calib14_ROT_t rot)
 {
     eoas_pos_ROT_t retValue = eoas_pos_ROT_unknown;
@@ -873,7 +863,6 @@ static eoas_pos_ROT_t JointSet_calib14_ROT2pos_ROT(eOmc_calib14_ROT_t rot)
     
     return retValue;
 }
-#endif
 
 void JointSet_do_pwm_control(JointSet* o)
 {
@@ -1595,14 +1584,6 @@ static void JointSet_set_inner_control_flags(JointSet* o)
     }
 }
 
-
-#if defined(MOVE_JointSet_calib_functions_to_Calibrator)
-static void JointSet_do_wait_calibration(JointSet* o)
-{
-    Calibrator_do_wait_calibration(0);
-}
-#else
-#error DONT use it in here anymore
 static void JointSet_do_wait_calibration(JointSet* o)
 {
     int N = *(o->pN);
@@ -1733,17 +1714,9 @@ static void JointSet_do_wait_calibration(JointSet* o)
     }
     
     JointSet_set_control_mode(o, eomc_controlmode_cmd_position);
-    
+   
 }
-#endif // MOVE_JointSet_calib_functions_to_Calibrator
 
-#if defined(MOVE_JointSet_calib_functions_to_Calibrator)
-void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
-{
-    Calibrator_calibrate(o, e, calibrator);
-}
-#else
-#error DONT use it in here anymore
 void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
 {
 //    for (int js=0; js<*(o->pN); ++js)
@@ -2257,8 +2230,6 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             break;
     }
 }
-#endif // MOVE_JointSet_calib_functions_to_Calibrator
-
 
 void JointSet_send_debug_message(char *message, uint8_t jid, uint16_t par16, uint64_t par64)
 {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet_hid.h
@@ -23,12 +23,6 @@
 #include "CalibrationHelperData.h" 
 
 
-// keep this macro defined because some code parts in JointSet are actually 
-// related to the calibration, so it is better to move them in Calibrator.c
-
-#define MOVE_JointSet_calib_functions_to_Calibrator
-
-
 #ifdef WRIST_MK2
 
 enum wrist_mk_version_t {WRIST_MK_VER_2_0 = 20,  WRIST_MK_VER_2_1 = 21};


### PR DESCRIPTION
This PR reverts from `Calibration.c` back to `JointSet.c` the calibration functions that I moved in a previous PR #591.

I do that because `Calibration.c` is actually a holder of functions that `JointSet.c` uses (as the calibration is done for an entire joint set) so the move is not strictly necessary for the purpose of cleaning up. 

Also, moving back as much as possible to the state of PR #583 helps simplifying further work on the MC controller.

This PR also fix some compilation issues on the `amc2` board.

I have tested the changes of MC controller on the lego setup running a motor w/ the `amcfoc` board.


