### PR TITLE
Holder for Trajectory MBD generator code in MC controller

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvoptx
@@ -2562,7 +2562,7 @@
 
   <Group>
     <GroupName>eo-motor-controller</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2890,7 +2890,7 @@
 
   <Group>
     <GroupName>embot::app::mc</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2903,6 +2903,26 @@
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\..\embot\app\mc\embot_app_mc_Trajectory.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_app_mc_Trajectory.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>embot::app::mc::mbd</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>45</GroupNumber>
+      <FileNumber>196</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\src\mbd\trajectory\Trajectory1.cpp</PathWithFileName>
+      <FilenameWithoutPath>Trajectory1.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvoptx
@@ -22,7 +22,7 @@
   </DaveTm>
 
   <Target>
-    <TargetName>amc-icc-osal-ulpro</TargetName>
+    <TargetName>amcfoc</TargetName>
     <ToolsetNumber>0x4</ToolsetNumber>
     <ToolsetName>ARM-ADS</ToolsetName>
     <TargetOption>
@@ -170,7 +170,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>0</aLwin>
+        <aLwin>1</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -187,7 +187,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
+        <aSer4>1</aSer4>
         <StkLoc>1</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -990,7 +990,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp-core-cm4</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -2875,6 +2875,34 @@
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theMCserviceEOtesterconfig.cpp</PathWithFileName>
       <FilenameWithoutPath>embot_app_eth_theMCserviceEOtesterconfig.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+  </Group>
+
+  <Group>
+    <GroupName>mbd::torque-estimator</GroupName>
+    <tvExp>0</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+  </Group>
+
+  <Group>
+    <GroupName>embot::app::mc</GroupName>
+    <tvExp>1</tvExp>
+    <tvExpOptDlg>0</tvExpOptDlg>
+    <cbSel>0</cbSel>
+    <RteFlg>0</RteFlg>
+    <File>
+      <GroupNumber>44</GroupNumber>
+      <FileNumber>195</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\..\..\embot\app\mc\embot_app_mc_Trajectory.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_app_mc_Trajectory.cpp</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvprojx
@@ -7,10 +7,10 @@
 
   <Targets>
     <Target>
-      <TargetName>amc-icc-osal-ulpro</TargetName>
+      <TargetName>amcfoc</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6220000::V6.22::ARMCLANG</pCCUsed>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
@@ -340,7 +340,7 @@
               <MiscControls> -DuseICCserviceCAN -DxdebugNOicc -DxYRI_uses_MC_foc_actuator_descriptor_generic -DxuseMCfoc_actuator_descriptor_generic -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal -DIPAL_use_cfg2 -DUSE_EMBOT_theHandler -DUSE_EMBOT_theServices -DUSE_EMBOT_theServicesMC -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_ICC_COMM USE_EMBOT_HW EMBOBJ_USE_EMBOT USE_STM32HAL STM32HAL_BOARD_AMCFOC_2CM4 STM32HAL_DRIVER_V1A0 STM32HAL_dualcore_BOOT_cm4master</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\libs\highlevel\abslayer\ipal\api;--..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ipnet;..\src\emb-env;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\bsp;..\cfg;..\..\bsp\ipaldrv;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\app\eth;.;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\cfg\protocol\rop;..\..\..\..\..\embobj\plus\can;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embot\prot\can;..\..\..\..\..\mbd\wrist_decoupler;..\..\..\bsp\cm4;..\..\..\bsp\cm4\ipaldrv;..\..\..\bsp\shared</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\libs\highlevel\abslayer\ipal\api;--..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ipnet;..\src\emb-env;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\bsp;..\cfg;..\..\bsp\ipaldrv;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\app\eth;.;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\cfg\protocol\rop;..\..\..\..\..\embobj\plus\can;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embot\prot\can;..\..\..\..\..\mbd\wrist_decoupler;..\..\..\bsp\cm4;..\..\..\bsp\cm4\ipaldrv;..\..\..\bsp\shared;..\..\..\..\..\embot\app\mc</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -2242,6 +2242,19 @@
               <FileName>embot_app_eth_theMCserviceEOtesterconfig.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\ems004\appl\v2\src\eoappservices\embot_app_eth_theMCserviceEOtesterconfig.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>mbd::torque-estimator</GroupName>
+        </Group>
+        <Group>
+          <GroupName>embot::app::mc</GroupName>
+          <Files>
+            <File>
+              <FileName>embot_app_mc_Trajectory.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\..\..\embot\app\mc\embot_app_mc_Trajectory.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/proj/amcfoc.2cm4-yri.uvprojx
@@ -340,7 +340,7 @@
               <MiscControls> -DuseICCserviceCAN -DxdebugNOicc -DxYRI_uses_MC_foc_actuator_descriptor_generic -DxuseMCfoc_actuator_descriptor_generic -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal -DIPAL_use_cfg2 -DUSE_EMBOT_theHandler -DUSE_EMBOT_theServices -DUSE_EMBOT_theServicesMC -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_ICC_COMM USE_EMBOT_HW EMBOBJ_USE_EMBOT USE_STM32HAL STM32HAL_BOARD_AMCFOC_2CM4 STM32HAL_DRIVER_V1A0 STM32HAL_dualcore_BOOT_cm4master</Define>
               <Undefine></Undefine>
-              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\libs\highlevel\abslayer\ipal\api;--..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ipnet;..\src\emb-env;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\bsp;..\cfg;..\..\bsp\ipaldrv;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\app\eth;.;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\cfg\protocol\rop;..\..\..\..\..\embobj\plus\can;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embot\prot\can;..\..\..\..\..\mbd\wrist_decoupler;..\..\..\bsp\cm4;..\..\..\bsp\cm4\ipaldrv;..\..\..\bsp\shared;..\..\..\..\..\embot\app\mc</IncludePath>
+              <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\libs\highlevel\abslayer\ipal\api;--..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\core\core;..\..\..\..\..\embobj\core\exec\multitask;..\..\..\..\..\embobj\plus\ipnet;..\src\emb-env;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\prot\eth;..\..\bsp;..\cfg;..\..\bsp\ipaldrv;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\..\..\embobj\plus\embenv;..\..\..\..\..\libs\highlevel\abslayer\hal2\api;..\..\..\..\..\embobj\plus\ctrloop;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\icub;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\app\eth;.;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\transport;..\..\..\..\..\..\..\..\..\icub-firmware-shared\eth\embobj\plus\comm-v2\protocol\api;..\cfg\protocol\rop;..\..\..\..\..\embobj\plus\can;..\..\..\..\ems004\appl\v2\src\eoappservices;..\..\..\..\..\embobj\plus\board;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\..\mbd\kalman_filter;..\..\..\..\..\embobj\plus\mc;..\..\..\..\..\libs\midware\hl-plus\api;..\..\..\..\..\embot\prot\can;..\..\..\..\..\mbd\wrist_decoupler;..\..\..\bsp\cm4;..\..\..\bsp\cm4\ipaldrv;..\..\..\bsp\shared;..\..\..\..\..\embot\app\mc;..\src\mbd\trajectory</IncludePath>
             </VariousControls>
           </Cads>
           <Aads>
@@ -2255,6 +2255,16 @@
               <FileName>embot_app_mc_Trajectory.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\app\mc\embot_app_mc_Trajectory.cpp</FilePath>
+            </File>
+          </Files>
+        </Group>
+        <Group>
+          <GroupName>embot::app::mc::mbd</GroupName>
+          <Files>
+            <File>
+              <FileName>Trajectory1.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\src\mbd\trajectory\Trajectory1.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory1.cpp
@@ -1,0 +1,950 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: Trajectory.cpp
+//
+// Code generated for Simulink model 'Trajectory'.
+//
+// Model version                  : 1.211
+// Simulink Coder version         : 24.2 (R2024b) 21-Jun-2024
+// C/C++ source code generated on : Thu Apr 24 14:56:11 2025
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#include "Trajectory1.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include "Trajectory_types.h"
+#include <cmath>
+#include <cstring>
+
+namespace namespace_s1
+{
+  //
+  // Output and update for action system:
+  //    '<S24>/If Action Subsystem'
+  //    '<S22>/If Action Subsystem'
+  //
+  void Trajectory::Trajectory_IfActionSubsystem(bool rtu_bVelocityMove, float
+    rtu_vTimer, float rtu_vT, float *rty_vn)
+  {
+    // SignalConversion generated from: '<S30>/vn' incorporates:
+    //   Constant: '<S30>/Constant'
+
+    *rty_vn = 0.0F;
+
+    // If: '<S30>/If' incorporates:
+    //   Logic: '<S30>/OR'
+    //   RelationalOperator: '<S30>/Less Than'
+
+    if (rtu_bVelocityMove || (rtu_vTimer < rtu_vT)) {
+      // Outputs for IfAction SubSystem: '<S30>/If Action Subsystem' incorporates:
+      //   ActionPort: '<S34>/Action Port'
+
+      // FunctionCaller: '<S34>/Function Caller'
+      Trajectory_velocity_stop();
+
+      // End of Outputs for SubSystem: '<S30>/If Action Subsystem'
+    }
+
+    // End of If: '<S30>/If'
+  }
+}
+
+namespace namespace_s1
+{
+  //
+  // Output and update for action system:
+  //    '<S24>/If Action Subsystem1'
+  //    '<S22>/If Action Subsystem1'
+  //
+  void Trajectory::Trajectory_IfActionSubsystem1(float *rty_an)
+  {
+    // SignalConversion generated from: '<S31>/an' incorporates:
+    //   Constant: '<S31>/Constant'
+
+    *rty_an = 0.0F;
+  }
+}
+
+namespace namespace_s1
+{
+  // Model step function
+  bool Trajectory::Trajectory_is_done() const
+  {
+    // Outputs for Function Call SubSystem: '<Root>/Done'
+    // SignalConversion generated from: '<S1>/Done' incorporates:
+    //   Constant: '<S17>/Constant'
+    //   DataStoreRead: '<S1>/Data Store Read'
+    //   RelationalOperator: '<S17>/Compare'
+    //   Sum: '<S1>/Add'
+
+    return Trajectory_DW.Trajectory_h.xTimer - Trajectory_DW.Trajectory_h.xT >=
+      0.0F;
+
+    // End of Outputs for SubSystem: '<Root>/Done'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_config_limits(const float rtu_pos_min, const float
+    rtu_pos_max, const float rtu_vel_max, const float rtu_acc_max)
+  {
+    // Outputs for Function Call SubSystem: '<Root>/config_limits'
+    // BusAssignment: '<S3>/Bus Assignment' incorporates:
+    //   DataStoreWrite: '<S3>/Data Store Write'
+    //   SignalConversion generated from: '<S3>/pos_max'
+    //   SignalConversion generated from: '<S3>/pos_min'
+
+    Trajectory_DW.Trajectory_h.pos_min = rtu_pos_min;
+    Trajectory_DW.Trajectory_h.pos_max = rtu_pos_max;
+
+    // Switch: '<S3>/Switch' incorporates:
+    //   SignalConversion generated from: '<S3>/vel_max'
+
+    if (rtu_vel_max != 0.0F) {
+      // BusAssignment: '<S3>/Bus Assignment' incorporates:
+      //   DataStoreWrite: '<S3>/Data Store Write'
+
+      Trajectory_DW.Trajectory_h.vel_max = rtu_vel_max;
+    }
+
+    // End of Switch: '<S3>/Switch'
+
+    // Switch: '<S3>/Switch1' incorporates:
+    //   SignalConversion generated from: '<S3>/acc_max'
+
+    if (rtu_acc_max != 0.0F) {
+      // BusAssignment: '<S3>/Bus Assignment' incorporates:
+      //   DataStoreWrite: '<S3>/Data Store Write'
+
+      Trajectory_DW.Trajectory_h.acc_max = rtu_acc_max;
+    }
+
+    // End of Switch: '<S3>/Switch1'
+    // End of Outputs for SubSystem: '<Root>/config_limits'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_do_step(float *rty_p, float *rty_v, float *rty_a,
+    int32_t *rty_value)
+  {
+    trajectoryhidParameters rtb_DataStoreRead_p;
+    float rtb_a;
+    float rtb_p;
+    float rtb_v;
+    float rtb_vA_k;
+    float rtb_vV_d;
+    float rtb_vX_p;
+    float rtb_xA;
+    float rtb_xV;
+    float rtb_xX;
+    int32_t tmp;
+
+    // Outputs for Function Call SubSystem: '<Root>/do_step'
+    // DataStoreRead: '<S4>/Data Store Read'
+    rtb_DataStoreRead_p = Trajectory_DW.Trajectory_h;
+
+    // Product: '<S4>/Divide' incorporates:
+    //   DataStoreRead: '<S4>/Data Store Read'
+
+    rtb_vV_d = Trajectory_DW.Trajectory_h.xTimer *
+      Trajectory_DW.Trajectory_h.xInvT;
+
+    // Sum: '<S4>/Add3' incorporates:
+    //   DataStoreRead: '<S4>/Data Store Read'
+    //   Product: '<S4>/Divide1'
+    //   Product: '<S4>/Divide2'
+    //   Product: '<S4>/Divide3'
+    //   Sum: '<S4>/Add'
+    //   Sum: '<S4>/Add1'
+
+    rtb_xA = ((Trajectory_DW.Trajectory_h.xK3 * rtb_vV_d +
+               Trajectory_DW.Trajectory_h.xK2) * rtb_vV_d +
+              Trajectory_DW.Trajectory_h.xK1) * rtb_vV_d +
+      Trajectory_DW.Trajectory_h.xK0;
+
+    // Switch: '<S4>/Switch' incorporates:
+    //   DataStoreRead: '<S4>/Data Store Read'
+    //   Gain: '<S4>/Gain'
+    //   Sum: '<S4>/Add4'
+    //   Sum: '<S4>/Add6'
+    //   Switch: '<S4>/Switch1'
+
+    if (Trajectory_DW.Trajectory_h.xTimer - Trajectory_DW.Trajectory_h.xT > 0.0F)
+    {
+      rtb_xA = 0.0F;
+      rtb_xV = 0.0F;
+    } else {
+      rtb_xV = 0.001F * rtb_xA + Trajectory_DW.Trajectory_h.xV;
+    }
+
+    // End of Switch: '<S4>/Switch'
+
+    // Sum: '<S4>/Add2' incorporates:
+    //   DataStoreRead: '<S4>/Data Store Read'
+    //   Gain: '<S4>/Gain2'
+
+    rtb_xX = 0.001F * rtb_xV + Trajectory_DW.Trajectory_h.xX;
+
+    // Switch: '<S4>/Switch4' incorporates:
+    //   Constant: '<S4>/Constant3'
+    //   DataStoreRead: '<S4>/Data Store Read'
+    //   Sum: '<S4>/Add12'
+
+    if (Trajectory_DW.Trajectory_h.vTimer - Trajectory_DW.Trajectory_h.vT > 0.0F)
+    {
+      // Switch: '<S4>/Switch2' incorporates:
+      //   Constant: '<S4>/Constant2'
+
+      if (Trajectory_DW.Trajectory_h.bVelocityMove) {
+        tmp = 2;
+      } else {
+        tmp = 0;
+      }
+
+      // End of Switch: '<S4>/Switch2'
+    } else {
+      tmp = 1;
+    }
+
+    // SwitchCase: '<S4>/Switch Case' incorporates:
+    //   Switch: '<S4>/Switch4'
+
+    switch (tmp) {
+     case 1:
+      // Outputs for IfAction SubSystem: '<S4>/vTimer-vT' incorporates:
+      //   ActionPort: '<S21>/Action Port'
+
+      // Product: '<S21>/Divide4' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+
+      rtb_vV_d = Trajectory_DW.Trajectory_h.vTimer *
+        Trajectory_DW.Trajectory_h.vInvT;
+
+      // Sum: '<S21>/Add8' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   Product: '<S21>/Divide5'
+      //   Product: '<S21>/Divide6'
+      //   Sum: '<S21>/Add7'
+
+      rtb_vA_k = (Trajectory_DW.Trajectory_h.vK2 * rtb_vV_d +
+                  Trajectory_DW.Trajectory_h.vK1) * rtb_vV_d +
+        Trajectory_DW.Trajectory_h.vK0;
+
+      // Sum: '<S21>/Add9' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   Gain: '<S21>/Gain1'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_vV_d = 0.001F * rtb_vA_k + Trajectory_DW.Trajectory_h.vV;
+
+      // Sum: '<S21>/Add10' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   Gain: '<S21>/Gain3'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_vX_p = 0.001F * rtb_vV_d + Trajectory_DW.Trajectory_h.vX;
+
+      // Sum: '<S21>/Add'
+      rtb_p = rtb_vX_p + rtb_xX;
+
+      // Sum: '<S21>/Add1'
+      rtb_v = rtb_vV_d + rtb_xV;
+
+      // Sum: '<S21>/Add2'
+      rtb_a = rtb_vA_k + rtb_xA;
+
+      // End of Outputs for SubSystem: '<S4>/vTimer-vT'
+      break;
+
+     case 2:
+      // Outputs for IfAction SubSystem: '<S4>/bVelocityMove' incorporates:
+      //   ActionPort: '<S20>/Action Port'
+
+      // SignalConversion generated from: '<S20>/vAn' incorporates:
+      //   Constant: '<S20>/Constant'
+
+      rtb_vA_k = 0.0F;
+
+      // Sum: '<S20>/Add12' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   Gain: '<S20>/Gain4'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+      //
+      rtb_vX_p = 0.001F * Trajectory_DW.Trajectory_h.vV +
+        Trajectory_DW.Trajectory_h.vX;
+
+      // Sum: '<S20>/Add'
+      rtb_p = rtb_vX_p + rtb_xX;
+
+      // Sum: '<S20>/Add1' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_v = Trajectory_DW.Trajectory_h.vV + rtb_xV;
+
+      // SignalConversion generated from: '<S20>/vVn' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_vV_d = Trajectory_DW.Trajectory_h.vV;
+
+      // SignalConversion generated from: '<S20>/xA'
+      rtb_a = rtb_xA;
+
+      // End of Outputs for SubSystem: '<S4>/bVelocityMove'
+      break;
+
+     default:
+      // Outputs for IfAction SubSystem: '<S4>/Switch Case Action Subsystem2' incorporates:
+      //   ActionPort: '<S19>/Action Port'
+
+      // SignalConversion generated from: '<S19>/xX'
+      rtb_p = rtb_xX;
+
+      // SignalConversion generated from: '<S19>/xV'
+      rtb_v = rtb_xV;
+
+      // SignalConversion generated from: '<S19>/xA'
+      rtb_a = rtb_xA;
+
+      // SignalConversion generated from: '<S19>/vA' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_vA_k = Trajectory_DW.Trajectory_h.vA;
+
+      // SignalConversion generated from: '<S19>/vV' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_vV_d = Trajectory_DW.Trajectory_h.vV;
+
+      // SignalConversion generated from: '<S19>/vX' incorporates:
+      //   DataStoreRead: '<S4>/Data Store Read'
+      //   SignalConversion generated from: '<S4>/Bus Selector'
+
+      rtb_vX_p = Trajectory_DW.Trajectory_h.vX;
+
+      // End of Outputs for SubSystem: '<S4>/Switch Case Action Subsystem2'
+      break;
+    }
+
+    // End of SwitchCase: '<S4>/Switch Case'
+
+    // BusAssignment: '<S4>/Bus Assignment' incorporates:
+    //   Constant: '<S4>/Constant'
+    //   Constant: '<S4>/Constant1'
+    //   DataStoreRead: '<S4>/Data Store Read'
+    //   DataStoreWrite: '<S4>/Data Store Write'
+    //   Sum: '<S4>/Add11'
+    //   Sum: '<S4>/Add5'
+
+    Trajectory_DW.Trajectory_h.xTimer += 0.001F;
+    Trajectory_DW.Trajectory_h.vTimer += 0.001F;
+    Trajectory_DW.Trajectory_h.xA = rtb_xA;
+    Trajectory_DW.Trajectory_h.xV = rtb_xV;
+    Trajectory_DW.Trajectory_h.xX = rtb_xX;
+    Trajectory_DW.Trajectory_h.vX = rtb_vX_p;
+    Trajectory_DW.Trajectory_h.vV = rtb_vV_d;
+    Trajectory_DW.Trajectory_h.vA = rtb_vA_k;
+
+    // Outputs for Enabled SubSystem: '<S4>/Enabled Subsystem' incorporates:
+    //   EnablePort: '<S18>/Enable'
+
+    // RelationalOperator: '<S4>/Equal' incorporates:
+    //   SignalConversion generated from: '<S4>/Bus Selector'
+    //
+    if (rtb_DataStoreRead_p.pos_min != rtb_DataStoreRead_p.pos_max) {
+      // If: '<S18>/If'
+      if (rtb_p <= rtb_DataStoreRead_p.pos_min) {
+        // Outputs for IfAction SubSystem: '<S18>/If Action Subsystem2' incorporates:
+        //   ActionPort: '<S24>/Action Port'
+
+        // Merge: '<S18>/Merge' incorporates:
+        //   SignalConversion generated from: '<S24>/pos_min'
+
+        Trajectory_B.p = rtb_DataStoreRead_p.pos_min;
+
+        // If: '<S24>/If'
+        if (rtb_v < 0.0F) {
+          // Outputs for IfAction SubSystem: '<S24>/If Action Subsystem' incorporates:
+          //   ActionPort: '<S30>/Action Port'
+
+          Trajectory_IfActionSubsystem(rtb_DataStoreRead_p.bVelocityMove,
+            rtb_DataStoreRead_p.vTimer, rtb_DataStoreRead_p.vT, &Trajectory_B.v);
+
+          // End of Outputs for SubSystem: '<S24>/If Action Subsystem'
+        } else {
+          // Outputs for IfAction SubSystem: '<S24>/If Action Subsystem2' incorporates:
+          //   ActionPort: '<S32>/Action Port'
+
+          // Merge: '<S18>/Merge1' incorporates:
+          //   SignalConversion generated from: '<S32>/v'
+
+          Trajectory_B.v = rtb_v;
+
+          // End of Outputs for SubSystem: '<S24>/If Action Subsystem2'
+        }
+
+        // End of If: '<S24>/If'
+
+        // If: '<S24>/If1'
+        if (rtb_a < 0.0F) {
+          // Outputs for IfAction SubSystem: '<S24>/If Action Subsystem1' incorporates:
+          //   ActionPort: '<S31>/Action Port'
+
+          Trajectory_IfActionSubsystem1(&Trajectory_B.a);
+
+          // End of Outputs for SubSystem: '<S24>/If Action Subsystem1'
+        } else {
+          // Outputs for IfAction SubSystem: '<S24>/If Action Subsystem3' incorporates:
+          //   ActionPort: '<S33>/Action Port'
+
+          // Merge: '<S18>/Merge2' incorporates:
+          //   SignalConversion generated from: '<S33>/a'
+
+          Trajectory_B.a = rtb_a;
+
+          // End of Outputs for SubSystem: '<S24>/If Action Subsystem3'
+        }
+
+        // End of If: '<S24>/If1'
+
+        // Merge: '<S18>/Merge3' incorporates:
+        //   Constant: '<S24>/Zero'
+        //   SignalConversion generated from: '<S24>/value'
+
+        Trajectory_B.return_value = -1;
+
+        // End of Outputs for SubSystem: '<S18>/If Action Subsystem2'
+      } else if (rtb_p >= rtb_DataStoreRead_p.pos_max) {
+        // Outputs for IfAction SubSystem: '<S18>/If Action Subsystem' incorporates:
+        //   ActionPort: '<S22>/Action Port'
+
+        // Merge: '<S18>/Merge' incorporates:
+        //   SignalConversion generated from: '<S22>/pos_max'
+
+        Trajectory_B.p = rtb_DataStoreRead_p.pos_max;
+
+        // If: '<S22>/If'
+        if (rtb_v > 0.0F) {
+          // Outputs for IfAction SubSystem: '<S22>/If Action Subsystem' incorporates:
+          //   ActionPort: '<S25>/Action Port'
+
+          Trajectory_IfActionSubsystem(rtb_DataStoreRead_p.bVelocityMove,
+            rtb_DataStoreRead_p.vTimer, rtb_DataStoreRead_p.vT, &Trajectory_B.v);
+
+          // End of Outputs for SubSystem: '<S22>/If Action Subsystem'
+        } else {
+          // Outputs for IfAction SubSystem: '<S22>/If Action Subsystem2' incorporates:
+          //   ActionPort: '<S27>/Action Port'
+
+          // Merge: '<S18>/Merge1' incorporates:
+          //   SignalConversion generated from: '<S27>/v'
+
+          Trajectory_B.v = rtb_v;
+
+          // End of Outputs for SubSystem: '<S22>/If Action Subsystem2'
+        }
+
+        // End of If: '<S22>/If'
+
+        // If: '<S22>/If1'
+        if (rtb_a > 0.0F) {
+          // Outputs for IfAction SubSystem: '<S22>/If Action Subsystem1' incorporates:
+          //   ActionPort: '<S26>/Action Port'
+
+          Trajectory_IfActionSubsystem1(&Trajectory_B.a);
+
+          // End of Outputs for SubSystem: '<S22>/If Action Subsystem1'
+        } else {
+          // Outputs for IfAction SubSystem: '<S22>/If Action Subsystem3' incorporates:
+          //   ActionPort: '<S28>/Action Port'
+
+          // Merge: '<S18>/Merge2' incorporates:
+          //   SignalConversion generated from: '<S28>/a'
+
+          Trajectory_B.a = rtb_a;
+
+          // End of Outputs for SubSystem: '<S22>/If Action Subsystem3'
+        }
+
+        // End of If: '<S22>/If1'
+
+        // Merge: '<S18>/Merge3' incorporates:
+        //   Constant: '<S22>/Zero'
+        //   SignalConversion generated from: '<S22>/value'
+
+        Trajectory_B.return_value = 1;
+
+        // End of Outputs for SubSystem: '<S18>/If Action Subsystem'
+      } else {
+        // Outputs for IfAction SubSystem: '<S18>/If Action Subsystem1' incorporates:
+        //   ActionPort: '<S23>/Action Port'
+
+        // Merge: '<S18>/Merge' incorporates:
+        //   SignalConversion generated from: '<S23>/p'
+
+        Trajectory_B.p = rtb_p;
+
+        // Merge: '<S18>/Merge1' incorporates:
+        //   SignalConversion generated from: '<S23>/v'
+
+        Trajectory_B.v = rtb_v;
+
+        // Merge: '<S18>/Merge2' incorporates:
+        //   SignalConversion generated from: '<S23>/a'
+
+        Trajectory_B.a = rtb_a;
+
+        // Merge: '<S18>/Merge3' incorporates:
+        //   Constant: '<S23>/Zero'
+        //   SignalConversion generated from: '<S23>/value'
+
+        Trajectory_B.return_value = 0;
+
+        // End of Outputs for SubSystem: '<S18>/If Action Subsystem1'
+      }
+
+      // End of If: '<S18>/If'
+    }
+
+    // End of RelationalOperator: '<S4>/Equal'
+    // End of Outputs for SubSystem: '<S4>/Enabled Subsystem'
+
+    // SignalConversion generated from: '<S4>/a'
+    *rty_a = Trajectory_B.a;
+
+    // SignalConversion generated from: '<S4>/p'
+    *rty_p = Trajectory_B.p;
+
+    // SignalConversion generated from: '<S4>/v'
+    *rty_v = Trajectory_B.v;
+
+    // SignalConversion generated from: '<S4>/value'
+    *rty_value = Trajectory_B.return_value;
+
+    // End of Outputs for SubSystem: '<Root>/do_step'
+  }
+
+  // Model step function
+  int32_t Trajectory::Trajectory_get_acc_ref() const
+  {
+    // Outputs for Function Call SubSystem: '<Root>/get_acc_ref'
+    // SignalConversion generated from: '<S5>/value' incorporates:
+    //   DataStoreRead: '<S5>/Data Store Read'
+    //   DataTypeConversion: '<S5>/Data Type Conversion'
+    //   Sum: '<S5>/Add'
+
+    return static_cast<int32_t>(std::floor(Trajectory_DW.Trajectory_h.xA +
+      Trajectory_DW.Trajectory_h.vA));
+
+    // End of Outputs for SubSystem: '<Root>/get_acc_ref'
+  }
+
+  // Model step function
+  int32_t Trajectory::Trajectory_get_pos_ref() const
+  {
+    // Outputs for Function Call SubSystem: '<Root>/get_pos_ref'
+    // SignalConversion generated from: '<S6>/value' incorporates:
+    //   DataStoreRead: '<S6>/Data Store Read'
+    //   DataTypeConversion: '<S6>/Data Type Conversion'
+    //   Sum: '<S6>/Add'
+
+    return static_cast<int32_t>(std::floor(Trajectory_DW.Trajectory_h.xX +
+      Trajectory_DW.Trajectory_h.vX));
+
+    // End of Outputs for SubSystem: '<Root>/get_pos_ref'
+  }
+
+  // Model step function
+  float Trajectory::Trajectory_get_target_position() const
+  {
+    // Outputs for Function Call SubSystem: '<Root>/get_target_position'
+    // SignalConversion generated from: '<S7>/value' incorporates:
+    //   DataStoreRead: '<S7>/Data Store Read'
+
+    return Trajectory_DW.Trajectory_h.target_pos;
+
+    // End of Outputs for SubSystem: '<Root>/get_target_position'
+  }
+
+  // Model step function
+  float Trajectory::Trajectory_get_target_velocity() const
+  {
+    // Outputs for Function Call SubSystem: '<Root>/get_target_velocity'
+    // SignalConversion generated from: '<S8>/value' incorporates:
+    //   DataStoreRead: '<S8>/Data Store Read'
+
+    return Trajectory_DW.Trajectory_h.target_vel;
+
+    // End of Outputs for SubSystem: '<Root>/get_target_velocity'
+  }
+
+  // Model step function
+  int32_t Trajectory::Trajectory_get_vel_ref() const
+  {
+    // Outputs for Function Call SubSystem: '<Root>/get_vel_ref'
+    // SignalConversion generated from: '<S9>/value' incorporates:
+    //   DataStoreRead: '<S9>/Data Store Read'
+    //   DataTypeConversion: '<S9>/Data Type Conversion'
+    //   Sum: '<S9>/Add'
+
+    return static_cast<int32_t>(std::floor(Trajectory_DW.Trajectory_h.xV +
+      Trajectory_DW.Trajectory_h.vV));
+
+    // End of Outputs for SubSystem: '<Root>/get_vel_ref'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_init(const float rtu_p0, const float rtu_v0, const
+    float rtu_a0)
+  {
+    // Outputs for Function Call SubSystem: '<Root>/init'
+    // SignalConversion generated from: '<S10>/p0'
+    Trajectory_DW.Trajectory_h.xX = rtu_p0;
+
+    // SignalConversion generated from: '<S10>/v0'
+    Trajectory_DW.Trajectory_h.xV = rtu_v0;
+
+    // SignalConversion generated from: '<S10>/a0'
+    Trajectory_DW.Trajectory_h.xA = rtu_a0;
+
+    // BusAssignment: '<S10>/Bus Assignment' incorporates:
+    //   Constant: '<S10>/Constant'
+    //   DataStoreWrite: '<S10>/Data Store Write'
+
+    Trajectory_DW.Trajectory_h.xTimer = 0.0F;
+    Trajectory_DW.Trajectory_h.xT = 0.0F;
+    Trajectory_DW.Trajectory_h.vX = 0.0F;
+    Trajectory_DW.Trajectory_h.vV = 0.0F;
+    Trajectory_DW.Trajectory_h.vA = 0.0F;
+    Trajectory_DW.Trajectory_h.vTimer = 0.0F;
+    Trajectory_DW.Trajectory_h.vT = 0.0F;
+
+    // End of Outputs for SubSystem: '<Root>/init'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_set_pos_end(const float rtu_xStar, const float
+    rtu_velAvg)
+  {
+    float rtb_Divide_f;
+    float rtb_Gain_k;
+    float rtb_Reciprocal;
+    float rtb_Switch2_n;
+    float rtb_Switch_l;
+
+    // Outputs for Function Call SubSystem: '<Root>/set_pos_end'
+    // Switch: '<S39>/Switch2' incorporates:
+    //   DataStoreRead: '<S11>/Data Store Read'
+    //   RelationalOperator: '<S39>/LowerRelop1'
+    //   RelationalOperator: '<S39>/UpperRelop'
+    //   SignalConversion generated from: '<S11>/xStar'
+    //   Switch: '<S39>/Switch'
+
+    if (rtu_xStar > Trajectory_DW.Trajectory_h.pos_max) {
+      rtb_Switch2_n = Trajectory_DW.Trajectory_h.pos_max;
+    } else if (rtu_xStar < Trajectory_DW.Trajectory_h.pos_min) {
+      // Switch: '<S39>/Switch'
+      rtb_Switch2_n = Trajectory_DW.Trajectory_h.pos_min;
+    } else {
+      rtb_Switch2_n = rtu_xStar;
+    }
+
+    // End of Switch: '<S39>/Switch2'
+
+    // Sum: '<S11>/Add' incorporates:
+    //   DataStoreRead: '<S11>/Data Store Read'
+
+    rtb_Divide_f = rtb_Switch2_n - Trajectory_DW.Trajectory_h.xX;
+
+    // Switch: '<S11>/Switch' incorporates:
+    //   Constant: '<S35>/Constant'
+    //   Constant: '<S36>/Constant'
+    //   Gain: '<S11>/Gain5'
+    //   Logic: '<S11>/XOR'
+    //   RelationalOperator: '<S35>/Compare'
+    //   RelationalOperator: '<S36>/Compare'
+    //   SignalConversion generated from: '<S11>/velAvg'
+
+    if (static_cast<bool>((rtb_Divide_f > 0.0F) ^ (rtu_velAvg > 0.0F))) {
+      rtb_Switch_l = -rtu_velAvg;
+    } else {
+      rtb_Switch_l = rtu_velAvg;
+    }
+
+    // End of Switch: '<S11>/Switch'
+
+    // Switch: '<S40>/Switch2' incorporates:
+    //   DataStoreRead: '<S11>/Data Store Read'
+    //   Gain: '<S11>/Gain3'
+    //   RelationalOperator: '<S40>/LowerRelop1'
+    //   RelationalOperator: '<S40>/UpperRelop'
+    //   Switch: '<S40>/Switch'
+
+    if (rtb_Switch_l > Trajectory_DW.Trajectory_h.vel_max) {
+      rtb_Switch_l = Trajectory_DW.Trajectory_h.vel_max;
+    } else if (rtb_Switch_l < -Trajectory_DW.Trajectory_h.vel_max) {
+      // Switch: '<S40>/Switch' incorporates:
+      //   Gain: '<S11>/Gain3'
+
+      rtb_Switch_l = -Trajectory_DW.Trajectory_h.vel_max;
+    }
+
+    // End of Switch: '<S40>/Switch2'
+
+    // Gain: '<S11>/Gain1'
+    rtb_Switch_l *= 2.0F;
+
+    // Product: '<S11>/Divide'
+    rtb_Divide_f /= rtb_Switch_l;
+
+    // Product: '<S11>/Reciprocal'
+    rtb_Reciprocal = 1.0F / rtb_Divide_f;
+
+    // Gain: '<S37>/Gain' incorporates:
+    //   DataStoreRead: '<S11>/Data Store Read'
+    //   Product: '<S37>/Divide'
+    //   Sum: '<S37>/Add'
+
+    rtb_Gain_k = (Trajectory_DW.Trajectory_h.xV * rtb_Reciprocal +
+                  Trajectory_DW.Trajectory_h.xA) * 0.75F;
+
+    // Sum: '<S38>/Add1' incorporates:
+    //   DataStoreRead: '<S11>/Data Store Read'
+    //   Gain: '<S38>/Gain'
+    //   Gain: '<S38>/Gain1'
+    //   Product: '<S38>/Divide'
+    //   Sum: '<S38>/Add'
+
+    rtb_Switch_l = (0.0F - (Trajectory_DW.Trajectory_h.xV - rtb_Switch_l) *
+                    rtb_Reciprocal * 3.75F) - 1.25F *
+      Trajectory_DW.Trajectory_h.xA;
+
+    // BusAssignment: '<S11>/Bus Assignment' incorporates:
+    //   DataStoreRead: '<S11>/Data Store Read'
+    //   DataStoreWrite: '<S11>/Data Store Write'
+    //   Gain: '<S11>/Gain'
+    //   Gain: '<S11>/Gain2'
+    //   Gain: '<S11>/Gain4'
+    //   Sum: '<S11>/Add1'
+    //   Sum: '<S11>/Add2'
+
+    Trajectory_DW.Trajectory_h.xK0 = 0.5F * Trajectory_DW.Trajectory_h.xA -
+      rtb_Gain_k;
+    Trajectory_DW.Trajectory_h.xK1 = (0.0F - 0.5F *
+      Trajectory_DW.Trajectory_h.xA) - rtb_Switch_l;
+    Trajectory_DW.Trajectory_h.xK2 = rtb_Gain_k;
+    Trajectory_DW.Trajectory_h.xK3 = rtb_Switch_l;
+    Trajectory_DW.Trajectory_h.xT = rtb_Divide_f;
+    Trajectory_DW.Trajectory_h.target_pos = rtb_Switch2_n;
+    Trajectory_DW.Trajectory_h.xInvT = rtb_Reciprocal;
+    Trajectory_DW.Trajectory_h.xTimer = -rtb_Divide_f;
+
+    // End of Outputs for SubSystem: '<Root>/set_pos_end'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_set_pos_raw(const float rtu_p0)
+  {
+    float rtb_Switch_d;
+
+    // Outputs for Function Call SubSystem: '<Root>/set_pos_raw'
+    // Switch: '<S12>/Switch' incorporates:
+    //   DataStoreRead: '<S12>/Data Store Read'
+    //   SignalConversion generated from: '<S12>/p0'
+    //   Sum: '<S12>/Add'
+
+    if (Trajectory_DW.Trajectory_h.pos_max - Trajectory_DW.Trajectory_h.pos_min
+        != 0.0F) {
+      // Switch: '<S41>/Switch2' incorporates:
+      //   RelationalOperator: '<S41>/LowerRelop1'
+      //   RelationalOperator: '<S41>/UpperRelop'
+      //   SignalConversion generated from: '<S12>/p0'
+      //   Switch: '<S41>/Switch'
+
+      if (rtu_p0 > Trajectory_DW.Trajectory_h.pos_max) {
+        rtb_Switch_d = Trajectory_DW.Trajectory_h.pos_max;
+      } else if (rtu_p0 < Trajectory_DW.Trajectory_h.pos_min) {
+        // Switch: '<S41>/Switch'
+        rtb_Switch_d = Trajectory_DW.Trajectory_h.pos_min;
+      } else {
+        rtb_Switch_d = rtu_p0;
+      }
+
+      // End of Switch: '<S41>/Switch2'
+    } else {
+      rtb_Switch_d = rtu_p0;
+    }
+
+    // End of Switch: '<S12>/Switch'
+
+    // BusAssignment: '<S12>/Bus Assignment' incorporates:
+    //   Constant: '<S12>/Constant'
+    //   Constant: '<S12>/Constant1'
+    //   DataStoreWrite: '<S12>/Data Store Write'
+
+    Trajectory_DW.Trajectory_h.target_pos = rtb_Switch_d;
+    Trajectory_DW.Trajectory_h.xX = rtb_Switch_d;
+    Trajectory_DW.Trajectory_h.xV = 0.0F;
+    Trajectory_DW.Trajectory_h.xA = 0.0F;
+    Trajectory_DW.Trajectory_h.xTimer = 0.0F;
+    Trajectory_DW.Trajectory_h.xT = 0.0F;
+    Trajectory_DW.Trajectory_h.vX = 0.0F;
+    Trajectory_DW.Trajectory_h.vV = 0.0F;
+    Trajectory_DW.Trajectory_h.vA = 0.0F;
+    Trajectory_DW.Trajectory_h.vTimer = 0.0F;
+    Trajectory_DW.Trajectory_h.vT = 0.0F;
+    Trajectory_DW.Trajectory_h.bVelocityMove = false;
+
+    // End of Outputs for SubSystem: '<Root>/set_pos_raw'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_set_vel_end(const float rtu_vStar, const float
+    rtu_accAvg)
+  {
+    float rtb_vK0;
+    float rtb_vT;
+
+    // Outputs for Function Call SubSystem: '<Root>/set_vel_end'
+    // Gain: '<S13>/Gain' incorporates:
+    //   SignalConversion generated from: '<S13>/accAvg'
+
+    rtb_vK0 = 2.0F * rtu_accAvg;
+
+    // Product: '<S13>/Divide' incorporates:
+    //   DataStoreRead: '<S13>/Data Store Read'
+    //   SignalConversion generated from: '<S13>/vStar'
+    //   Sum: '<S13>/Add'
+
+    rtb_vT = 1.0F / rtb_vK0 * (rtu_vStar - Trajectory_DW.Trajectory_h.vV);
+
+    // Gain: '<S13>/Gain2' incorporates:
+    //   DataStoreRead: '<S13>/Data Store Read'
+
+    Trajectory_DW.Trajectory_h.vK1 = -0.5F * Trajectory_DW.Trajectory_h.vA;
+
+    // Sum: '<S13>/Add1' incorporates:
+    //   Gain: '<S13>/Gain2'
+    //   Gain: '<S13>/Gain3'
+    //   Gain: '<S13>/Gain4'
+
+    rtb_vK0 = 0.5F * Trajectory_DW.Trajectory_h.vK1 + 0.75F * rtb_vK0;
+
+    // Sum: '<S13>/Add2' incorporates:
+    //   Gain: '<S13>/Gain2'
+
+    Trajectory_DW.Trajectory_h.vK2 = (0.0F - rtb_vK0) -
+      Trajectory_DW.Trajectory_h.vK1;
+
+    // BusAssignment: '<S13>/Bus Assignment' incorporates:
+    //   Constant: '<S13>/Constant'
+    //   DataStoreWrite: '<S13>/Data Store Write'
+    //   Gain: '<S13>/Gain1'
+    //   Product: '<S13>/Reciprocal'
+    //   SignalConversion generated from: '<S13>/vStar'
+
+    Trajectory_DW.Trajectory_h.bVelocityMove = true;
+    Trajectory_DW.Trajectory_h.target_vel = rtu_vStar;
+    Trajectory_DW.Trajectory_h.vT = rtb_vT;
+    Trajectory_DW.Trajectory_h.vTimer = -rtb_vT;
+    Trajectory_DW.Trajectory_h.vInvT = 1.0F / rtb_vT;
+    Trajectory_DW.Trajectory_h.vK0 = rtb_vK0;
+
+    // End of Outputs for SubSystem: '<Root>/set_vel_end'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_start2end(const float rtu_start, const float
+    rtu_end, const float rtu_velAvg)
+  {
+    // Outputs for Function Call SubSystem: '<Root>/start2end'
+    // FunctionCaller: '<S14>/Function Caller' incorporates:
+    //   SignalConversion generated from: '<S14>/start'
+
+    Trajectory_set_pos_raw(rtu_start);
+
+    // FunctionCaller: '<S14>/Function Caller2' incorporates:
+    //   SignalConversion generated from: '<S14>/end'
+    //   SignalConversion generated from: '<S14>/velAvg'
+
+    Trajectory_set_pos_end(rtu_end, rtu_velAvg);
+
+    // End of Outputs for SubSystem: '<Root>/start2end'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_stop(const float rtu_pos)
+  {
+    // Outputs for Function Call SubSystem: '<Root>/stop'
+    // FunctionCaller: '<S15>/Function Caller4' incorporates:
+    //   SignalConversion generated from: '<S15>/pos'
+
+    Trajectory_set_pos_raw(rtu_pos);
+
+    // End of Outputs for SubSystem: '<Root>/stop'
+  }
+
+  // Model step function
+  void Trajectory::Trajectory_velocity_stop()
+  {
+    // Outputs for Function Call SubSystem: '<Root>/velocity_stop'
+    // Sum: '<S16>/Add' incorporates:
+    //   DataStoreRead: '<S16>/Data Store Read'
+
+    Trajectory_DW.Trajectory_h.xX += Trajectory_DW.Trajectory_h.vX;
+
+    // BusAssignment: '<S16>/Bus Assignment' incorporates:
+    //   Constant: '<S16>/Zero'
+    //   Constant: '<S16>/Zero1'
+    //   DataStoreWrite: '<S16>/Data Store Write'
+
+    Trajectory_DW.Trajectory_h.bVelocityMove = false;
+    Trajectory_DW.Trajectory_h.vTimer = 0.0F;
+    Trajectory_DW.Trajectory_h.vT = 0.0F;
+    Trajectory_DW.Trajectory_h.vX = 0.0F;
+    Trajectory_DW.Trajectory_h.vV = 0.0F;
+    Trajectory_DW.Trajectory_h.vA = 0.0F;
+    Trajectory_DW.Trajectory_h.target_vel = 0.0F;
+
+    // End of Outputs for SubSystem: '<Root>/velocity_stop'
+  }
+
+  // Model initialize function
+  void Trajectory::initialize()
+  {
+    // Outputs for Atomic SubSystem: '<Root>/Initialize Function'
+    // DataStoreWrite: '<S2>/Data Store Write'
+    std::memset(&Trajectory_DW.Trajectory_h, 0, sizeof(trajectoryhidParameters));
+
+    // End of Outputs for SubSystem: '<Root>/Initialize Function'
+  }
+
+  // Constructor
+  Trajectory::Trajectory():
+    Trajectory_B(),
+    Trajectory_DW()
+  {
+    // Currently there is no constructor body generated.
+  }
+
+  // Destructor
+  Trajectory::~Trajectory()
+  {
+    // Currently there is no destructor body generated.
+  }
+}
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory1.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory1.h
@@ -1,0 +1,194 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: Trajectory.h
+//
+// Code generated for Simulink model 'Trajectory'.
+//
+// Model version                  : 1.211
+// Simulink Coder version         : 24.2 (R2024b) 21-Jun-2024
+// C/C++ source code generated on : Thu Apr 24 14:56:11 2025
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef Trajectory_h_
+#define Trajectory_h_
+#include <stdbool.h>
+#include <stdint.h>
+#include "Trajectory_types.h"
+
+// Class declaration for model Trajectory
+namespace namespace_s1
+{
+  class Trajectory
+  {
+    // public data and function members
+   public:
+    // Block signals (default storage)
+    struct B_Trajectory_T {
+      float p;                         // '<S18>/Merge'
+      float v;                         // '<S18>/Merge1'
+      float a;                         // '<S18>/Merge2'
+      int32_t return_value;            // '<S18>/Merge3'
+    };
+
+    // Block states (default storage) for system '<Root>'
+    struct DW_Trajectory_T {
+      trajectoryhidParameters Trajectory_h;// '<Root>/Data Store Memory'
+    };
+
+    // model step function
+    void Trajectory_config_limits(const float rtu_pos_min, const float
+      rtu_pos_max, const float rtu_vel_max, const float rtu_acc_max);
+
+    // model step function
+    void Trajectory_do_step(float *rty_p, float *rty_v, float *rty_a, int32_t
+      *rty_value);
+
+    // model step function
+    void Trajectory_init(const float rtu_p0, const float rtu_v0, const float
+                         rtu_a0);
+
+    // model step function
+    void Trajectory_set_pos_end(const float rtu_xStar, const float rtu_velAvg);
+
+    // model step function
+    void Trajectory_set_pos_raw(const float rtu_p0);
+
+    // model step function
+    void Trajectory_set_vel_end(const float rtu_vStar, const float rtu_accAvg);
+
+    // model step function
+    void Trajectory_start2end(const float rtu_start, const float rtu_end, const
+      float rtu_velAvg);
+
+    // model step function
+    void Trajectory_stop(const float rtu_pos);
+
+    // model initialize function
+    void initialize();
+
+    // model step function
+    bool Trajectory_is_done() const;
+
+    // model step function
+    int32_t Trajectory_get_acc_ref() const;
+
+    // model step function
+    int32_t Trajectory_get_pos_ref() const;
+
+    // model step function
+    float Trajectory_get_target_position() const;
+
+    // model step function
+    float Trajectory_get_target_velocity() const;
+
+    // model step function
+    int32_t Trajectory_get_vel_ref() const;
+
+    // model step function
+    void Trajectory_velocity_stop();
+
+    // Constructor
+    Trajectory();
+
+    // Destructor
+    ~Trajectory();
+
+    // private data and function members
+   private:
+    // Block signals
+    B_Trajectory_T Trajectory_B;
+
+    // Block states
+    DW_Trajectory_T Trajectory_DW;
+
+    // private member function(s) for subsystem '<S24>/If Action Subsystem'
+    void Trajectory_IfActionSubsystem(bool rtu_bVelocityMove, float rtu_vTimer,
+      float rtu_vT, float *rty_vn);
+
+    // private member function(s) for subsystem '<S24>/If Action Subsystem1'
+    static void Trajectory_IfActionSubsystem1(float *rty_an);
+  };
+}
+
+//-
+//  These blocks were eliminated from the model due to optimizations:
+//
+//  Block '<S39>/Data Type Duplicate' : Unused code path elimination
+//  Block '<S39>/Data Type Propagation' : Unused code path elimination
+//  Block '<S40>/Data Type Duplicate' : Unused code path elimination
+//  Block '<S40>/Data Type Propagation' : Unused code path elimination
+//  Block '<S41>/Data Type Duplicate' : Unused code path elimination
+//  Block '<S41>/Data Type Propagation' : Unused code path elimination
+
+
+//-
+//  The generated code includes comments that allow you to trace directly
+//  back to the appropriate location in the model.  The basic format
+//  is <system>/block_name, where system is the system number (uniquely
+//  assigned by Simulink) and block_name is the name of the block.
+//
+//  Use the MATLAB hilite_system command to trace the generated code back
+//  to the model.  For example,
+//
+//  hilite_system('<S3>')    - opens system 3
+//  hilite_system('<S3>/Kp') - opens and selects block Kp which resides in S3
+//
+//  Here is the system hierarchy for this model
+//
+//  '<Root>' : 'Trajectory'
+//  '<S1>'   : 'Trajectory/Done'
+//  '<S2>'   : 'Trajectory/Initialize Function'
+//  '<S3>'   : 'Trajectory/config_limits'
+//  '<S4>'   : 'Trajectory/do_step'
+//  '<S5>'   : 'Trajectory/get_acc_ref'
+//  '<S6>'   : 'Trajectory/get_pos_ref'
+//  '<S7>'   : 'Trajectory/get_target_position'
+//  '<S8>'   : 'Trajectory/get_target_velocity'
+//  '<S9>'   : 'Trajectory/get_vel_ref'
+//  '<S10>'  : 'Trajectory/init'
+//  '<S11>'  : 'Trajectory/set_pos_end'
+//  '<S12>'  : 'Trajectory/set_pos_raw'
+//  '<S13>'  : 'Trajectory/set_vel_end'
+//  '<S14>'  : 'Trajectory/start2end'
+//  '<S15>'  : 'Trajectory/stop'
+//  '<S16>'  : 'Trajectory/velocity_stop'
+//  '<S17>'  : 'Trajectory/Done/Compare To Constant'
+//  '<S18>'  : 'Trajectory/do_step/Enabled Subsystem'
+//  '<S19>'  : 'Trajectory/do_step/Switch Case Action Subsystem2'
+//  '<S20>'  : 'Trajectory/do_step/bVelocityMove'
+//  '<S21>'  : 'Trajectory/do_step/vTimer-vT'
+//  '<S22>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem'
+//  '<S23>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem1'
+//  '<S24>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem2'
+//  '<S25>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem/If Action Subsystem'
+//  '<S26>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem/If Action Subsystem1'
+//  '<S27>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem/If Action Subsystem2'
+//  '<S28>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem/If Action Subsystem3'
+//  '<S29>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem/If Action Subsystem/If Action Subsystem'
+//  '<S30>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem2/If Action Subsystem'
+//  '<S31>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem2/If Action Subsystem1'
+//  '<S32>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem2/If Action Subsystem2'
+//  '<S33>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem2/If Action Subsystem3'
+//  '<S34>'  : 'Trajectory/do_step/Enabled Subsystem/If Action Subsystem2/If Action Subsystem/If Action Subsystem'
+//  '<S35>'  : 'Trajectory/set_pos_end/Compare To Zero'
+//  '<S36>'  : 'Trajectory/set_pos_end/Compare To Zero1'
+//  '<S37>'  : 'Trajectory/set_pos_end/Subsystem'
+//  '<S38>'  : 'Trajectory/set_pos_end/Subsystem2'
+//  '<S39>'  : 'Trajectory/set_pos_end/posSaturation'
+//  '<S40>'  : 'Trajectory/set_pos_end/velSaturation'
+//  '<S41>'  : 'Trajectory/set_pos_raw/Saturation Dynamic'
+
+#endif                                 // Trajectory_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory_private.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory_private.h
@@ -1,0 +1,30 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: Trajectory_private.h
+//
+// Code generated for Simulink model 'Trajectory'.
+//
+// Model version                  : 1.211
+// Simulink Coder version         : 24.2 (R2024b) 21-Jun-2024
+// C/C++ source code generated on : Thu Apr 24 14:56:11 2025
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef Trajectory_private_h_
+#define Trajectory_private_h_
+#include <stdbool.h>
+#include <stdint.h>
+#include "Trajectory_types.h"
+#endif                                 // Trajectory_private_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory_types.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/Trajectory_types.h
@@ -1,0 +1,62 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: Trajectory_types.h
+//
+// Code generated for Simulink model 'Trajectory'.
+//
+// Model version                  : 1.211
+// Simulink Coder version         : 24.2 (R2024b) 21-Jun-2024
+// C/C++ source code generated on : Thu Apr 24 14:56:11 2025
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef Trajectory_types_h_
+#define Trajectory_types_h_
+#include <stdbool.h>
+#ifndef DEFINED_TYPEDEF_FOR_trajectoryhidParameters_
+#define DEFINED_TYPEDEF_FOR_trajectoryhidParameters_
+
+struct trajectoryhidParameters
+{
+  float pos_min;
+  float pos_max;
+  float vel_max;
+  float acc_max;
+  float target_pos;
+  float xX;
+  float xV;
+  float xA;
+  float xT;
+  float xTimer;
+  bool bVelocityMove;
+  float target_vel;
+  float vX;
+  float vV;
+  float vA;
+  float vT;
+  float vTimer;
+  float xInvT;
+  float vInvT;
+  float xK0;
+  float xK1;
+  float xK2;
+  float xK3;
+  float vK0;
+  float vK1;
+  float vK2;
+};
+
+#endif
+#endif                                 // Trajectory_types_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/rtmodel.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.yri/src/mbd/trajectory/rtmodel.h
@@ -1,0 +1,50 @@
+//
+// Non-Degree Granting Education License -- for use at non-degree
+// granting, nonprofit, education, and research organizations only. Not
+// for commercial or industrial use.
+//
+// File: rtmodel.h
+//
+// Code generated for Simulink model 'Trajectory'.
+//
+// Model version                  : 1.211
+// Simulink Coder version         : 24.2 (R2024b) 21-Jun-2024
+// C/C++ source code generated on : Thu Apr 24 14:56:11 2025
+//
+// Target selection: ert.tlc
+// Embedded hardware selection: ARM Compatible->ARM Cortex-M
+// Code generation objectives: Unspecified
+// Validation result: Not run
+//
+#ifndef rtmodel_h_
+#define rtmodel_h_
+#include "Trajectory.h"
+#define MODEL_CLASSNAME                namespace_s1::Trajectory
+#define MODEL_STEPNAME                 Trajectory_step
+
+//
+//  ROOT_IO_FORMAT: 0 (Individual arguments)
+//  ROOT_IO_FORMAT: 1 (Structure reference)
+//  ROOT_IO_FORMAT: 2 (Part of model data structure)
+
+#define ROOT_IO_FORMAT                 1
+
+// Macros generated for backwards compatibility
+#ifndef rtmGetErrorStatus
+#define rtmGetErrorStatus(rtm)         ((void*) 0)
+#endif
+
+#ifndef rtmSetErrorStatus
+#define rtmSetErrorStatus(rtm, val)    ((void) 0)
+#endif
+
+#ifndef rtmGetStopRequested
+#define rtmGetStopRequested(rtm)       ((void*) 0)
+#endif
+#endif                                 // rtmodel_h_
+
+//
+// File trailer for generated code.
+//
+// [EOF]
+//

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
@@ -154,8 +154,16 @@ typedef enum {
 #define FALSE eobool_false
 #define TRUE  eobool_true
 
+
+#if defined(STM32HAL_BOARD_AMCFOC_2CM4)
+// for amcfoc, we use the new experimental MC embot::app::mc::trajectory
 #define MC_use_embot_app_mc_Trajectory
 //#define MC_use_Trajectory
+#else
+// in here we use the legacy trajectory code
+//#define MC_use_embot_app_mc_Trajectory
+#define MC_use_Trajectory
+#endif
 
 // - declaration of extern public functions ---------------------------------------------------------------------------
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/EOemsControllerCfg.h
@@ -154,6 +154,9 @@ typedef enum {
 #define FALSE eobool_false
 #define TRUE  eobool_true
 
+#define MC_use_embot_app_mc_Trajectory
+//#define MC_use_Trajectory
+
 // - declaration of extern public functions ---------------------------------------------------------------------------
 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet_hid.h
@@ -18,17 +18,35 @@
 #include "Joint.h"
 #include "Motor.h"
 #include "AbsEncoder.h"
+#include "CalibrationHelperData.h" 
+
+#if defined(MC_use_embot_app_mc_Trajectory)
+#include "embot_app_mc_Trajectory.h"
+#endif
+
+#if defined(MC_use_Trajectory)
 #include "Trajectory.h"
 #include "Trajectory_hid.h"
-#include "CalibrationHelperData.h" 
+#endif
+
+
 
 
 #ifdef WRIST_MK2
 
 enum wrist_mk_version_t {WRIST_MK_VER_2_0 = 20,  WRIST_MK_VER_2_1 = 21};
 
-/* The struct wristMk2_t contains all the data related to the wrist MK2*/
-typedef struct //wristMk2_t
+#if defined(MC_use_embot_app_mc_Trajectory)
+    struct Trajectories
+    {
+        static constexpr size_t njoints {3};    
+        embot::app::mc::Trajectory *ypr_trajectory[njoints] {nullptr, nullptr, nullptr};
+        embot::app::mc::Trajectory *prk_trajectory[njoints] {nullptr, nullptr, nullptr};
+    };
+#endif
+
+/* The struct wristMK2_t contains all the data related to the wrist MK2*/
+struct wristMK2_t
 {
     // The warmup flag is == 2 at startup and makes the wrist start a first parking move.
     // warmup == 1 means first parking in progress, and warmup == 0 means first parking done.
@@ -43,9 +61,18 @@ typedef struct //wristMk2_t
     BOOL is_right_wrist;
     
     wrist_decoupler wristDecoupler;
+
+#if defined(MC_use_embot_app_mc_Trajectory)
+//    static constexpr size_t njoints {3};    
+//    embot::app::mc::Trajectory *ypr_traj[njoints] {nullptr, nullptr, nullptr};
+//    embot::app::mc::Trajectory *prk_traj[njoints] {nullptr, nullptr, nullptr};
+    Trajectories trajectories {};
+#endif
     
+#if defined(MC_use_Trajectory)    
     Trajectory ypr_trajectory[3];
     Trajectory prk_trajectory[3];
+#endif
     
     CTRL_UNITS ypr_pos_ref[3];
     CTRL_UNITS ypr_vel_ref[3];
@@ -58,7 +85,7 @@ typedef struct //wristMk2_t
     
     CTRL_UNITS last_valid_pos[3];
 
-} wristMK2_t;
+};
 
 #endif
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint_hid.h
@@ -1,15 +1,31 @@
+
+/*
+ * Copyright (C) 2025 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
 #ifndef MC_JOINT_HID___
 #define MC_JOINT_HID___
-   
+ 
+
+#include "EOemsControllerCfg.h"
 
 #include "Pid.h"
 #include "Pid_hid.h"
-#include "Trajectory.h"
-#include "Trajectory_hid.h"
 #include "WatchDog.h"
 #include "WatchDog_hid.h"
 #include "CalibrationHelperData.h"
 #include "kalman_filter.h"
+
+#if defined(MC_use_embot_app_mc_Trajectory)
+#include "embot_app_mc_Trajectory.h"
+#endif
+
+#if defined(MC_use_Trajectory)
+#include "Trajectory.h"
+#include "Trajectory_hid.h"
+#endif
 
 
 typedef enum
@@ -161,7 +177,14 @@ struct Joint_hid
     WatchDog trq_fbk_wdog;
     WatchDog vel_ref_wdog;
     
+#if defined(MC_use_embot_app_mc_Trajectory)    
+    embot::app::mc::Trajectory *traj {nullptr};
+#endif    
+
+#if defined(MC_use_Trajectory)
     Trajectory trajectory;
+#endif
+
     
     eOmc_controlmode_t     control_mode;
     eOmc_interactionmode_t interaction_mode;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Trajectory.h
@@ -34,9 +34,10 @@ typedef struct Trajectory_hid Trajectory;
 // marco.accame on 16apr2025: not used
 // extern Trajectory* Trajectory_new(uint8_t n);
 
-
+// embot::app::mc::Trajectory::config()
 extern void Trajectory_config_limits(Trajectory *o, float pos_min, float pos_max, float vel_max, float acc_max);
 
+// embot::app::mc::Trajectory::set() for all of them
 extern void Trajectory_set_pos_end(Trajectory *o, float p1, float avg_vel);
 extern void Trajectory_set_vel_end(Trajectory *o, float v1, float avg_acc);
 extern void Trajectory_set_pos_raw(Trajectory *o, float p0);
@@ -47,10 +48,14 @@ extern void Trajectory_set_vel_raw(Trajectory *o, float v0);
 extern void Trajectory_start2end(Trajectory *o, int32_t start, float end, float velAvg);
 #endif
 
+// embot::app::mc::Trajectory::tick() once to advance simulation step + embot::app::mc::Trajectory::get() as may times we need to get the latest {p, v, a}
 extern int8_t Trajectory_do_step(Trajectory *o, float *p, float *v, float *a);
 
+// embot::app::mc::Trajectory::reset() as it is always used w/ 0 arguments
 extern void Trajectory_init(Trajectory *o, int32_t p0, int32_t v0, int32_t a0);
+// embot::app::mc::Trajectory::stop()
 extern void Trajectory_stop(Trajectory *o, int32_t pos);
+// embot::app::mc::Trajectory::stop()
 extern void Trajectory_velocity_stop(Trajectory *o);
 
 // marco.accame on 16apr2025: not used
@@ -58,8 +63,10 @@ extern void Trajectory_velocity_stop(Trajectory *o);
 // extern int32_t Trajectory_get_vel_ref(Trajectory *o);
 // extern int32_t Trajectory_get_acc_ref(Trajectory *o);
 
+// embot::app::mc::Trajectory::isdone()
 extern BOOL Trajectory_is_done(Trajectory* o);
 
+// embot::app::mc::Trajectory::get() for both of them
 extern float Trajectory_get_target_position(Trajectory* o);
 extern float Trajectory_get_target_velocity(Trajectory* o);
 

--- a/emBODY/eBcode/arch-arm/embot/app/mc/embot_app_mc_Trajectory.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/mc/embot_app_mc_Trajectory.cpp
@@ -1,0 +1,355 @@
+
+
+/*
+ * Copyright (C) 2025 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_app_mc_Trajectory.h"
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - choice of implementation by assigning a macro
+// --------------------------------------------------------------------------------------------------------------------
+
+//#define useDUMMYimplementation
+#define useLEGACYimplementation
+//#define useMBDv01implementation
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+#if defined(useDUMMYimplementation)
+// nothing is needed
+#elif defined(useLEGACYimplementation)
+#include "Trajectory.h"
+#include "Trajectory_hid.h"
+using LegacyTrajectory = Trajectory; // the one in Trajectory_hid.h
+#elif defined(useMBDv01implementation)
+// include the files from code generator
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
+// --------------------------------------------------------------------------------------------------------------------
+
+// dummy implementation
+
+#if defined(useDUMMYimplementation)
+namespace trajectory::dummy
+{
+    
+    struct Impl
+    { 
+        Impl() = default;     
+
+        bool config(const  embot::app::mc::Trajectory::Config &c) { return false; }
+        bool reset() { return false; }
+        bool set(const  embot::app::mc::Trajectory::Setpoint &s) { return false; }
+        bool tick() { return false; }
+        bool get( embot::app::mc::Trajectory::Point &target) const { return false; }
+        bool isdone() const { return false; }    
+        bool stop(const float &v) { return false; } 
+        bool stopvel() { return false; } 
+        bool start2end(int32_t start, float end, float avgvel) { return false; }         
+    };
+
+}
+#endif // #if defined(useDUMMYimplementation)
+
+
+// legacy implementation
+
+#if defined(useLEGACYimplementation)
+
+namespace trajectory::legacy
+{
+    
+    struct Impl
+    { 
+        LegacyTrajectory traj {};
+        
+        struct Status
+        {
+            uint32_t tbd {0};  
+            embot::app::mc::Trajectory::Point target {};
+            embot::app::mc::Trajectory::Setpoint setpoint {};       
+            
+            constexpr Status(uint32_t t) : tbd(t) {}
+            constexpr Status() = default;
+            bool isvalid() const { return true; }
+        };
+        
+        Status _status {};
+            
+            
+        embot::app::mc::Trajectory::Config _config {};    
+
+        Impl() = default;     
+
+        bool config(const  embot::app::mc::Trajectory::Config &c);
+        bool reset();
+        bool set(const  embot::app::mc::Trajectory::Setpoint &s);
+        bool tick();
+        bool get( embot::app::mc::Trajectory::Point &target) const;
+        bool isdone();    
+        bool stop(const float &v);
+        bool stopvel();
+        bool start2end(int32_t start, float end, float avgvel); 
+                            
+    };
+
+}
+
+
+bool trajectory::legacy::Impl::config(const embot::app::mc::Trajectory::Config &c)
+{
+    if(false == c.isvalid())
+    {
+        return false;
+    }
+    
+    _config = c;
+    
+    Trajectory_config_limits(&traj, _config.posmin, _config.posmax, _config.velmax, _config.accmax);
+    
+    return true;        
+}
+
+
+bool trajectory::legacy::Impl::reset()
+{
+    bool r {true};
+    
+    Trajectory_init(&traj, 0, 0, 0);
+    return r;
+}
+
+
+bool trajectory::legacy::Impl::set(const embot::app::mc::Trajectory::Setpoint &s)
+{
+    _status.setpoint = s;
+    bool r {true};
+    
+    switch(_status.setpoint.type)
+    {
+        case embot::app::mc::Trajectory::Setpoint::Type::POS:
+        {
+            Trajectory_set_pos_end(&traj, s.point.pos, s.point.vel);
+        } break;
+
+        case embot::app::mc::Trajectory::Setpoint::Type::VEL:
+        {
+            Trajectory_set_vel_end(&traj, s.point.vel, s.point.acc);
+        } break;   
+
+        case embot::app::mc::Trajectory::Setpoint::Type::POSraw:
+        {
+            Trajectory_set_pos_raw(&traj, s.point.pos);
+        } break; 
+
+        case embot::app::mc::Trajectory::Setpoint::Type::VELraw:
+        {
+            Trajectory_set_vel_raw(&traj, s.point.vel);
+        } break; 
+        
+        default:
+        {
+        } break;
+    }
+    
+    
+    return r;
+}
+
+bool trajectory::legacy::Impl::tick()
+{
+    bool r {true};
+     
+    float pos {};
+    float vel {};
+    float acc {};
+    Trajectory_do_step(&traj, &pos, &vel, &acc);
+    _status.target.pos = pos;
+    _status.target.vel = vel;
+    _status.target.acc = acc;
+    return r;
+}
+
+bool trajectory::legacy::Impl::get(embot::app::mc::Trajectory::Point &target) const
+{
+    bool r {true};
+    target = _status.target;
+    return r;
+}
+
+bool trajectory::legacy::Impl::isdone()
+{
+    bool r {true};
+    r = Trajectory_is_done(&traj);
+    return r;
+}
+
+bool trajectory::legacy::Impl::stop(const float &v)
+{
+    bool r {true};
+    Trajectory_stop(&traj, v);
+    return r;    
+}  
+
+
+bool trajectory::legacy::Impl::stopvel()
+{
+    bool r {true};
+    Trajectory_velocity_stop(&traj);
+    return r;    
+}  
+
+bool trajectory::legacy::Impl::start2end(int32_t start, float end, float avgvel)
+{
+    bool r {true};
+#if defined(WRIST_MK2)    
+    Trajectory_start2end(&traj, end, avgvel);
+#endif
+    return r;    
+} 
+
+#endif // #if defined(useLEGACYimplementation)
+
+
+// mbd first implementation
+
+#if defined(useMBDv01implementation)
+
+namespace trajectory::mbd01
+{
+    
+    struct Impl
+    { 
+        // just a template for now
+        
+        MyMBDclass cla {};
+        
+        Impl() = default;     
+
+        bool config(const  embot::app::mc::Trajectory::Config &c);
+        bool reset() { return false; }
+        bool set(const  embot::app::mc::Trajectory::Setpoint &s) { return false; }
+        bool tick() { return false; }
+        bool get( embot::app::mc::Trajectory::Point &target) const { return false; }
+        bool isdone() { return false; }    
+        bool stop(const float &v) { return false; }
+        bool start2end(int32_t start, float end, float avgvel) { return false; }         
+    };
+    
+    bool Impl::config(const embot::app::mc::Trajectory::Config &c)
+    {
+        if(false == c.isvalid())
+        {
+            return false;
+        }
+        
+        // my mbd
+        
+        return true;    
+    } 
+
+    bool Impl::stop(const float &v) 
+    {
+        Mode mode = cla.getmode();
+        if mode == vel)
+        {
+            cla.Trajectory_velocity_stop();
+        }
+
+    }    
+
+  
+    
+
+}
+ #endif // if defined(useMBDv01implementation)
+
+// --------------------------------------------------------------------------------------------------------------------
+// - choice of implemention
+// --------------------------------------------------------------------------------------------------------------------
+
+#if defined(useDUMMYimplementation)
+struct embot::app::mc::Trajectory::Impl : public trajectory::dummy::Impl { };
+#elif defined(useLEGACYimplementation)
+struct embot::app::mc::Trajectory::Impl : public trajectory::legacy::Impl { };
+#elif defined(useMBDv01implementation)
+struct embot::app::mc::Trajectory::Impl : public trajectory::mbd01::Impl { };
+#endif
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - pimpl interface
+// --------------------------------------------------------------------------------------------------------------------
+
+
+embot::app::mc::Trajectory::Trajectory() : pImpl(new Impl) {}
+
+
+embot::app::mc::Trajectory::~Trajectory()
+{   
+    delete pImpl;
+}
+
+
+bool embot::app::mc::Trajectory::config(const Config &c) 
+{   
+    return pImpl->config(c);
+}
+
+
+bool embot::app::mc::Trajectory::reset()
+{
+    return pImpl->reset();
+}
+
+
+bool embot::app::mc::Trajectory::set(const Setpoint &s)
+{
+    return pImpl->set(s);
+}
+
+bool embot::app::mc::Trajectory::tick()
+{
+    return pImpl->tick();
+}
+
+bool embot::app::mc::Trajectory::get(Point &target) const
+{
+    return pImpl->get(target);
+}
+
+bool embot::app::mc::Trajectory::isdone()
+{
+    return pImpl->isdone();
+}
+
+bool embot::app::mc::Trajectory::stop(const float &v)
+{
+    return pImpl->stop(v);
+}
+
+bool embot::app::mc::Trajectory::stopvel()
+{
+    return pImpl->stopvel();
+}
+
+bool embot::app::mc::Trajectory::start2end(int32_t start, float end, float avgvel)
+{
+    return pImpl->start2end(start, end, avgvel);
+}
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+

--- a/emBODY/eBcode/arch-arm/embot/app/mc/embot_app_mc_Trajectory.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/mc/embot_app_mc_Trajectory.cpp
@@ -388,7 +388,7 @@ bool trajectory::mbd01::Impl::start2end(int32_t start, float end, float avgvel)
  #endif // if defined(useMBDv01implementation)
 
 // --------------------------------------------------------------------------------------------------------------------
-// - choice of implemention
+// - choice of implementation
 // --------------------------------------------------------------------------------------------------------------------
 
 #if defined(useDUMMYimplementation)

--- a/emBODY/eBcode/arch-arm/embot/app/mc/embot_app_mc_Trajectory.h
+++ b/emBODY/eBcode/arch-arm/embot/app/mc/embot_app_mc_Trajectory.h
@@ -1,0 +1,110 @@
+
+/*
+ * Copyright (C) 2025 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame
+ * email:   marco.accame@iit.it
+*/
+
+
+// - include guard ----------------------------------------------------------------------------------------------------
+
+#ifndef __EMBOT_APP_MC_TRAJECTORY_H_
+#define __EMBOT_APP_MC_TRAJECTORY_H_
+
+
+#include "embot_core.h"
+
+
+
+namespace embot::app::mc {
+    
+    class Trajectory
+    {
+    public:
+        
+        struct Point
+        {
+            float pos {0};
+            float vel {0};
+            float acc {0}; 
+            
+            constexpr Point() = default; 
+            constexpr Point(float p, float v, float a) : pos(p), vel(v), acc(a) {}  
+                
+            void load(float p, float v, float a) { pos = p; vel = v; acc = a; }
+            void clear() { load(0, 0, 0); }             
+        };
+        
+        struct Setpoint
+        {
+            enum class Type { NONE, POS, VEL, POSraw, VELraw} ;
+            
+            Type type { Type::NONE };
+            Point point {};
+                        
+            constexpr Setpoint() = default;
+            constexpr Setpoint(Type t, float p, float v, float a) : type(t), point({p, v, a}) {}
+            constexpr Setpoint(Type t, const Point &po) : type(t), point(po) {}
+                
+            void clear() { point.clear(); type = Type::NONE; }
+                
+            void loadPOS(float p, float withvel)    { type = Type::POS; point.load(p, withvel, 0); }
+            void loadVEL(float v, float withacc)    { type = Type::VEL; point.load(0, v, withacc); }
+            void loadPOSraw(float p)                { type = Type::POSraw; point.load(p, 0, 0); }
+            void loadVELraw(float v)                { type = Type::VELraw; point.load(0, v, 0);  }
+            bool isvalid() const                    { return Type::NONE != type; }
+        };
+        
+        struct Config
+        {
+            float posmin {0};
+            float posmax {0};
+            float velmax {0};
+            float accmax {0};         
+            
+            constexpr Config(float p0, float p1, float vm, float am) : posmin(p0), posmax(p1), velmax(vm), accmax(am) {}
+            constexpr Config() = default;
+            bool isvalid() const { return true; }
+        };
+        
+                    
+        Trajectory();
+        ~Trajectory();
+    
+        bool config(const Config &config);        
+        bool reset(); 
+
+        bool set(const Setpoint &s);        
+        
+        bool tick();       
+        bool get(Point &target) const;
+        
+        bool isdone();
+        
+        // if the former setpoint is position we stop with a position
+        // else with zero velocity
+        bool stop(const float &withvalue);
+        
+        bool stopvel();
+        
+        bool start2end(int32_t start, float end, float avgvel);
+        
+        // maybe some methods to retrieve the kind of setpoint we have
+
+           
+    private:        
+        struct Impl;
+        Impl *pImpl;  
+    };  
+   
+    
+} // namespace embot::app::mc {
+
+
+
+
+#endif  // include-guard
+
+
+// - end-of-file (leave a blank line after)----------------------------------------------------------------------------
+


### PR DESCRIPTION
This PR adds support for the MBD generated code for the Trajectory generator in the MC controller.

## Description

The support is done through these steps:
- file `EOemsControllerCfg.h` contains two macros (`MC_use_Trajectory` and `MC_use_embot_app_mc_Trajectory`) that shape the code inside `Joint.c `and `JointSet.c` that have calls for the trajectory generator so that:
   - the MC controller code for trajectory is exactly as now (w/ only `MC_use_Trajectory` defined),
   - the MC controller code uses calls to the PIMPL class `embot::app::mc::Trajectory` (w/ only `MC_use_embot_app_mc_Trajectory` defined).
- the internals of `embot::app::mc::Trajectory` support several different implementations for trajectory generation that can be:
   - either the legacy code (as now),
   - or w/ MBD generated code as per model in https://github.com/robotology/icub-firmware-models/pull/114,
   - or any other future improvements of the model.

For now this support is turned off for the boards running on the robots (`amc`, `ems`, `mc4plus` and `mc2plus`) as they have  only `MC_use_Trajectory` defined.

Only the `amcfoc` board now enables the new `embot::app::mc::Trajectory` w/ the MBD generated code in its internal.


## Tests
Tests on a lego setup w/ the `amcfoc` + `tdrive` have shown that the motor moves correctly. See Figure below.

https://github.com/user-attachments/assets/a42bcea3-e271-4f3a-8f7f-3b87df015f5e

**Figure**. The lego setup w/ the `amcfoc` + `tdrive` moves a motor using `yarpmotorgui`. The trajectory is generated inside the `amcfoc.app.yri` application  using MBD generated code.


Further tests are required to assess the correctness of the trajectory as well as the efficiency (execution time) of the MBD generated code. 

After that we can turn on the MBD trajectory generator on all the boards.

## Mergeability

Only the `amcfoc` code contains new code, all the other boards continue using the old code. So we can safely merge.



