### PR TITLE
Fix calibration issue observed in the neck joints

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 21},
-            {2025, Month::Mar, Day::twentyeight, 17, 17}
+            {2, 22},
+            {2025, Month::Mar, Day::twentyone, 13, 13}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 7, 0, 0},   // application version
+        {3, 8, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::May, embot::app::eth::Day::six, 17, 17}
+        {2025, embot::app::eth::Month::May, embot::app::eth::Day::twentyone, 13, 13}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Joint.c
@@ -39,7 +39,6 @@
 #include "embot_app_eth_theEncoderReader.h"
 #endif
 
-    
 static void Joint_set_inner_control_flags(Joint* o);
 static BOOL Joint_set_pos_ref_in_calib(Joint* o, CTRL_UNITS pos_ref, CTRL_UNITS vel_ref);
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_AGENTadvfoc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_AGENTadvfoc.cpp
@@ -536,8 +536,14 @@ bool AGENTadvfoc::activate()
 }
   
 bool AGENTadvfoc::stop()
-{
-    // nothing is required 
+{       
+    MController_go_idle();
+    if(!(MController_get_maintenanceMode()))
+    {
+        embot::os::Thread *thr {embot::os::theScheduler::getInstance().scheduled()};
+        embot::app::eth::theErrorManager::getInstance().emit(embot::app::eth::theErrorManager::Severity::trace, {"MController_deinit()", thr}, {}, "called");        
+        MController_deinit();
+    }
     return true;        
 }
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_AGENTfoc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_AGENTfoc.cpp
@@ -380,8 +380,14 @@ bool AGENTfoc::activate()
 
 
 bool AGENTfoc::stop()
-{
-    // nothing is required 
+{      
+    MController_go_idle();
+    if(!(MController_get_maintenanceMode()))
+    {
+        embot::os::Thread *thr {embot::os::theScheduler::getInstance().scheduled()};
+        embot::app::eth::theErrorManager::getInstance().emit(embot::app::eth::theErrorManager::Severity::trace, {"MController_deinit()", thr}, {}, "called");        
+        MController_deinit();
+    }
     return true;        
 }
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_SERVICE.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_SERVICE.cpp
@@ -325,9 +325,7 @@ namespace embot::app::eth::service::impl::mc {
     {
         bool r {true};
         
-        // i just idle the controller, not the encoder reader      
-        MController_go_idle();
-        
+        // i just idle the controller, not the encoder reader    
         r = mcagents.stop();
       
         return r;          


### PR DESCRIPTION
This PR solves a problem that we have observed lately on the neck joints that can be described as follows:

- all 3 neck joints calibrate correctly
- set `neck_pitch` joint in IDLE
- move the joint outside its hardware limits triggering HW error for overcoming hw boundaries
- stop the `yarprobotinterface`
- move the joint back inside the hw boundaries
- restart the `yarprobotinterface`

Doing the previous steps we  were continuing to see the joint in hw fault at the restart even if the encoder was reading a position inside the limit. The only way to recover the problem was restarting again the `yri` or power cycle the boards.

This was due to the fact of not having the deinitialization of the motion control inside the agents `stop()` method. 
Thus we added that. 
Then, in order to keep the state machine of the whole `agents manager` clean, we moved the MC calls inside the specific agent, such as the foc or advfoc agent

Update also versions for amc and amc2c

Issue related: https://github.com/icub-tech-iit/study-icub-headedge/issues/238

`icub-firmware-build` related PR: https://github.com/robotology/icub-firmware-build/pull/209