### PR TITLE
Add sw filter in test cin for current evaluation

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
@@ -313,7 +313,7 @@ namespace embot { namespace app { namespace skeleton { namespace os { namespace 
 			constexpr uint8_t sizeOfCins = 100;
             // Create an array that stores 10 reading for the CIN, then we do a simple mean of those
             // to apply a second filtering to the currents read
-            std::array<float, sizeOfCins> arrayOfCins {};
+            static std::array<float, sizeOfCins> arrayOfCins {};
             
             for(uint8_t i = 0; i < arrayOfCins.size(); ++i)
             {

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
@@ -14,7 +14,7 @@
 
 
 constexpr extern uint8_t  Firmware_vers = 1;
-constexpr extern uint8_t  Revision_vers = 1;
+constexpr extern uint8_t  Revision_vers = 2;
 constexpr extern uint8_t  Build_number  = 0;
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcbldc/test/src/embot_app_skeleton_os_test.cpp
@@ -41,6 +41,8 @@ constexpr extern uint8_t  Build_number  = 0;
 #include "pwm.h"
 #include "encoder.h"
 
+#include <numeric>
+
 #include "tests.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -308,7 +310,18 @@ namespace embot { namespace app { namespace skeleton { namespace os { namespace 
 			
             uint8_t data[8] {0};
             float cin {0.00};
-			cin = embot::hw::bsp::amcbldc::getCIN();
+			constexpr uint8_t sizeOfCins = 100;
+            // Create an array that stores 10 reading for the CIN, then we do a simple mean of those
+            // to apply a second filtering to the currents read
+            std::array<float, sizeOfCins> arrayOfCins {};
+            
+            for(uint8_t i = 0; i < arrayOfCins.size(); ++i)
+            {
+                arrayOfCins[i] = embot::hw::bsp::amcbldc::getCIN();
+            }
+            
+
+			cin = std::accumulate(arrayOfCins.begin(), arrayOfCins.end(), 0.0) / sizeOfCins;
 
 			embot::core::print("Cin : " + std::to_string(cin));
 			


### PR DESCRIPTION
Considering that it might be that the DMA current evaluation, even though already filtered on the low level, it might still be noisy, we had preferred to add a high level average filter that takes in input 100 measures.
Considering that the Cin is evaluated quite fast, the test time remains in the order of ms.

This completes the update of the `amc-bldc` test suite.

Related to this issue: https://github.com/icub-tech-iit/ipts/issues/80
and this PR: https://github.com/icub-tech-iit/ipts/pull/78

cc: @Nicogene 