### PR TITLE
amcfoc: quadrature encoder reading implementation

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_bsp_amcfoc_1cm7_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_bsp_amcfoc_1cm7_config.h
@@ -59,7 +59,7 @@
         #define EMBOT_ENABLE_hw_motor_adc
         #define EMBOT_ENABLE_hw_motor_enc
         #define EMBOT_ENABLE_hw_motor_pwm
-        #define  EMBOT_ENABLE_hw_analog_ish        
+        #define EMBOT_ENABLE_hw_analog_ish        
     #endif
     
     #define EMBOT_ENABLE_hw_can

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
@@ -41,6 +41,12 @@ namespace embot::hw::motor::bldc::bsp::amcfoc::cm7 {
     extern ADC_HandleTypeDef &hadcMOT2;  
     extern ADC_HandleTypeDef &hadcOTHERS; 
     
+    
+    extern TIM_HandleTypeDef htim5;
+    extern TIM_HandleTypeDef htim2;
+    
+    
+    
     struct PWMvalues
     {   // the default is for pwm @ 10.240 us ....
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
@@ -42,8 +42,10 @@ namespace embot::hw::motor::bldc::bsp::amcfoc::cm7 {
     extern ADC_HandleTypeDef &hadcOTHERS; 
     
     
-    extern TIM_HandleTypeDef htim5;
-    extern TIM_HandleTypeDef htim2;
+//    extern TIM_HandleTypeDef htim5;
+//    extern TIM_HandleTypeDef htim2;
+    extern TIM_HandleTypeDef &hTimEnc1;        // qenc
+    extern TIM_HandleTypeDef &hTimEnc2;        // qenc
     
     
     
@@ -95,6 +97,9 @@ namespace embot::hw::motor::bldc::bsp::amcfoc::cm7 {
 //    constexpr PWMvalues PWMvals {pwm066666Hz};
 //    constexpr PWMvalues PWMvals {PWM100000Hz};
     
+    
+    constexpr uint8_t QEncoder1Mode TIM_ENCODERMODE_TI12;
+    constexpr uint8_t QEncoder2Mode TIM_ENCODERMODE_TI12;
     
 }
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
@@ -42,8 +42,6 @@ namespace embot::hw::motor::bldc::bsp::amcfoc::cm7 {
     extern ADC_HandleTypeDef &hadcOTHERS; 
     
     
-//    extern TIM_HandleTypeDef htim5;
-//    extern TIM_HandleTypeDef htim2;
     extern TIM_HandleTypeDef &hTimEnc1;        // qenc
     extern TIM_HandleTypeDef &hTimEnc2;        // qenc
     

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1cm7.h
@@ -96,8 +96,10 @@ namespace embot::hw::motor::bldc::bsp::amcfoc::cm7 {
 //    constexpr PWMvalues PWMvals {PWM100000Hz};
     
     
-    constexpr uint8_t QEncoder1Mode TIM_ENCODERMODE_TI12;
-    constexpr uint8_t QEncoder2Mode TIM_ENCODERMODE_TI12;
+    constexpr auto QEncoder1Mode TIM_ENCODERMODE_TI12;
+    constexpr auto QEncoder2Mode TIM_ENCODERMODE_TI12;
+    
+    constexpr uint8_t QencICFilter = 4;
     
 }
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -685,7 +685,7 @@ void MX_TIM2_Init(void)
   {
     Error_Handler();
   }
-  sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
+  sConfig.EncoderMode = embot::hw::motor::bldc::bsp::amcfoc::cm7::QEncoder2Mode;
   sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
@@ -827,7 +827,7 @@ void MX_TIM5_Init(void)
   {
     Error_Handler();
   }
-  sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
+  sConfig.EncoderMode = embot::hw::motor::bldc::bsp::amcfoc::cm7::QEncoder1Mode;
   sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -177,7 +177,6 @@ namespace embot::hw::motor::bldc::bsp {
         if((true == cfg.has_quad_enc) && (0 != cfg.enc_resolution) && (cfg.pwm_num_polar_couples > 0))
         {
             // start the encoder
-            #warning the amcfoc must init encoder using MOTOR m
             embot::hw::motor::enc::Mode mode {cfg.enc_resolution, cfg.pwm_num_polar_couples, false, false};
             embot::hw::motor::enc::start(m, mode);
             r = true;

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -1,17 +1,14 @@
-
 /*
  * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it
 */
 
-
 // --------------------------------------------------------------------------------------------------------------------
 // - public interface
 // --------------------------------------------------------------------------------------------------------------------
 
 #include "embot_hw_motor_bldc_bsp_amcfoc_1cm7.h"
-
 
 // --------------------------------------------------------------------------------------------------------------------
 // - external dependencies
@@ -39,7 +36,6 @@ using namespace embot::core::binary;
 // --------------------------------------------------------------------------------------------------------------------
 
 #include "embot_hw_bsp_config.h"
-
 
 // --------------------------------------------------------------------------------------------------------------------
 // - support maps
@@ -184,6 +180,7 @@ namespace embot::hw::motor::bldc::bsp {
             #warning the amcfoc must init encoder using MOTOR m
             embot::hw::motor::enc::Mode mode {cfg.enc_resolution, cfg.pwm_num_polar_couples, false, false};
             embot::hw::motor::enc::start(m, mode);
+            r = true;
         }
         
         if(true == cfg.pwm_has_hall_sens)
@@ -191,11 +188,13 @@ namespace embot::hw::motor::bldc::bsp {
             // start the hall acquisition
              embot::hw::motor::hall::Mode mode { cfg.pwm_swapBC ?  embot::hw::motor::hall::Mode::SWAP::BC :  embot::hw::motor::hall::Mode::SWAP::none, cfg.pwm_hall_offset, cfg.pwm_num_polar_couples };
              embot::hw::motor::hall::start(m, mode);
+             r = true;
         }
-        
+        if ((false == cfg.has_quad_enc) && false == cfg.pwm_has_hall_sens)
+        {
+            embot::core::print("motor config wrong, no motor encoder selected");
+        }
         _configs[embot::core::tointegral(m)] = cfg;
-        
-        r = true;
         
         return r;
     }
@@ -255,10 +254,11 @@ namespace embot::hw::motor::bldc::bsp {
         {
             r = embot::hw::motor::hall::angle(m, type);
         }
-        else if(type == AngleType::hall_electrical)
-        {
+        else if(type == AngleType::quadenc_mechanical)
+        {   
+            //only mechanical angle at the moment
             r = embot::hw::motor::enc::angle(m);
-        }            
+        }
         //Angle r = (enc == Encoder::hall) ? 0.0 : 1.0;        
         //r = embot::hw::motor::hall::angle(m) OR .....;         
         return r;

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -126,7 +126,7 @@ namespace embot::hw::motor::bldc::bsp {
     bool BSP::deinit(embot::hw::MOTOR m) const
     {
         embot::hw::motor::adc::deinit(m);
-        embot::hw::motor::enc::deinit(); 
+        embot::hw::motor::enc::deinit(m); 
         embot::hw::motor::hall::deinit(m); 
         embot::hw::motor::pwm::deinit(m);
         embot::hw::analog::deinit();
@@ -154,7 +154,7 @@ namespace embot::hw::motor::bldc::bsp {
             // adc acquisition of the currents starts straigth away with ::init()
             embot::hw::motor::adc::init(m, {});         
             // then we init the encoder. we actually dont start acquisition because we do that in enc::start()            
-            embot::hw::motor::enc::init({}); 
+            embot::hw::motor::enc::init(m, {}); 
             // same applies for hall 
             embot::hw::motor::hall::init(m, {});               
             // ok, we start pwm
@@ -183,7 +183,7 @@ namespace embot::hw::motor::bldc::bsp {
             // start the encoder
             #warning the amcfoc must init encoder using MOTOR m
             embot::hw::motor::enc::Mode mode {cfg.enc_resolution, cfg.pwm_num_polar_couples, false, false};
-            embot::hw::motor::enc::start(mode);
+            embot::hw::motor::enc::start(m, mode);
         }
         
         if(true == cfg.pwm_has_hall_sens)
@@ -254,6 +254,10 @@ namespace embot::hw::motor::bldc::bsp {
         if((type == AngleType::hall_electrical) || (type == AngleType::hall_mechanical))
         {
             r = embot::hw::motor::hall::angle(m, type);
+        }
+        else if(type == AngleType::hall_electrical)
+        {
+            r = embot::hw::motor::enc::angle(m);
         }            
         //Angle r = (enc == Encoder::hall) ? 0.0 : 1.0;        
         //r = embot::hw::motor::hall::angle(m) OR .....;         

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -306,9 +306,10 @@ namespace embot::hw::motor::bldc::bsp::amcfoc::cm7 {
     TIM_HandleTypeDef &htimMOT2 = htim1;
     
     TIM_HandleTypeDef &htimTriggerOfadcOTHERS = htim15;
-
     
-    
+    TIM_HandleTypeDef &hTimEnc1 = htim5;        // qenc
+    TIM_HandleTypeDef &hTimEnc2 = htim2;        // qenc
+        
     // adc1 and adc2 sample motor currents in synch with pwm (tim1 and tim 8)
     // for each pwm cycle the adc samples the same current twice, when pwm line is low and then high.
     // hence 3 pwm cycles are required to collect all the three phases.

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -693,11 +693,11 @@ void MX_TIM2_Init(void)
   sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = 4;
+  sConfig.IC1Filter = embot::hw::motor::bldc::bsp::amcfoc::cm7::QencICFilter;
   sConfig.IC2Polarity = TIM_ICPOLARITY_RISING;
   sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC2Filter = 4;
+  sConfig.IC2Filter = embot::hw::motor::bldc::bsp::amcfoc::cm7::QencICFilter;
   if (HAL_TIM_Encoder_Init(&htim2, &sConfig) != HAL_OK)
   {
     Error_Handler();
@@ -835,11 +835,11 @@ void MX_TIM5_Init(void)
   sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = 4;
+  sConfig.IC1Filter = embot::hw::motor::bldc::bsp::amcfoc::cm7::QencICFilter; 
   sConfig.IC2Polarity = TIM_ICPOLARITY_RISING;
   sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC2Filter = 4;
+  sConfig.IC2Filter = embot::hw::motor::bldc::bsp::amcfoc::cm7::QencICFilter;
   if (HAL_TIM_Encoder_Init(&htim5, &sConfig) != HAL_OK)
   {
     Error_Handler();

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
@@ -47,8 +47,8 @@ namespace embot::hw::motor::enc {
     
 #if defined(STM32HAL_BOARD_AMCFOC_1CM7) 
    
-    #define htimEnc1    (embot::hw::motor::bldc::bsp::amcfoc::cm7::htim5)
-    #define htimEnc2 (embot::hw::motor::bldc::bsp::amcfoc::cm7::htim2)
+    #define htimEnc1  (embot::hw::motor::bldc::bsp::amcfoc::cm7::htim5)
+    #define htimEnc2  (embot::hw::motor::bldc::bsp::amcfoc::cm7::htim2)
 #endif    
     
     
@@ -128,7 +128,7 @@ extern bool deinit()
 //    HAL_TIM_Encoder_Stop(&ENC_TIM, TIM_CHANNEL_ALL);
 
 #if defined(STM32HAL_BOARD_AMCFOC_1CM7) 
-//    embot::hw::motor::bsp::amc::cm7::DeInit_TIM5();
+//    embot::hw::motor::bsp::amc::cm7::DeInit_TIM5();     //????
 #endif      
         
     
@@ -170,32 +170,6 @@ extern bool start(const Mode& mode)
     
     #warning TODO: we can use EncInit() in here
 
-//    /* Register the callback function used to signal the activation of the Index pulse */
-//    if (HAL_OK == HAL_TIM_RegisterCallback(&ENC_TIM, HAL_TIM_IC_CAPTURE_CB_ID, EncCapture_cb))
-//    {
-//        /* Clear local variables */
-////        EncStatus = ENC_STATUS_IDLE;
-////        EncAbsoluteZero = 0;
-////        EncRotorZero = 0;
-//        /* Clear counter */
-//        __HAL_TIM_SET_COUNTER(&ENC_TIM, 0);
-//        /* Start timers in encoder mode */
-//        if (HAL_OK == HAL_TIM_Encoder_Start(&ENC_TIM, TIM_CHANNEL_ALL))
-//        {
-//            /* Enable leading edge capture, without interrupts */
-//            HAL_TIM_IC_Start(&ENC_TIM, ENC_INDEX_LEADING_EDGE);
-//            /* Enable trailing edge capture, with interrupts */
-//            HAL_TIM_IC_Start_IT(&ENC_TIM, ENC_INDEX_TRAILING_EDGE);
-//            ret = true;
-//        }
-//        else
-//        {
-//            /* Failed start of the timer */
-//            HAL_TIM_UnRegisterCallback(&ENC_TIM, HAL_TIM_IC_CAPTURE_CB_ID);
-//            ret = false;
-//        }
-//    }
-//    /* Errors detected */    
        
     _enc_internals.started = ret;
     
@@ -420,19 +394,27 @@ int32_t Enc2GetRotorPosition(void)
     
 void encoder1_test(void)
 {   
-    uint8_t encoder_slots_number =25;
+    Enc1Init();
+
+    static uint8_t encoder_slots_number = 25;
+    embot::core::print( std::to_string( encoder_slots_number));
     do
     {
         embot::core::print
         ( 
-                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_10)? "H" : "L" +
-                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_11)? "H" : "L" +
-                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_12)? "H" : "L " +
+//                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_10)? "H" : "L" +
+//                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_11)? "H" : "L" +
+//                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_12)? "H" : "L " +
                     std::to_string(Enc1GetRotorPosition()) +
-                    " angle:" +
-                    std::to_string((float)Enc1GetRotorPosition()/(float)encoder_slots_number*360.0)
+                    "  angle: " +
+                    std::to_string((float)Enc1GetRotorPosition()/(float)encoder_slots_number*360.0/4) + 
+                    "  Enc1RotorZero: " +
+                    std::to_string( Enc1RotorZero)
+                     
+                    
+                    
         );
-        embot::core::wait(100);
+        embot::core::wait(10*embot::core::time1millisec);
     } while (1);
 
 }

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
@@ -1,10 +1,8 @@
-
 /*
  * Copyright (C) 2024 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it
 */
-
 
 
 
@@ -16,16 +14,12 @@
 
 #include "embot_hw_motor_enc.h"
 
-
 // --------------------------------------------------------------------------------------------------------------------
 // - external dependencies
 // --------------------------------------------------------------------------------------------------------------------
 
-
-
 #include "embot_core.h"
 #include <array>
-
 
 // --------------------------------------------------------------------------------------------------------------------
 // - configuration of peripherals and chips. it is done board by board. it contains a check vs correct STM32HAL_BOARD_*
@@ -52,17 +46,33 @@
 namespace embot::hw::motor::enc {
     
 #if defined(STM32HAL_BOARD_AMCFOC_1CM7) 
-//    #define ENC_TIM (embot::hw::motor::bldc::bsp::amcfoc::cm7::hTIM5)
+   
+    #define htimEnc1    (embot::hw::motor::bldc::bsp::amcfoc::cm7::htim5)
+    #define htimEnc2 (embot::hw::motor::bldc::bsp::amcfoc::cm7::htim2)
 #endif    
     
     
-//#define ENC_INDEX_LEADING_EDGE          TIM_CHANNEL_3
-//#define ENC_INDEX_IT_LEADING_EDGE       TIM_IT_CC3
+#define ENC_INDEX_LEADING_EDGE          TIM_CHANNEL_3
+#define ENC_INDEX_IT_LEADING_EDGE       TIM_IT_CC3
 //#define ENC_INDEX_ACTIVE_LEADING_EDGE   HAL_TIM_ACTIVE_CHANNEL_3
-//#define ENC_INDEX_TRAILING_EDGE         TIM_CHANNEL_4
-//#define ENC_INDEX_IT_TRAILING_EDGE      TIM_IT_CC4
+#define ENC_INDEX_TRAILING_EDGE         TIM_CHANNEL_4
+#define ENC_INDEX_IT_TRAILING_EDGE      TIM_IT_CC4
 //#define ENC_INDEX_ACTIVE_TRAILING_EDGE  HAL_TIM_ACTIVE_CHANNEL_4
-    
+/* Status register values */
+#define ENC_STATUS_IDLE             (0)
+#define ENC_STATUS_WAIT             (1)
+#define ENC_STATUS_READY            (2)
+/* Offset between the counting edge and the index edge */
+#define ENC_UP_COUNTING_OFFSET      (1)
+#define ENC_DOWN_COUNTING_OFFSET    (1)
+
+static uint8_t  Enc1Status = ENC_STATUS_IDLE;
+static uint32_t Enc1RotorZero;
+static uint32_t Enc1AbsoluteZero;
+
+static uint8_t  Enc2Status = ENC_STATUS_IDLE;
+static uint32_t Enc2RotorZero;
+static uint32_t Enc2AbsoluteZero;
 
 struct enc_Conversion
 {
@@ -85,7 +95,15 @@ struct enc_Internals
     Mode mode {};
     enc_Conversion conversion {};
     int32_t forcedvalue {0};    
-        
+    
+    
+    uint8_t  encStatus = ENC_STATUS_IDLE;
+    uint32_t encRotorZero = 0;
+    uint32_t encAbsoluteZero = 0;
+    
+    
+    
+    
     enc_Internals() = default;   
 };
 
@@ -102,6 +120,8 @@ extern bool init(const Configuration &config)
 
 extern bool deinit()
 {
+    Enc1DeInit();
+    Enc2DeInit();
     /* Stop any pending operation */
 //    HAL_TIM_IC_Stop_IT(&ENC_TIM, ENC_INDEX_TRAILING_EDGE);
 //    HAL_TIM_IC_Stop(&ENC_TIM, ENC_INDEX_LEADING_EDGE);
@@ -139,7 +159,9 @@ extern bool start(const Mode& mode)
 #if defined(STM32HAL_BOARD_AMCFOC_1CM7) 
 //    embot::hw::motor::bldc::bsp::amcfoc::cm7::Init_TIM5(_enc_internals.mode.resolution, _enc_internals.mode.num_polar_couples);
 #endif       
-        
+    
+    Enc1Init();
+    Enc2Init();
     
     
     // and now i can do what is required ... i also start the index ... who cares
@@ -203,7 +225,219 @@ void force(int32_t value)
 }
 
 
+//////bool EncInit(TIM_HandleTypeDef htimEncx, void (*EncxCapture_cb) , enc_Internals enc_internals)
+//////{
+//////    /* Stop any pending operation */
+//////    HAL_TIM_IC_Stop_IT(&htimEncx, ENC_INDEX_LEADING_EDGE);
+//////    HAL_TIM_IC_Stop(&htimEncx, ENC_INDEX_TRAILING_EDGE);
+//////    HAL_TIM_Encoder_Stop(&htimEncx, TIM_CHANNEL_ALL);
+
+//////    /* Register the callback function used to signal the activation of the Index pulse */
+//////    if (HAL_OK == HAL_TIM_RegisterCallback(&htimEncx, HAL_TIM_IC_CAPTURE_CB_ID, EncxCapture_cb))
+//////    {
+//////        /* Clear local variables */
+//////           
+//////        enc_internals.encStatus = ENC_STATUS_IDLE;
+//////        enc_internals.encRotorZero = 0;
+//////        enc_internals.encAbsoluteZero = 0;
+
+//////        /* Clear counter */
+//////        __HAL_TIM_SET_COUNTER(&htimEncx, 0);
+//////        /* Start timers in encoder mode */
+//////        if (HAL_OK == HAL_TIM_Encoder_Start(&htimEncx, TIM_CHANNEL_ALL))
+//////        {
+//////            /* Enable leading edge capture, without interrupts */
+//////            HAL_TIM_IC_Start(&htimEncx, ENC_INDEX_LEADING_EDGE);
+//////            /* Enable trailing edge capture, with interrupts */
+//////            HAL_TIM_IC_Start_IT(&htimEncx, ENC_INDEX_TRAILING_EDGE);
+//////            return true;
+//////        }
+//////        /* Failed start of the timer */
+//////        HAL_TIM_UnRegisterCallback(&htimEncx, HAL_TIM_IC_CAPTURE_CB_ID);
+//////    }
+//////    /* Errors detected */
+//////    return false;
+//////}
+
+
+static void Enc1Capture_cb(TIM_HandleTypeDef *htim)
+{
+    int32_t le, te, delta;
+    /* There must be a leading edge before */
+    if (0 != __HAL_TIM_GET_FLAG(&htimEnc1, ENC_INDEX_IT_LEADING_EDGE))
+    {
+        /* Read the index trailing edge position */
+        te = (int32_t)__HAL_TIM_GetCompare(&htimEnc1, ENC_INDEX_TRAILING_EDGE);
+        /* Read the index leading edge position */
+        le = (int32_t)__HAL_TIM_GetCompare(&htimEnc1, ENC_INDEX_LEADING_EDGE);
+        /* Take the difference between readings */
+        delta = te - le;
+        /* Avoid inversion of direction over the index */
+        if (0 != delta)
+        {
+            /* Update the index position */
+            Enc1RotorZero = (uint32_t)((delta>=0)? (le + ENC_UP_COUNTING_OFFSET)
+                                                 : (le - ENC_DOWN_COUNTING_OFFSET));
+            /* Mark the absolute zero position */
+            if (ENC_STATUS_WAIT == Enc1Status)
+            {
+                /* Store the absolute zero */
+                Enc1AbsoluteZero = Enc1RotorZero;
+                /* Do not repeat again */
+                Enc1Status = ENC_STATUS_READY;
+            }
+        }
+    }
+}
+
+
+int32_t Enc1GetRotorPosition(void)
+{
+    /* Read counter 32 bits value */
+    return __HAL_TIM_GetCounter(&htimEnc1) - Enc1RotorZero;
+}
+bool Enc1Init(void)
+{
+    /* Stop any pending operation */
+    HAL_TIM_IC_Stop_IT(&htimEnc1, ENC_INDEX_LEADING_EDGE);
+    HAL_TIM_IC_Stop(&htimEnc1, ENC_INDEX_TRAILING_EDGE);
+    HAL_TIM_Encoder_Stop(&htimEnc1, TIM_CHANNEL_ALL);
+
+    /* Register the callback function used to signal the activation of the Index pulse */
+    if (HAL_OK == HAL_TIM_RegisterCallback(&htimEnc1, HAL_TIM_IC_CAPTURE_CB_ID, Enc1Capture_cb))
+    {
+        /* Clear local variables */
+        Enc1Status = ENC_STATUS_IDLE;
+        Enc1AbsoluteZero = 0;
+        Enc1RotorZero = 0;
+        /* Clear counter */
+        __HAL_TIM_SET_COUNTER(&htimEnc1, 0);
+        /* Start timers in encoder mode */
+        if (HAL_OK == HAL_TIM_Encoder_Start(&htimEnc1, TIM_CHANNEL_ALL))
+        {
+            /* Enable leading edge capture, without interrupts */
+            HAL_TIM_IC_Start(&htimEnc1, ENC_INDEX_LEADING_EDGE);
+            /* Enable trailing edge capture, with interrupts */
+            HAL_TIM_IC_Start_IT(&htimEnc1, ENC_INDEX_TRAILING_EDGE);
+            return true;
+        }
+        /* Failed start of the timer */
+        HAL_TIM_UnRegisterCallback(&htimEnc1, HAL_TIM_IC_CAPTURE_CB_ID);
+    }
+    /* Errors detected */
+    return false;
+}
+
+
+void Enc1DeInit(void)
+{
+    /* Stop any pending operation */
+    HAL_TIM_IC_Stop_IT(&htimEnc1, ENC_INDEX_TRAILING_EDGE);
+    HAL_TIM_IC_Stop(&htimEnc1, ENC_INDEX_LEADING_EDGE);
+    HAL_TIM_Encoder_Stop(&htimEnc1, TIM_CHANNEL_ALL);
+    HAL_TIM_UnRegisterCallback(&htimEnc1, HAL_TIM_IC_CAPTURE_CB_ID);
+}
+
+
+
+
+static void Enc2Capture_cb(TIM_HandleTypeDef *htim)
+{
+    int32_t le, te, delta;
+    /* There must be a leading edge before */
+    if (0 != __HAL_TIM_GET_FLAG(&htimEnc2, ENC_INDEX_IT_LEADING_EDGE))
+    {
+        /* Read the index trailing edge position */
+        te = (int32_t)__HAL_TIM_GetCompare(&htimEnc2, ENC_INDEX_TRAILING_EDGE);
+        /* Read the index leading edge position */
+        le = (int32_t)__HAL_TIM_GetCompare(&htimEnc2, ENC_INDEX_LEADING_EDGE);
+        /* Take the difference between readings */
+        delta = te - le;
+        /* Avoid inversion of direction over the index */
+        if (0 != delta)
+        {
+            /* Update the index position */
+            Enc2RotorZero = (uint32_t)((delta>=0)? (le + ENC_UP_COUNTING_OFFSET)
+                                                 : (le - ENC_DOWN_COUNTING_OFFSET));
+            /* Mark the absolute zero position */
+            if (ENC_STATUS_WAIT == Enc2Status)
+            {
+                /* Store the absolute zero */
+                Enc2AbsoluteZero = Enc2RotorZero;
+                /* Do not repeat again */
+                Enc2Status = ENC_STATUS_READY;
+            }
+        }
+    }
+}
+
+bool Enc2Init(void)
+{
+    /* Stop any pending operation */
+    HAL_TIM_IC_Stop_IT(&htimEnc2, ENC_INDEX_LEADING_EDGE);
+    HAL_TIM_IC_Stop(&htimEnc2, ENC_INDEX_TRAILING_EDGE);
+    HAL_TIM_Encoder_Stop(&htimEnc2, TIM_CHANNEL_ALL);
+
+    /* Register the callback function used to signal the activation of the Index pulse */
+    if (HAL_OK == HAL_TIM_RegisterCallback(&htimEnc2, HAL_TIM_IC_CAPTURE_CB_ID, Enc2Capture_cb))
+    {
+        /* Clear local variables */
+        Enc2Status = ENC_STATUS_IDLE;
+        Enc2AbsoluteZero = 0;
+        Enc2RotorZero = 0;
+        /* Clear counter */
+        __HAL_TIM_SET_COUNTER(&htimEnc2, 0);
+        /* Start timers in encoder mode */
+        if (HAL_OK == HAL_TIM_Encoder_Start(&htimEnc2, TIM_CHANNEL_ALL))
+        {
+            /* Enable leading edge capture, without interrupts */
+            HAL_TIM_IC_Start(&htimEnc2, ENC_INDEX_LEADING_EDGE);
+            /* Enable trailing edge capture, with interrupts */
+            HAL_TIM_IC_Start_IT(&htimEnc2, ENC_INDEX_TRAILING_EDGE);
+            return true;
+        }
+        /* Failed start of the timer */
+        HAL_TIM_UnRegisterCallback(&htimEnc2, HAL_TIM_IC_CAPTURE_CB_ID);
+    }
+    /* Errors detected */
+    return false;
+}
+
+void Enc2DeInit(void)
+{
+    /* Stop any pending operation */
+    HAL_TIM_IC_Stop_IT(&htimEnc2, ENC_INDEX_TRAILING_EDGE);
+    HAL_TIM_IC_Stop(&htimEnc2, ENC_INDEX_LEADING_EDGE);
+    HAL_TIM_Encoder_Stop(&htimEnc2, TIM_CHANNEL_ALL);
+    HAL_TIM_UnRegisterCallback(&htimEnc2, HAL_TIM_IC_CAPTURE_CB_ID);
+}
+
+int32_t Enc2GetRotorPosition(void)
+{
+    /* Read counter 32 bits value */
+    return __HAL_TIM_GetCounter(&htimEnc2) - Enc2RotorZero;
+}
     
+void encoder1_test(void)
+{   
+    uint8_t encoder_slots_number =25;
+    do
+    {
+        embot::core::print
+        ( 
+                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_10)? "H" : "L" +
+                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_11)? "H" : "L" +
+                    HAL_GPIO_ReadPin(GPIOH, GPIO_PIN_12)? "H" : "L " +
+                    std::to_string(Enc1GetRotorPosition()) +
+                    " angle:" +
+                    std::to_string((float)Enc1GetRotorPosition()/(float)encoder_slots_number*360.0)
+        );
+        embot::core::wait(100);
+    } while (1);
+
+}
+
+
 } // namespace embot::hw::motor::enc {
 
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
@@ -60,7 +60,6 @@ namespace embot::hw::motor::enc {
     #define htimEnc1  (embot::hw::motor::bldc::bsp::amcfoc::cm7::hTimEnc1)
     #define htimEnc2  (embot::hw::motor::bldc::bsp::amcfoc::cm7::hTimEnc2)
             
-//    std::array<TIM_HandleTypeDef, embot::hw::motor::bldc::MAXnumber> htimEnc {htimEnc1,htimEnc2};
     
     std::array<uint8_t, embot::hw::motor::bldc::MAXnumber> QEncMode {bldc::bsp::amcfoc::cm7::QEncoder1Mode,bldc::bsp::amcfoc::cm7::QEncoder2Mode};
     
@@ -257,7 +256,7 @@ bool Enc1Init(embot::hw::MOTOR m)
     
     if(TIM_ENCODERMODE_TI12 == QEncMode[motorIndex]) 
     {
-        embot::core::print("Enc Divider = 4");
+//        embot::core::print("Enc Divider = 4");
         _enc_internals._items[motorIndex].divider = 4;
     }
     else if (TIM_ENCODERMODE_TI2  == QEncMode[motorIndex]) 
@@ -272,15 +271,14 @@ bool Enc1Init(embot::hw::MOTOR m)
     }
     
     _enc_internals._items[motorIndex].conversionfactor = 360.0/(float)_enc_internals._items[motorIndex].divider/(float)_enc_internals._items[motorIndex].mode.resolution;
-    embot::core::print(
-        "Enc Resolution: " +
-        std::to_string(_enc_internals._items[motorIndex].mode.resolution)+
-        " Enc Conversionfactor: "+
-        std::to_string(_enc_internals._items[motorIndex].conversionfactor)
+//    embot::core::print(
+//        "Enc Resolution: " +
+//        std::to_string(_enc_internals._items[motorIndex].mode.resolution)+
+//        " Enc Conversionfactor: "+
+//        std::to_string(_enc_internals._items[motorIndex].conversionfactor) 
+//    );
     
-    );
-    
-    
+
     /* Register the callback function used to signal the activation of the Index pulse */
     if (HAL_OK == HAL_TIM_RegisterCallback(&htimEnc1, HAL_TIM_IC_CAPTURE_CB_ID, Enc1Capture_cb))
     {
@@ -305,7 +303,6 @@ bool Enc1Init(embot::hw::MOTOR m)
     /* Errors detected */
     return false;
 }
-
 
 
 
@@ -358,7 +355,7 @@ bool Enc2Init(embot::hw::MOTOR m)
     
     if(TIM_ENCODERMODE_TI12 == QEncMode[motorIndex]) 
     {
-        embot::core::print("Enc Divider = 4");
+//        embot::core::print("Enc Divider = 4");
         _enc_internals._items[motorIndex].divider = 4;
     }
     else if (TIM_ENCODERMODE_TI2  == QEncMode[motorIndex]) 
@@ -477,7 +474,14 @@ void encoder1_test(void)
 
 }
 
-
+void Enc1DeInit(void)
+{
+    /* Stop any pending operation */
+    HAL_TIM_IC_Stop_IT(&htimEnc1, ENC_INDEX_TRAILING_EDGE);
+    HAL_TIM_IC_Stop(&htimEnc1, ENC_INDEX_LEADING_EDGE);
+    HAL_TIM_Encoder_Stop(&htimEnc1, TIM_CHANNEL_ALL);
+    HAL_TIM_UnRegisterCallback(&htimEnc1, HAL_TIM_IC_CAPTURE_CB_ID);
+}
 
 void Enc2DeInit(void)
 {
@@ -488,95 +492,8 @@ void Enc2DeInit(void)
     HAL_TIM_UnRegisterCallback(&htimEnc2, HAL_TIM_IC_CAPTURE_CB_ID);
 }
 
-void Enc1DeInit(void)
-{
-    /* Stop any pending operation */
-    HAL_TIM_IC_Stop_IT(&htimEnc1, ENC_INDEX_TRAILING_EDGE);
-    HAL_TIM_IC_Stop(&htimEnc1, ENC_INDEX_LEADING_EDGE);
-    HAL_TIM_Encoder_Stop(&htimEnc1, TIM_CHANNEL_ALL);
-    HAL_TIM_UnRegisterCallback(&htimEnc1, HAL_TIM_IC_CAPTURE_CB_ID);
-}
-
-
-//////bool EncInit(TIM_HandleTypeDef htimEncx, void (*EncxCapture_cb) , enc_Internals enc_internals)
-//////{
-//////    /* Stop any pending operation */
-//////    HAL_TIM_IC_Stop_IT(&htimEncx, ENC_INDEX_LEADING_EDGE);
-//////    HAL_TIM_IC_Stop(&htimEncx, ENC_INDEX_TRAILING_EDGE);
-//////    HAL_TIM_Encoder_Stop(&htimEncx, TIM_CHANNEL_ALL);
-
-//////    /* Register the callback function used to signal the activation of the Index pulse */
-//////    if (HAL_OK == HAL_TIM_RegisterCallback(&htimEncx, HAL_TIM_IC_CAPTURE_CB_ID, EncxCapture_cb))
-//////    {
-//////        /* Clear local variables */
-//////           
-//////        enc_internals.encStatus = ENC_STATUS_IDLE;
-//////        enc_internals.encIndexCounter = 0;
-//////        enc_internals.encAbsoluteZero = 0;
-
-//////        /* Clear counter */
-//////        __HAL_TIM_SET_COUNTER(&htimEncx, 0);
-//////        /* Start timers in encoder mode */
-//////        if (HAL_OK == HAL_TIM_Encoder_Start(&htimEncx, TIM_CHANNEL_ALL))
-//////        {
-//////            /* Enable leading edge capture, without interrupts */
-//////            HAL_TIM_IC_Start(&htimEncx, ENC_INDEX_LEADING_EDGE);
-//////            /* Enable trailing edge capture, with interrupts */
-//////            HAL_TIM_IC_Start_IT(&htimEncx, ENC_INDEX_TRAILING_EDGE);
-//////            return true;
-//////        }
-//////        /* Failed start of the timer */
-//////        HAL_TIM_UnRegisterCallback(&htimEncx, HAL_TIM_IC_CAPTURE_CB_ID);
-//////    }
-//////    /* Errors detected */
-//////    return false;
-//////}
-
-//float Enc1GetAngle(void)
-//{
-//    return (float)__HAL_TIM_GetCounter(&htimEnc1)*_enc_internals._items[0].conversionfactor;
-//    //return 360.0*(Enc1CounterZeroCross + (float)(Enc1DeltaFirstCross + (__HAL_TIM_GetCounter(&htimEnc1) - Enc1RotorZero))/(float)(Enc1SlotsNumber*Enc1Divider));
-//}
-
-
-
-//struct enc_Conversion
-//{
-//    int32_t offset {0};
-//    int32_t factor {1}; 
-//    
-//    int32_t convert(int32_t v) const
-//    {
-//       return offset + (factor*v);
-//    }
-
-//    constexpr enc_Conversion() = default;  
-//    constexpr enc_Conversion(int32_t o, int32_t f) : offset(o), factor(f) {}        
-//};
-
-
-//int32_t getvalue()
-//{
-//    if(false == _enc_internals.started)
-//    {
-//        return _enc_internals.forcedvalue;
-//    }
-//    
-//    int32_t v = 0; //__HAL_TIM_GetCounter(&ENC_TIM);
-//    
-//    return _enc_internals.conversion.convert(v);
-//}
-
-
-//void force(int32_t value)
-//{
-//    _enc_internals.forcedvalue = value;
-//}
 
 } // namespace embot::hw::motor::enc {
-
-
-
 
 
 #endif // #elif defined(EMBOT_ENABLE_hw_motor_enc)

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.cpp
@@ -107,7 +107,6 @@ struct enc_Internals
         {
             started = false;
             config.acquisition = Configuration::ACQUISITION::deferred;
-//            mode.reset();
             data.reset();            
         }
         
@@ -135,11 +134,7 @@ bool init(embot::hw::MOTOR m, const Configuration &config)
 
 bool deinit(embot::hw::MOTOR m)
 {
-//    /* Stop any pending operation */
-//    HAL_TIM_IC_Stop_IT(&(htimEnc[embot::core::tointegral(m)]), ENC_INDEX_TRAILING_EDGE);
-//    HAL_TIM_IC_Stop(&htimEnc[embot::core::tointegral(m)], ENC_INDEX_LEADING_EDGE);
-//    HAL_TIM_Encoder_Stop(&htimEnc[embot::core::tointegral(m)], TIM_CHANNEL_ALL);
-//    HAL_TIM_UnRegisterCallback(&htimEnc[embot::core::tointegral(m)], HAL_TIM_IC_CAPTURE_CB_ID);
+    
     if (0 == embot::core::tointegral(m))
     {
         Enc1DeInit();
@@ -275,7 +270,7 @@ bool Enc1Init(embot::hw::MOTOR m)
 //        embot::core::print("Enc1Divider = 1");
         _enc_internals._items[motorIndex].divider = 1;
     }
-
+    
     _enc_internals._items[motorIndex].conversionfactor = 360.0/(float)_enc_internals._items[motorIndex].divider/(float)_enc_internals._items[motorIndex].mode.resolution;
     embot::core::print(
         "Enc Resolution: " +

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -66,9 +66,9 @@ namespace embot::hw::motor::enc {
     int32_t Enc1GetRotorPosition(void);
     int32_t Enc2GetRotorPosition(void);
     
-    float GetEncRotorZeroAngle(embot::hw::MOTOR m);
+    float GetencIndexAngle(embot::hw::MOTOR m);
 
-    float GetencFirstIndexRotorZeroAngle(embot::hw::MOTOR m);
+    float GetencFirstIndexCrossAngle(embot::hw::MOTOR m);
     
     
     void Enc1DeInit(void);

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -13,6 +13,8 @@
 #include "embot_core.h"
 #include "embot_hw.h"
 
+#include "stm32hal.h"
+
 #if 0
 
 this API exposes what is required to move the motor using embot::hw::motor
@@ -56,17 +58,41 @@ namespace embot::hw::motor::enc {
 //    int32_t getvalue(); 
 //    void force(int32_t value);
     float angle(embot::hw::MOTOR m);
-    float Enc1GetAngle();
+
     
     bool Enc1Init(embot::hw::MOTOR m);
     bool Enc2Init(embot::hw::MOTOR m);
     
     int32_t Enc1GetRotorPosition(void);
     int32_t Enc2GetRotorPosition(void);
+    
+    float GetEncRotorZeroAngle(embot::hw::MOTOR m);
+
+    float GetencFirstIndexRotorZeroAngle(embot::hw::MOTOR m);
+    
+    
     void Enc1DeInit(void);
     void Enc2DeInit(void);
     
     void encoder1_test(void);
+    
+    
+    /* Common encoder constants */   
+    static constexpr auto ENC_INDEX_LEADING_EDGE = TIM_CHANNEL_3;
+    static constexpr auto ENC_INDEX_IT_LEADING_EDGE = TIM_IT_CC3;
+    static constexpr auto ENC_INDEX_TRAILING_EDGE = TIM_CHANNEL_4;
+    static constexpr auto ENC_INDEX_IT_TRAILING_EDGE = TIM_IT_CC4;
+
+    /* Status register values */
+    static constexpr auto ENC_STATUS_IDLE  = 0;
+    static constexpr auto ENC_STATUS_WAIT  = 1;
+    static constexpr auto ENC_STATUS_READY = 2;
+    
+    /* Offset between the counting edge and the index edge */
+    static constexpr auto ENC_UP_COUNTING_OFFSET = 1;
+    static constexpr auto ENC_DOWN_COUNTING_OFFSET = 1;
+
+    
     
 } // namespace embot::hw::motor::enc {
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -56,7 +56,7 @@ namespace embot::hw::motor::enc {
 //    int32_t getvalue(); 
 //    void force(int32_t value);
     float angle(embot::hw::MOTOR m);
-    
+    float Enc1GetAngle();
     
     bool Enc1Init(void);
     bool Enc2Init(void);

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -49,12 +49,13 @@ namespace embot::hw::motor::enc {
         }
     };
 
-    bool init(const Configuration &config);
-    bool deinit();
-    bool start(const Mode& mode);
-    bool isstarted();
-    int32_t getvalue(); 
-    void force(int32_t value);
+    bool init(embot::hw::MOTOR m, const Configuration &config);
+    bool deinit(embot::hw::MOTOR m);
+    bool start(embot::hw::MOTOR m, const Mode& mode);
+    bool isstarted(embot::hw::MOTOR m);
+//    int32_t getvalue(); 
+//    void force(int32_t value);
+    float angle(embot::hw::MOTOR m);
     
     
     bool Enc1Init(void);

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -56,6 +56,17 @@ namespace embot::hw::motor::enc {
     int32_t getvalue(); 
     void force(int32_t value);
     
+    
+    bool Enc1Init(void);
+    bool Enc2Init(void);
+    
+    int32_t Enc1GetRotorPosition(void);
+    int32_t Enc2GetRotorPosition(void);
+    void Enc1DeInit(void);
+    void Enc2DeInit(void);
+    
+    void encoder1_test(void);
+    
 } // namespace embot::hw::motor::enc {
 
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -58,13 +58,13 @@ namespace embot::hw::motor::enc {
     float angle(embot::hw::MOTOR m);
     float Enc1GetAngle();
     
-    bool Enc1Init(void);
+    bool Enc1Init(embot::hw::MOTOR m);
     bool Enc2Init(void);
     
     int32_t Enc1GetRotorPosition(void);
     int32_t Enc2GetRotorPosition(void);
-    void Enc1DeInit(void);
-    void Enc2DeInit(void);
+//    void Enc1DeInit(void);
+//    void Enc2DeInit(void);
     
     void encoder1_test(void);
     

--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/motorhal/embot_hw_motor_enc.h
@@ -59,12 +59,12 @@ namespace embot::hw::motor::enc {
     float Enc1GetAngle();
     
     bool Enc1Init(embot::hw::MOTOR m);
-    bool Enc2Init(void);
+    bool Enc2Init(embot::hw::MOTOR m);
     
     int32_t Enc1GetRotorPosition(void);
     int32_t Enc2GetRotorPosition(void);
-//    void Enc1DeInit(void);
-//    void Enc2DeInit(void);
+    void Enc1DeInit(void);
+    void Enc2DeInit(void);
     
     void encoder1_test(void);
     

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -928,25 +928,21 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
 
 #if defined(TEST_Quad_Encoder_Mot_1)
 
+    //this can be used to debug without sending the motor configuration
 //        embot::hw::motor::enc::encoder1_test();
-//////    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
+    
+    //this can be used by sending thr motor configuration via CAN
     if(embot::hw::motor::enc::isstarted(static_cast<embot::hw::MOTOR> (0)))
     {
-        embot::core::print("encoder started");
-//        
-//        
-////        angle_global = (int32_t) embot::hw::motor::enc::angle((embot::hw::MOTOR) 0);
-////        static uint8_t ii=1;
-////        if (ii++%150 == 0)
-////            embot::core::print(
-////        
-//////        "encoder angle:  "+
-//////        std::to_string(embot::hw::motor::enc::angle((embot::hw::MOTOR) 0)) //+
-////        
-////        
-////        "encoder angle:  "+
-////        std::to_string((int32_t) embot::hw::motor::enc::angle((embot::hw::MOTOR) 0))
-//        );
+////        embot::core::print("encoder started");
+        
+        angle_global = (int32_t) embot::hw::motor::enc::angle(static_cast<embot::hw::MOTOR> (0) );
+        static uint8_t ii=1;
+        if (ii++%150 == 0)
+            embot::core::print(
+                    "encoder angle:  " +
+                    std::to_string( (int32_t) embot::hw::motor::enc::angle(static_cast<embot::hw::MOTOR> (0) ) )
+        );
     }
 #endif //defined(TEST_Quad_Encoder_Mot_1)
     

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -926,8 +926,17 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
     
 //    //encoder test
 
-        embot::hw::motor::enc::encoder1_test();
-    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
+////        embot::hw::motor::enc::encoder1_test();
+////    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
+    if(embot::hw::motor::enc::isstarted((embot::hw::MOTOR) 0))
+    {
+        angle_global = (int32_t) embot::hw::motor::enc::angle((embot::hw::MOTOR) 0);
+        static uint8_t ii=0;
+        if (ii++%100 == 0)
+            embot::core::print(
+        "angle:  "+
+        std::to_string(angle_global));
+    }
     
 #else
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -928,16 +928,25 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
 
 #if defined(TEST_Quad_Encoder_Mot_1)
 
-////        embot::hw::motor::enc::encoder1_test();
-////    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
-    if(embot::hw::motor::enc::isstarted((embot::hw::MOTOR) 0))
+//        embot::hw::motor::enc::encoder1_test();
+//////    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
+    if(embot::hw::motor::enc::isstarted(static_cast<embot::hw::MOTOR> (0)))
     {
-        angle_global = (int32_t) embot::hw::motor::enc::angle((embot::hw::MOTOR) 0);
-        static uint8_t ii=0;
-        if (ii++%100 == 0)
-            embot::core::print(
-        "angle:  "+
-        std::to_string(angle_global));
+        embot::core::print("encoder started");
+//        
+//        
+////        angle_global = (int32_t) embot::hw::motor::enc::angle((embot::hw::MOTOR) 0);
+////        static uint8_t ii=1;
+////        if (ii++%150 == 0)
+////            embot::core::print(
+////        
+//////        "encoder angle:  "+
+//////        std::to_string(embot::hw::motor::enc::angle((embot::hw::MOTOR) 0)) //+
+////        
+////        
+////        "encoder angle:  "+
+////        std::to_string((int32_t) embot::hw::motor::enc::angle((embot::hw::MOTOR) 0))
+//        );
     }
 #endif //defined(TEST_Quad_Encoder_Mot_1)
     

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -26,6 +26,9 @@ int32_t CU1 = 0;
 int32_t CU2 = 0;
 int32_t CU3 = 0;
 
+
+int32_t angle_global=0;
+
 // --------------------------------------------------------------------------------------------------------------------
 // - defines
 // --------------------------------------------------------------------------------------------------------------------
@@ -922,8 +925,9 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
 //    #warning this is enabled
     
 //    //encoder test
-//    embot::hw::motor::enc::encoder1_test();
-        
+
+        embot::hw::motor::enc::encoder1_test();
+    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
     
 #else
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -919,10 +919,10 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
         outputmessages.push_back(msg);
     }
     
-    #warning this is enabled
+//    #warning this is enabled
     
-    //encoder test
-    embot::hw::motor::enc::encoder1_test();
+//    //encoder test
+//    embot::hw::motor::enc::encoder1_test();
         
     
 #else

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -136,6 +136,9 @@ int32_t CU3 = 0;
 #include "embot_hw_motor_hall.h"
 #include "embot_hw_analog.h"
 
+
+#include "embot_hw_motor_enc.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 // - pimpl: private implementation (see scott meyers: item 22 of effective modern c++, item 31 of effective c++
 // --------------------------------------------------------------------------------------------------------------------
@@ -914,7 +917,12 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
         embot::app::msg::Location l {bus2use, _config.adr};
         embot::app::bldc::MSG msg {l, o};
         outputmessages.push_back(msg);
-    }  
+    }
+    
+    #warning this is enabled
+    
+    //encoder test
+    embot::hw::motor::enc::encoder1_test();
         
     
 #else

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -931,11 +931,10 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
     //this can be used to debug without sending the motor configuration
 //        embot::hw::motor::enc::encoder1_test();
     
+    
     //this can be used by sending thr motor configuration via CAN
     if(embot::hw::motor::enc::isstarted(static_cast<embot::hw::MOTOR> (0)))
-    {
-////        embot::core::print("encoder started");
-        
+    {        
         angle_global = (int32_t) embot::hw::motor::enc::angle(static_cast<embot::hw::MOTOR> (0) );
         static uint8_t ii=1;
         if (ii++%150 == 0)

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -46,6 +46,9 @@ int32_t angle_global=0;
 
 //#define DEBUG_PWM_min_0perc
 
+#define TEST_Quad_Encoder_Mot_1
+
+
 // -
 // - MBD code section
 // -
@@ -922,9 +925,8 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
         outputmessages.push_back(msg);
     }
     
-//    #warning this is enabled
-    
-//    //encoder test
+
+#if defined(TEST_Quad_Encoder_Mot_1)
 
 ////        embot::hw::motor::enc::encoder1_test();
 ////    angle_global = (int32_t) embot::hw::motor::enc::Enc1GetAngle();
@@ -937,6 +939,7 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
         "angle:  "+
         std::to_string(angle_global));
     }
+#endif //defined(TEST_Quad_Encoder_Mot_1)
     
 #else
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/src/app-board-amc1cm7/embot_app_board_amcfoc_1cm7_theMBD.cpp
@@ -27,8 +27,6 @@ int32_t CU2 = 0;
 int32_t CU3 = 0;
 
 
-int32_t angle_global=0;
-
 // --------------------------------------------------------------------------------------------------------------------
 // - defines
 // --------------------------------------------------------------------------------------------------------------------
@@ -46,8 +44,11 @@ int32_t angle_global=0;
 
 //#define DEBUG_PWM_min_0perc
 
-#define TEST_Quad_Encoder_Mot_1
+//#define TEST_Quad_Encoder_Mot_1
 
+#if defined(TEST_Quad_Encoder_Mot_1)
+    int32_t angle_global=0;
+#endif
 
 // -
 // - MBD code section
@@ -932,7 +933,7 @@ bool embot::app::board::amcfoc::cm7::theMBD::Impl::tick(const std::vector<embot:
 //        embot::hw::motor::enc::encoder1_test();
     
     
-    //this can be used by sending thr motor configuration via CAN
+    //this can be used by sending the motor configuration via CAN
     if(embot::hw::motor::enc::isstarted(static_cast<embot::hw::MOTOR> (0)))
     {        
         angle_global = (int32_t) embot::hw::motor::enc::angle(static_cast<embot::hw::MOTOR> (0) );

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.h
@@ -74,7 +74,7 @@ namespace embot::hw::motor::bldc {
     
     using Angle = float; // in [degrees]
     
-    enum class AngleType : uint8_t { hall_electrical = 0, hall_mechanical = 2, quadenc = 3 };
+    enum class AngleType : uint8_t { hall_electrical = 0, hall_mechanical = 2, quadenc_mechanical = 3 };
     
     struct Config
     {


### PR DESCRIPTION
Adding quadrature encoder reading implementation for the `amcfoc`.

Recap of this driver: 
- it gives as output an angle given by:  $\ TimerCounter*360/EncoderResolution/TimerEncoderMode$
- pass the `index_timer_counter`, the position in `TimerCounterof` the index
- does not handle under/overflow of the timer

