### PR TITLE
Fixed compilation for single core boards after PR 593

### DIFF
--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -41,9 +41,11 @@
     #include "embot_app_eth_theEncoderReader.h"
     #endif
 #else
-
-
+#include "embot_app_eth_theEncoderReader.h"
+#include "EOtheMAIS.h"
+#include "EOthePOS.h"
 #endif
+
 
 #include "Joint.h"
 #include "Joint_hid.h"          // we access internals of the object


### PR DESCRIPTION
Just a commit for fixing compilation for `ems`, `mc4plus`, `mc2plus` boards after #593 

