### PR TITLE
Change .`hex` generated name for `amc`

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvoptx
@@ -2314,7 +2314,7 @@
 
   <Group>
     <GroupName>embot::app::scope</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
@@ -49,7 +49,7 @@
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
           <OutputDirectory>.\obj\</OutputDirectory>
-          <OutputName>amc_app_yri</OutputName>
+          <OutputName>amc_appl_yri</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>1</CreateHexFile>
@@ -82,7 +82,7 @@
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>cmd.exe /C copy .\obj\amc_app_yri.hex ..\bin\amc.appl.yri.hex</UserProg1Name>
+            <UserProg1Name>cmd.exe /C copy .\obj\amc_appl_yri.hex ..\bin\amc.appl.yri.hex</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
@@ -49,7 +49,7 @@
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
           <OutputDirectory>.\obj\</OutputDirectory>
-          <OutputName>amc</OutputName>
+          <OutputName>amc_app_yri</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>1</CreateHexFile>
@@ -82,7 +82,7 @@
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>cmd.exe /C copy .\obj\amc.hex ..\bin\amc.appl.yri.hex</UserProg1Name>
+            <UserProg1Name>cmd.exe /C copy .\obj\amc_app_yri.hex ..\bin\amc.appl.yri.hex</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/proj/amc-icc.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM7</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.1.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x38000000,0x00010000) IRAM2(0x24000000,0x00080000) IROM(0x08000000,0x00100000) XRAM(0x20000000,0x00020000) CPUTYPE("Cortex-M7") FPU3(DFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -82,7 +82,7 @@
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>cmd.exe /C copy .\obj\amc.hex ..\bin\amc.hex</UserProg1Name>
+            <UserProg1Name>cmd.exe /C copy .\obj\amc.hex ..\bin\amc.appl.yri.hex</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvoptx
@@ -628,7 +628,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -648,7 +648,7 @@
 
   <Group>
     <GroupName>embot::app::board::amc2c</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -768,7 +768,7 @@
 
   <Group>
     <GroupName>embot::app::application</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1768,7 +1768,7 @@
 
   <Group>
     <GroupName>mbd::control-outer</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
@@ -1182,7 +1182,7 @@
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
           <OutputDirectory>.\obj\</OutputDirectory>
-          <OutputName>amc2c_app_mot</OutputName>
+          <OutputName>amc2c_appl_mot</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>1</CreateHexFile>
@@ -1215,7 +1215,7 @@
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>cmd.exe /C copy .\obj\amc2c_app_mot.hex ..\bin\amc.appl.mot.hex</UserProg1Name>
+            <UserProg1Name>cmd.exe /C copy .\obj\amc2c_appl_mot.hex ..\bin\amc.appl.mot.hex</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
@@ -1182,7 +1182,7 @@
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
           <OutputDirectory>.\obj\</OutputDirectory>
-          <OutputName>amc2c_icc</OutputName>
+          <OutputName>amc2c_app_mot</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>1</CreateHexFile>
@@ -1215,7 +1215,7 @@
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>cmd.exe /C copy .\obj\amc2c_icc.hex ..\bin\amc.appl.mot.hex</UserProg1Name>
+            <UserProg1Name>cmd.exe /C copy .\obj\amc2c_app_mot.hex ..\bin\amc.appl.mot.hex</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/proj/amc2c-appl-dual-icc-can.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.1.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1149,7 +1149,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.1.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -1215,7 +1215,7 @@
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>cmd.exe /C copy .\obj\amc2c_icc.hex ..\bin\amc2c.icc.hex</UserProg1Name>
+            <UserProg1Name>cmd.exe /C copy .\obj\amc2c_icc.hex ..\bin\amc.appl.mot.hex</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
@@ -2231,7 +2231,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.4.0.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.1.0</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>


### PR DESCRIPTION
Change .`hex` generated name in the project for the two cores of the `amc`:

- amc.hex -> amc.appl.yri.hex
- amc2c.hex -> amc.appl.mot.hex