### PR TITLE
Added support in the `amcfoc` for rotor-stator motor calibration

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm7/embot_hw_motor_bldc_bsp_amcfoc_1mc7.cpp
@@ -258,8 +258,11 @@ namespace embot::hw::motor::bldc::bsp {
             //only mechanical angle at the moment
             r = embot::hw::motor::enc::angle(m);
         }
-        //Angle r = (enc == Encoder::hall) ? 0.0 : 1.0;        
-        //r = embot::hw::motor::hall::angle(m) OR .....;         
+        else if(type == AngleType::quadenc_mechanical_lastindex)
+        {
+            r = embot::hw::motor::enc::GetencIndexAngle(m);
+        }
+  
         return r;
     }     
 

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/proj/amcfoc.1cm7-mot.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/proj/amcfoc.1cm7-mot.uvoptx
@@ -991,7 +991,7 @@
 
   <Group>
     <GroupName>embot::prot::can</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1251,7 +1251,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp-core-cm7</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1283,7 +1283,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp-motor</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/proj/amcfoc.1cm7-mot.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/procs/appl.mot/proj/amcfoc.1cm7-mot.uvprojx
@@ -337,7 +337,7 @@
             <v6WtE>0</v6WtE>
             <v6Rtti>0</v6Rtti>
             <VariousControls>
-              <MiscControls>-D_dont_MBD_foc_keep_degenerated_code -DSTM32HAL_dualcore_BOOT_cm4master -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
+              <MiscControls>-DtemporaryDISABLEqencMBD -D_dont_DEBUG_canQENCemission -D_dont_MBD_foc_keep_degenerated_code -DSTM32HAL_dualcore_BOOT_cm4master -Wno-pragma-pack -Wno-deprecated-register -DEMBOT_USE_rtos_osal</MiscControls>
               <Define>USE_ICC_COMM USE_ICC_CAN_COMM USE_STM32HAL STM32HAL_BOARD_AMCFOC_1CM7 STM32HAL_DRIVER_V1A0</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\..\..\..\libs\lowlevel\stm32hal\api;..\..\..\..\..\libs\highlevel\abslayer\osal\api;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\core;..\..\..\..\..\..\..\..\..\icub-firmware-shared\embot\tools;..\..\..\..\..\..\..\..\..\icub-firmware-shared\can\canProtocolLib;..\..\..\..\..\embot\hw;..\..\..\..\..\embot\os;..\..\..\..\..\embot\app;..\..\..\..\..\libs\midware\eventviewer\api;..\..\..\..\..\embot\app\bldc;..\..\..\..\..\embot\prot\can;..\..\..\..\..\embot\app\eth;..\src\app-board-amc1cm7;..\..\..\..\..\libs\highlevel\services\embenv\api;..\..\..\bsp\shared;..\..\..\bsp\cm7;..\..\..\bsp\motorhal;..\src\bldc-mbd-moc;.;..\..\..\..\..\mbd\amcfoc\control-foc;..\..\..\..\..\mbd\amcfoc\control-outer;..\..\..\..\..\mbd\amcfoc\estimation-velocity;..\..\..\..\..\mbd\amcfoc\filter-current;..\..\..\..\..\mbd\amcfoc\motion-controller;..\..\..\..\..\mbd\amcfoc\supervisor;..\..\..\..\..\mbd\amcfoc\supervisor-tx;..\..\..\..\..\mbd\amcfoc\sharedutils;..\..\..\..\..\mbd\amcfoc\iterative-motion-controller\</IncludePath>

--- a/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_MBD_interface.h
+++ b/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_MBD_interface.h
@@ -86,7 +86,19 @@ namespace embot::app::bldc::mbd::interface {
             uint32_t motorfaultstate {0};
             canADDITIONALSTATUSinfo() = default;            
         };
+        
+        struct canDEBUGqenccalibresult
+        {
+            int16_t offset {0};
+            bool calibrationdone {false};
+            canDEBUGqenccalibresult() = default;            
+        };        
 
+        struct Qenc
+        {
+            float counter {0};
+            float indexcounter {0};  
+        };
 
         struct FOCinput
         {
@@ -94,17 +106,19 @@ namespace embot::app::bldc::mbd::interface {
             embot::hw::motor::bldc::Currents currents {}; 
             float mechanicalangle {0.0};
             uint8_t hall {0};
+            Qenc qenc {};
                 
             FOCinput() = default;
-            FOCinput(float ea, const embot::hw::motor::bldc::Currents &cu, float me, uint8_t h) 
-                : electricalangle(ea), currents(cu), mechanicalangle(me), hall(h) {}
+            FOCinput(float ea, const embot::hw::motor::bldc::Currents &cu, float me, uint8_t h, const Qenc &q) 
+                : electricalangle(ea), currents(cu), mechanicalangle(me), hall(h), qenc {q} {}
                     
-            void load(float ea, const embot::hw::motor::bldc::Currents &cu, float me, uint8_t h)
+            void load(float ea, const embot::hw::motor::bldc::Currents &cu, float me, uint8_t h, const Qenc &q)
             {
                 electricalangle = ea;
                 currents = cu;
                 mechanicalangle = me;
                 hall = h;
+                qenc = q;
             }
         };  
 
@@ -159,7 +173,8 @@ namespace embot::app::bldc::mbd::interface {
         void get(canFOCinfo &info, uint8_t motor) const;
         void get(canSTATUSinfo &info, uint8_t motor) const;        
         float get_temperature(uint8_t motor) const;
-        void get(FOCoutput &o, uint8_t motor);
+        void get(FOCoutput &o, uint8_t motor) const;
+        void get(canDEBUGqenccalibresult &info, uint8_t motor) const;
 
         void get_current_limits(uint8_t motor, embot::app::bldc::mbd::interface::SupervisorInputLimits &cl);
         void get_current_pid(uint8_t motor, embot::app::bldc::mbd::interface::PID &pid);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.h
@@ -74,7 +74,7 @@ namespace embot::hw::motor::bldc {
     
     using Angle = float; // in [degrees]
     
-    enum class AngleType : uint8_t { hall_electrical = 0, hall_mechanical = 2, quadenc_mechanical = 3 };
+    enum class AngleType : uint8_t { hall_electrical = 0, hall_mechanical = 2, quadenc_mechanical = 3, quadenc_mechanical_lastindex = 4 };
     
     struct Config
     {

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.cpp
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.cpp
@@ -131,6 +131,24 @@ namespace embot { namespace prot { namespace can { namespace motor { namespace p
     } 
 
 
+    bool Message_DEBUG::load(const Info& inf)
+    {
+        info = inf;  
+        return true;
+    }
+            
+    bool Message_DEBUG::get(embot::prot::can::Frame &outframe)
+    {
+        std::uint8_t data08[8] = {0};
+        std::memmove(data08, &info.payload, sizeof(data08));
+        std::uint8_t size = 8;
+               
+        Message::set(info.canaddress, 0xf, Clas::periodicMotorControl, static_cast<std::uint8_t>(CMD::DEBUG), data08, size);
+        std::memmove(&outframe, &canframe, sizeof(embot::prot::can::Frame));
+                    
+        return true;
+    } 
+    
     bool Message_EMSTO2FOC_DESIRED_CURRENT::load(const embot::prot::can::Frame &inframe)
     {
         Message::set(inframe);  

--- a/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.h
+++ b/emBODY/eBcode/arch-arm/embot/prot/can/embot_prot_can_motor_periodic.h
@@ -39,6 +39,7 @@ namespace embot::prot::can::motor::periodic {
         FOC = 0,
         STATUS = 3,
         PRINT = 6,
+        DEBUG = 9,
         ADDITIONAL_STATUS = 12,
         EMSTO2FOC_DESIRED_CURRENT = 15        
     };
@@ -85,7 +86,43 @@ namespace embot::prot::can::motor::periodic {
         std::uint8_t nchars;           
         static std::uint8_t textIDmod4;  // 0, 1, 2, 3, 0, 1, 2, etc      
     }; 
-   
+    
+    
+//    template< typename T >
+//    std::string int_to_hex( T i )
+//    {
+//      std::stringstream stream;
+//      stream << "0x" 
+//             << std::setfill ('0') << std::setw(sizeof(T)*2) 
+//             << std::hex << i;
+//      return stream.str();
+//    }    
+       
+    struct Message_DEBUG : public Message
+    {
+        struct Info
+        { 
+            uint64_t                    payload {0};   // the full payload
+            std::uint8_t                canaddress {0};
+            Info() = default;
+            Info(uint64_t p, uint8_t a) : payload(p), canaddress(a) {}
+            std::string to_string() const
+            {
+                return std::string("sig<DEBUG = (") 
+                                    + std::to_string(payload) 
+//                                    + int_to_hex(payload) 
+                                    + ")"
+                                   + ">";               
+            }
+        };
+        
+        Info info {};
+        
+        Message_DEBUG() = default;
+            
+        bool load(const Info& inf);            
+        bool get(embot::prot::can::Frame &outframe);  
+    }; 
     
     class Message_EMSTO2FOC_DESIRED_CURRENT : public Message
     {


### PR DESCRIPTION
This PR adds support in the `amcfoc` for rotor-stator motor calibration.

In particular, I added:
- glue code to the `amcfoc` for exchanging data w/ MBD rotor-stator calibrator that uses a qenc. For now, I have defined a macro `temporaryDISABLEqencMBD` to disable the calls to MBD APIs that are not in` icub-firmware` yet;
- management of the CAN message DEBUG in class MC streaming so that it can send the offset that is result of the calibration procedure;
- the  reading of the quadrature encoder angle  w/ embot::hw::motor::bldc::angle().


We have following successful tests:
- emulation of calibration that will be done by the model so that we can verify the correct emission of the debug message (use macro `DEBUG_canQENCemission`);
- movement of  the Kollmorgen motor using `amcfoc `+ `tdriver-rev-b` using CAN messages.


The PR affects only the `amcfoc` code, so it can be safely merged.
