### PR TITLE
Trigger i2c comm error when tdb continuously re-configure

### DIFF
--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/2FOC.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/2FOC.h
@@ -63,6 +63,7 @@ volatile extern int gTemperatureLimit;
 volatile extern int gTemperatureOverheatingCounter;
 volatile extern BOOL isTemperatureRead;
 volatile extern unsigned int i2cERRORS;
+volatile extern unsigned int i2cConfigTimeoutErrorsCounter;
 volatile extern long gQEPosition;
 volatile extern int  gQEVelocity;
 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/can_icubProto.h
@@ -29,7 +29,7 @@
 /************ FIRMWARE AND CAN PROTOCOL VERSION DEFINITION *******************************************/
 #define FW_VERSION_MAJOR          3
 #define FW_VERSION_MINOR          3
-#define FW_VERSION_BUILD          42
+#define FW_VERSION_BUILD          43
 
 #define CAN_PROTOCOL_VERSION_MAJOR      1
 #define CAN_PROTOCOL_VERSION_MINOR      6

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/i2cTsens.h
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/include/i2cTsens.h
@@ -16,6 +16,8 @@ extern "C" {
 
 #define isActiveI2CTsens() (I2C1CONbits.I2CEN)
     
+//TODO: add a struct for setting up the temperature error values instead of using a define
+    
 int setupI2CTsens(void);
 int readI2CTsens(volatile int* temperature);
 // function used for generating synthetic temperature data useful for testing 

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/2FOC.c
@@ -169,6 +169,7 @@ volatile int gTemperatureLimit = 0;
 volatile int gTemperatureOverheatingCounter = 0;
 volatile BOOL isTemperatureRead = FALSE;
 volatile unsigned int i2cERRORS = 0;
+volatile unsigned int i2cConfigTimeoutErrorsCounter = 0;
 
 volatile char sAlignInProgress = 0;
 
@@ -1310,7 +1311,7 @@ int main(void)
     {
         if (MotorConfig.has_tsens) 
         {
-            gTemperature = SetupPorts_I2C();
+            gTemperature = SetupPorts_I2C();    
         }
         else
         {

--- a/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c
+++ b/emBODY/eBcode/arch-dspic/board/2foc/appl/2FOC-V3/src/System.c
@@ -168,14 +168,21 @@ void __attribute__((__interrupt__, no_auto_psv)) _T1Interrupt(void)
                 else if (gTemperature < gTemperatureLimit)
                 {
                     gTemperatureOverheatingCounter = 0;
-                    i2cConfigTimeoutErrorsCounter = 0;
                 }
+                i2cConfigTimeoutErrorsCounter = 0;
             }
             else if(err >= -11)
             {
+                // this error is related to a failing 
+                // in conifguration of the tdb_i2c
+                // it is raised when the i2c comm goes in I2Ctimeout before getting the ACK
                 ++i2cConfigTimeoutErrorsCounter;
             }
             
+            // Error -21 is related to the following cases:
+            // - we can configure the tdb_i2c sensor but we cannot receive the ACK reply
+            // - we can receive the ACK and data config byte is valid (==0x19) but the temp data are 0x7fff
+            // - we can receive the ACK but the data config byte is not valid (!= 0x19))
             if(((err == -21) || (i2cConfigTimeoutErrorsCounter > 100)) && !SysError.I2C_CommFailure)
             {
                 SysError.I2C_CommFailure = TRUE;


### PR DESCRIPTION
This PR solves a corner case problem we had when the tdb is coupled with 1 or 2 i2c_ext (thus when using the tdb with the 2 ext or when using the new tdb_diff with one i2c_ext).
The problem generates from the following condition:
- it should be first noted that the `i2c_ext`, which is used for taking a normal i2c signal and make it differential in order to make it inert to the electromagnetic disturbances, when connected to a 2foc board is seen as a slave to the board. Therefore, we know that when it is connected to another `i2c_ext` and then to a normal `tdb` or to just a `tdb_diff` we can correctly read a temperature. However, if the connection between one `i2c_ext` and the other or the `tdb`, while the cable between the `i2c_ext` and the 2foc remains intact we won't see any communication error on either the `motorgui` or the `yarprobotinterface` even though we would not read any temperature. Instead, if the connection between the `i2c_ext` and the 2foc breaks we can detect the error. This happens because, since the `i2c_ext` is seen as a slave to the 2foc, when it cannot configure the tdb because it is not connected to it anymore, the code continues to loop between the tdb configuration and its timeout function while not generating any error.

We solved this. From the video below you can see that we triggered both cases, in order to verify that the old condition was still fine:
- first error --> i2c_ext disconnected from 2foc (old and current condition)
- second error --> i2c_ext disconnected just from `tdb_diff` (new condition)

In both cases we have the same error for 2 reasons:
- both are i2c communication errors
- we do not have any free bit in the bitmask error in the 2foc

https://github.com/user-attachments/assets/7186df85-b830-4109-803b-b4459a30d8c7


Increased version to 3.43

cc: @Nicogene 