### PR TITLE
Improving the `theEncoderReader` on dual core boards

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 22},
-            {2025, Month::Mar, Day::twentyone, 13, 13}
+            {2, 23},
+            {2025, Month::Jun, Day::nine, 13, 13}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -595,8 +595,23 @@ bool embot::app::eth::theEncoderReader::Impl::TestRead(const Config &config)
         if(resNOK == embot::hw::encoder::read(enc, pos, 5*embot::core::time1millisec))     
         {                        
             diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par16 | (1<<i);
-            
-//            embot::core::print("theEncoderReader: encoder reading fails");   
+            switch(_implconfig.jomo_cfg[i].encoder1des.type)
+            {
+                case eomc_enc_aea:
+                case eomc_enc_aea3:
+                {
+                    diagnostics.errorDescriptor.par64 = diagnostics.errorDescriptor.par64 | (embot::core::tointegral(embot::app::eth::encoder::v1::Error::AEA_READING)<<(i*4));
+                } break;
+                
+                case eomc_enc_aksim2:
+                case eomc_enc_unknown:
+                case eomc_enc_none:
+                default:
+                {
+                    diagnostics.errorDescriptor.par64 = diagnostics.errorDescriptor.par64 | (embot::core::tointegral(embot::app::eth::encoder::v1::Error::GENERIC)<<(i*4));
+                } break;
+            }
+//            embot::core::print("theEncoderReader: encoder test reading fails");   
             ret = false;            
         }
     }

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -244,7 +244,6 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
 //    }
     
   
-    
     bool _verified = true;
     constexpr bool verificationisOK {true};
 
@@ -320,7 +319,7 @@ bool embot::app::eth::theEncoderReader::Impl::IsEncoderSupported(const Config &c
             default:
             {
                 //unknown/no/unsupported encoder, pass to embot::hw::encoder::init cfg.type = embot::hw::encoder::Type::none, it will rise an error
-//                    embot::core::print("theEncoderReader: encoder unknown/none/unsupported");
+//                embot::core::print("theEncoderReader: encoder unknown/none/unsupported");
                 ret = false;
             } break;
         }
@@ -330,7 +329,7 @@ bool embot::app::eth::theEncoderReader::Impl::IsEncoderSupported(const Config &c
         embot::hw::result_t r = embot::hw::encoder::init(enc, cfg);
         if(embot::hw::resOK != r)
         {                            
-            ////        embot::core::print("theEncoderReader: encoder type not supported");
+//            embot::core::print("theEncoderReader: encoder type not supported");
             //to do: tell the specific error to yarp    
             diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par16 |((_implconfig.numofjomos)<<12);
             diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par16 | (1<<i);
@@ -601,11 +600,10 @@ bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth
 
 
 
-// I'll do one reading of the encoder
+// I'll do one reading for each one of the encoder
 bool embot::app::eth::theEncoderReader::Impl::TestRead(const Config &config)
 {
-    diagnostics.errorDescriptor.par16 = 0; 
-    diagnostics.errorDescriptor.par64 = 0;
+    diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par64 = 0;
     diagnostics.errorDescriptor.code = eoerror_code_get(eoerror_category_HardWare,eoerror_value_HW_encoder_not_connected);  
     diagnostics.errorDescriptor.sourcedevice = eo_errman_sourcedevice_localboard;
     diagnostics.errorDescriptor.sourceaddress = 0;
@@ -613,8 +611,8 @@ bool embot::app::eth::theEncoderReader::Impl::TestRead(const Config &config)
     bool ret {true};
     
     EOconstarray* carray = eo_constarray_Load(reinterpret_cast<EOconstarray*>(config.carrayofjomodes));
-
     _implconfig.numofjomos = eo_constarray_Size(carray);
+    
     //I will try to read the primary encoder, if the reading is succesfful (aka embot::hw::encoder::read reads plausible data) ok, if not I will send an error to yarp
     for(uint8_t i=0; i<_implconfig.numofjomos; i++)
     {

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -203,7 +203,7 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
     activateafterverify = ActivateafterverifY;
     onverifycompleted = oncompletion;
     
-//    #warning acemor-says: embot::app::eth::theEncoderReader should be revised again?
+//    #warning sanlordkevin-says: embot::app::eth::theEncoderReader should be revised again?
 
 #if 0 
     READ this:
@@ -218,21 +218,26 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
     
     constexpr bool verificationFailed {false};
     
-    if(false == IsEncoderSupported(config))
-    {
-
+    if( false == IsEncoderSupported(config) )
+    {        
         _verified = false;
         onverifycompleted.execute(verificationFailed);  
-    
+
         return false;  
     }
-    if(false ==  TestRead(config))
+    if( false ==  TestRead(config) )
     {
+        diagnostics.errorDescriptor.par16            = 0;
+        diagnostics.errorDescriptor.par64            = 0;    
+        diagnostics.errorType = eo_errortype_error;
+        diagnostics.errorDescriptor.sourceaddress = eo_errman_sourcedevice_localboard;
+        diagnostics.errorDescriptor.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_encoders_failed_verify);  
+        eo_errman_Error(eo_errman_GetHandle(), diagnostics.errorType, nullptr, s_eobj_ownname, &diagnostics.errorDescriptor);
+        
          _verified = false;
         onverifycompleted.execute(verificationFailed);  
-        
+
         return false;  
-        
     }
    
     
@@ -272,14 +277,6 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
     
     return true;  
 }
-
-
-
-
-
-
-
-
 
 
 bool embot::app::eth::theEncoderReader::Impl::IsEncoderSupported(const Config &config)
@@ -371,8 +368,6 @@ bool embot::app::eth::theEncoderReader::Impl::IsEncoderSupported(const Config &c
     if(false == ret)
     {
         eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &diagnostics.errorDescriptor); 
-        diagnostics.errorDescriptor.par16 = 0;
-        diagnostics.errorDescriptor.par64 = 0;
         Deactivate();      
     }
 
@@ -669,9 +664,7 @@ bool embot::app::eth::theEncoderReader::Impl::TestRead(const Config &config)
             diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par16 | i;
             diagnostics.errorDescriptor.par64 = 1;
             eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &diagnostics.errorDescriptor);
-            
-            diagnostics.errorDescriptor.par16 = 0;
-            diagnostics.errorDescriptor.par64 = 0;     
+             
             ret = false;            
         }
     }

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -218,16 +218,6 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
     
     constexpr bool verificationisOK {true};
     
-    static uint8_t ii=0;
-    if(ii==0)
-    {
-        ii++;
-    }
-    else if(ii==1)
-    {
-        ii++;
-    }
-        
     
     if(true == activateafterverify)
     {
@@ -319,40 +309,36 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
                 } break;
                 case eomc_enc_unknown:
                 case eomc_enc_none:
-                {
-                    //no encoder
-                    embot::core::print("theEncoderReader: encoder none");
-                    ret = false;
-                } break;
-                
                 default:
                 {
-                    // unsupported encoder
-                    embot::core::print("theEncoderReader: encoder type not supported");
-                    embot::core::print(std::to_string(i) +" enc type: "+ std::to_string(_implconfig.jomo_cfg[i].encoder1des.type));
-                    // in some cases, we need to alert the pc104 that the board does not support this service
-                    eOerrmanDescriptor_t errdes = {};
-                    errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_encoders_failed_notsupported);  
-                    errdes.sourcedevice = eo_errman_sourcedevice_localboard;
-                    errdes.sourceaddress = 0;
-                    errdes.par16 = errdes.par64 = 0;
-                    eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
-                              
-                    #warning: to do send to yarp unsupported encoder, and block yarp?
+                    //unknown/no/unsupported encoder, pass to embot::hw::encoder::init cfg.type = embot::hw::encoder::Type::none, it will rise an error
+//                    embot::core::print("theEncoderReader: encoder unknown/none/unsupported");
                     ret = false;
                 } break;
             }
             
             // 2. configure and initialize SPI encoder
-            
             embot::hw::ENCODER enc = port2encoder(_implconfig.jomo_cfg[i].encoder1des.port);
             embot::hw::result_t r = embot::hw::encoder::init(enc, cfg);
             if(embot::hw::resOK != r)
             {
-                embot::core::print("theEncoderReader: encoder init failed");
-                #warning: to do send to yarp init failed encoder
+                embot::core::print("theEncoderReader: encoder type not supported");
+//                embot::core::print(std::to_string(i) +" enc type: "+ std::to_string(_implconfig.jomo_cfg[i].encoder1des.type));
+                // in some cases, we need to alert the pc104 that the board does not support this service, in our case the encoder
+                eOerrmanDescriptor_t errdes = {};
+                errdes.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_encoders_failed_notsupported);  
+                errdes.sourcedevice = eo_errman_sourcedevice_localboard;
+                errdes.sourceaddress = 0;
+                    //possible to do: tell which encoder is not supported by the specific joint    
+                errdes.par16 = errdes.par64 = 0;
+                eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);
+                              
                 ret = false;
             }
+//            else
+//            {
+//                embot::core::print("theEncoderReader: encoder init successfull");
+//            }
             
         }
     }
@@ -369,7 +355,7 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
 
 bool embot::app::eth::theEncoderReader::Impl::Deactivate()
 {
-    eo_errman_Trace(eo_errman_GetHandle(), "::Deactivate()", s_eobj_ownname);
+//    eo_errman_Trace(eo_errman_GetHandle(), "::Deactivate()", s_eobj_ownname);
 //    
 //    embot::app::eth::theErrorManager::getInstance().trace("", {"",     
 //                              embot::os::theScheduler::getInstance().scheduled()}); 
@@ -393,7 +379,7 @@ bool embot::app::eth::theEncoderReader::Impl::StartReading()
     embot::hw::encoder::startRead(embot::hw::ENCODER::two);
     embot::hw::encoder::startRead(embot::hw::ENCODER::three);
     
-    return true;;
+    return true;
 }
 
 bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth::encoder::v1::valueInfo &primary, embot::app::eth::encoder::v1::valueInfo &secondary)

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -18,7 +18,6 @@
 
 #include "embot_hw_encoder.h"
 #include "EOtheErrorManager.h"
-#include "embot_app_eth_theErrorManager.h"
 #include "EoProtocol.h"
 #include "EoMotionControl.h"
 #include "EoError.h"
@@ -27,7 +26,6 @@
 #include "embot_app_eth_theServices.h"
 #include "embot_app_eth_Service_legacy.h"
 
-#include "embot_os_theScheduler.h"
 
 #if defined(STM32HAL_BOARD_AMC) && defined(DEBUG_AEA3_stream_over_theBackdoor)   
 #include "embot_app_eth_theBackdoor.h"
@@ -200,19 +198,7 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
     eo_timer_Stop(diagnostics.reportTimer);  
         
     activateafterverify = ActivateafterverifY;
-    onverifycompleted = oncompletion;
-    
-//    #warning sanlordkevin-says: embot::app::eth::theEncoderReader should be revised again?
-
-#if 0 
-    READ this:
-    we should enhance this object w/   
-    - a proper verify and activate
-    - internal data structure as in namespace embot::app::eth::service::impl
-    - surely diagnostics
-    - ...    
-
-#endif    
+    onverifycompleted = oncompletion; 
 
     
     constexpr bool verificationFailed {false};
@@ -226,8 +212,7 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
     }
     if( false ==  TestRead(config) )
     {
-        diagnostics.errorDescriptor.par16            = 0;
-        diagnostics.errorDescriptor.par64            = 0;    
+        diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par64 = 0;
         diagnostics.errorType = eo_errortype_error;
         diagnostics.errorDescriptor.sourceaddress = eo_errman_sourcedevice_localboard;
         diagnostics.errorDescriptor.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_encoders_failed_verify);  
@@ -239,8 +224,6 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
         return false;  
     }
    
-    
-    
     
     diagnostics.errorDescriptor.sourcedevice     = eo_errman_sourcedevice_localboard;
     diagnostics.errorDescriptor.sourceaddress    = 0;
@@ -280,8 +263,7 @@ bool embot::app::eth::theEncoderReader::Impl::Verify(const Config &config, bool 
 //check if the encoder(s) selected is supported by the board
 bool embot::app::eth::theEncoderReader::Impl::IsEncoderSupported(const Config &config)
 {
-    diagnostics.errorDescriptor.par16 = 0;
-    diagnostics.errorDescriptor.par64 = 0;
+    diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par64 = 0;
     diagnostics.errorDescriptor.code = eoerror_code_get(eoerror_category_Config, eoerror_value_CFG_encoders_failed_verify);  
     diagnostics.errorDescriptor.sourcedevice = eo_errman_sourcedevice_localboard;
     diagnostics.errorDescriptor.sourceaddress = 0;
@@ -432,8 +414,7 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
             case eomc_enc_none:
             default:
             {
-                //unknown/no/unsupported encoder, pass to embot::hw::encoder::init cfg.type = embot::hw::encoder::Type::none, it will rise an error
-//                    embot::core::print("theEncoderReader: encoder unknown/none/unsupported");
+                //unknown/no/unsupported encoder
                 ret = false;
             } break;
         }
@@ -460,11 +441,6 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
 
 bool embot::app::eth::theEncoderReader::Impl::Deactivate()
 {
-//    eo_errman_Trace(eo_errman_GetHandle(), "::Deactivate()", s_eobj_ownname);
-//    
-//    embot::app::eth::theErrorManager::getInstance().trace("", {"",     
-//                              embot::os::theScheduler::getInstance().scheduled()}); 
-//    
     _implconfig.numofjomos = 0;
     embot::hw::encoder::deinit(embot::hw::ENCODER::one);
     embot::hw::encoder::deinit(embot::hw::ENCODER::two);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -62,12 +62,14 @@ namespace embot::hw::encoder {
     static std::uint32_t initialisedmask = 0;
     
     struct privateData
-    {
+    {   
+        //chip used in AEA and AEA2
         embot::hw::chip::AS5045 *chip_AS5045 = {nullptr};
-        embot::hw::chip::MA730  *chip_MA730 = {nullptr};
-        
         embot::hw::chip::AS5045::Data as5045_data {};
+            
+        //chip used in AEA3
         embot::hw::chip::MA730::Data ma730_data {};
+        embot::hw::chip::MA730  *chip_MA730 = {nullptr};
         
         Config config = {};
         volatile bool data_is_ready {false};
@@ -148,14 +150,10 @@ namespace embot::hw::encoder {
                         } 
             );
         }
-        else if(embot::hw::encoder::Type::none == cfg.type)
-        {
-            #warning, verify if this is necessary
-        }
         else
         {
-            //this error message is onl for debugging on keil
-            embot::core::print("hw_encoder:encoder type not supported");
+            //this error message is for debugging on keil
+//            embot::core::print("embot_hw_encoder: encoder type not supported");
             return resNOK;
         }
         
@@ -263,8 +261,11 @@ namespace embot::hw::encoder {
             // retrieve the current encoder position from data saved internally.
             if(_data_array[index].data_is_ready)
             {
-                pos = _data_array[index].as5045_data.position;
-                res = resOK;
+                if(_data_array[index].as5045_data.status.ok)
+                {
+                    pos = _data_array[index].as5045_data.position;
+                    res = resOK;
+                }
             }
         }
         else if(embot::hw::encoder::Type::chipMA730 == _data_array[index].config.type)
@@ -277,8 +278,6 @@ namespace embot::hw::encoder {
                     pos = _data_array[index].ma730_data.position;
                     res = resOK;
                 }
-                else
-                    res = resNOK;
             }
         }
         

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -304,6 +304,10 @@ namespace embot::hw::encoder {
                 pos = dd.position;
                 //destination.status = dd.status.ok;
             }
+            else
+            {
+                return resNOK;
+            }
         }
         else if(embot::hw::encoder::Type::chipMA730 == _data_array[index].config.type)
         {
@@ -314,6 +318,10 @@ namespace embot::hw::encoder {
             {
                 pos = dd.position;
                 //destination.status = dd.status.ok;
+            }
+            else
+            {
+                return resNOK;
             }
         }
         else

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -148,10 +148,14 @@ namespace embot::hw::encoder {
                         } 
             );
         }
+        else if(embot::hw::encoder::Type::none == cfg.type)
+        {
+            #warning, verify if this is necessary
+        }
         else
         {
             //this error message is onl for debugging on keil
-            embot::core::print("encoder type not supported");
+            embot::core::print("hw_encoder:encoder type not supported");
             return resNOK;
         }
         


### PR DESCRIPTION
Improving the object `theEncoderReader`.
Now it includes two checks in its verify function:

1) It checks whether the encoder type sent to the board is supported by the board, meaning the firmware is present to handle that specific encoder.

Amo encoder is not supported by the `amc`, on `yarprobotinterface` appears an error that remands to a generic error of the encoder; there is not the case of unsupported encoder.
On the debugger also appears the error message.

![Image](https://github.com/user-attachments/assets/853f8a29-a627-4d2b-b48c-a83c8215d37f)

 ####

2) It performs one read from the encoder to verify that data is being received.


In case of encoder detached from the board a message is sent to `yarprobotinterface.`
In this case it remands to an `AEA_READING` error. In case of other encoder it gives a generic encoder error.
On the debugger also appears the error message.

![Image](https://github.com/user-attachments/assets/dcc41ade-072c-4a6a-9981-f35000326cf1)


####
Tested on a `amc lego setup`.
