### PR TITLE
Add factory header to the amc family board tests

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/test/src/factoryTestRunner.h
+++ b/emBODY/eBcode/arch-arm/board/amc/test/src/factoryTestRunner.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Valentina Gaggero, Jacopo Losi
+ * email:   valentina.gaggero@iit.it, jacopo.losi@iit.it
+*/
+
+#ifndef __FACTORYTESTRUNNER_H_
+#define __FACTORYTESTRUNNER_H_
+
+#include "testRunnerBase.h"
+#include "testRunnerAmc_CM7.h"
+#include "testRunnerAmc_CM4.h"
+
+// std system includes
+#include <memory>
+
+
+class FactoryTestRunner
+{
+    public:
+        enum class BoardRunnerType
+        {
+            amc_cm7 = 0,
+            amc_cm4 = 1,
+            amc_bldc = 2,
+            unknown = 244,
+            dummy = 255
+        };
+        // generic base class creator made using the factory method design pattern
+        std::unique_ptr<TestRunnerBase> createTestRunner(FactoryTestRunner::BoardRunnerType boardType)
+        {
+            switch(boardType)
+            {
+                case BoardRunnerType::amc_cm7:
+                {
+                    embot::core::print("Build unique_ptr type TestRunnerAmc_CM7");
+                    return std::make_unique<TestRunnerAmc_CM7>();
+                } break;
+                case BoardRunnerType::amc_cm4:
+                {
+                    embot::core::print("Build unique_ptr type TestRunnerAmc_CM4");
+                    return std::make_unique<TestRunnerAmc_CM4>();
+                } break;
+                case BoardRunnerType::unknown:
+                case BoardRunnerType::dummy:
+                default:
+                {
+                    embot::core::print("Build unique_ptr type TestRunnerBase");
+                    return std::make_unique<TestRunnerBase>();
+                } break;
+            }
+            
+        }
+        
+        ~FactoryTestRunner() = default;
+};
+
+#endif

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 6, 0, 0},   // application version
+        {3, 7, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::Mar, embot::app::eth::Day::twentyeight, 17, 17}
+        {2025, embot::app::eth::Month::May, embot::app::eth::Day::six, 17, 17}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc2c/bsp/embot_hw_bsp_amc2c_config.h
@@ -35,6 +35,8 @@
     #define EMBOT_ENABLE_hw_timer
     #define EMBOT_ENABLE_hw_can
     
+    #define EMBOT_ENABLE_hw_mtx
+    
 #if defined(ENABLE_TEST)
     #define EMBOT_ENABLE_hw_mtx
 #else


### PR DESCRIPTION
This PR adds a missing file to the folder of amc-X test files
Moreover it align the amc2c version to the binaries in this PR: https://github.com/robotology/icub-firmware-build/pull/208
I've also re-add an include that fix correct ICC between the 2 cores of the amc2c removed in https://github.com/robotology/icub-firmware/commit/c4594da0506280bfddd79c49df2da820e3a232e5#diff-940d5e92c6f0842deed29cdb8db69b561554b434542604b6ee886829ffc330dc

cc: @Nicogene 