### PR TITLE
amc SPI communication with chip KSZ8563R

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
@@ -137,26 +137,17 @@ namespace embot::hw::eth::bsp {
         return (embot::hw::chip::KSZ8563::Link::UP == lnk) ? true : false;       
     }
     
-    
-    
     uint64_t BSP::errors(embot::hw::PHY phy, ERR e) const
     {
         if(nullptr == ethswitch)
         {            
             return 0;
         }  
-                
-        static constexpr embot::hw::chip::KSZ8563::MIB mibs[3] =
-        {
-            embot::hw::chip::KSZ8563::MIB::RxCRCerror,
-            embot::hw::chip::KSZ8563::MIB::RxUnicast,
-            embot::hw::chip::KSZ8563::MIB::TxUnicastPkts
-        };
-
+        
         //Convert PHY to PORT
         const auto port = static_cast<embot::hw::chip::KSZ8563::PORT> ( embot::core::tointegral(phy) );
         
-        const auto mib  = mibs[embot::core::tointegral(e)];
+        const auto mib  = embot::hw::chip::KSZ8563::mibs[embot::core::tointegral(e)];
         
         embot::hw::chip::KSZ8563::MIBdata data {};
         ethswitch->readMIB(port, mib, data);

--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_eth_bsp_amc.cpp
@@ -137,6 +137,8 @@ namespace embot::hw::eth::bsp {
         return (embot::hw::chip::KSZ8563::Link::UP == lnk) ? true : false;       
     }
     
+    
+    
     uint64_t BSP::errors(embot::hw::PHY phy, ERR e) const
     {
         if(nullptr == ethswitch)
@@ -144,19 +146,20 @@ namespace embot::hw::eth::bsp {
             return 0;
         }  
                 
-        static constexpr embot::hw::chip::KSZ8563::MIB mibs[2] =
+        static constexpr embot::hw::chip::KSZ8563::MIB mibs[3] =
         {
             embot::hw::chip::KSZ8563::MIB::RxCRCerror,
-            embot::hw::chip::KSZ8563::MIB::RxUnicast
+            embot::hw::chip::KSZ8563::MIB::RxUnicast,
+            embot::hw::chip::KSZ8563::MIB::TxUnicastPkts
         };
-        static constexpr embot::hw::chip::KSZ8563::PORT ports[3] =
-        {
-            embot::hw::chip::KSZ8563::PORT::one, 
-            embot::hw::chip::KSZ8563::PORT::two,
-            embot::hw::chip::KSZ8563::PORT::three
-        };
-        static embot::hw::chip::KSZ8563::MIBdata data {};
-        ethswitch->readMIB(ports[embot::core::tointegral(phy)], mibs[embot::core::tointegral(e)], data);
+
+        //Convert PHY to PORT
+        const auto port = static_cast<embot::hw::chip::KSZ8563::PORT> ( embot::core::tointegral(phy) );
+        
+        const auto mib  = mibs[embot::core::tointegral(e)];
+        
+        embot::hw::chip::KSZ8563::MIBdata data {};
+        ethswitch->readMIB(port, mib, data);
         
         return data.value();
     }

--- a/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_spi_bsp_amc.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/bsp/embot_hw_spi_bsp_amc.cpp
@@ -236,8 +236,8 @@ namespace embot::hw::spi::bsp {
             
             case SPI::five:
             {
-                // ETH ... use what cube-mx has chosen
-                MX_SPI5_Init();
+                // ETH
+                s_SPIinit(h, config);  
             } break;
             
             case SPI::six:
@@ -273,8 +273,8 @@ namespace embot::hw::spi::bsp {
             
             case SPI::five:
             {
-                // ETH ... use what cube-mx has chosen
-                HAL_SPI_DeInit(&hspi5);
+                // ETH
+                s_J5_SPIpinout(h, false);
             } break;
             
             case SPI::six:

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -261,14 +261,14 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
         }
     }
     
-//      //test for CRC etc
-//    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
-    uint64_t unicast_error_number;// = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
-    static uint16_t iii=0;
-    if((iii++)%10 == 0)
-    {   
-        uint64_t t = embot::core::now(); 
-        embot::core::TimeFormatter tf{t};   
+//    //test for CRC etc
+//    uint64_t unicast_error_number;
+//    static uint16_t iii=0;
+//    if((iii++)%10 == 0)
+//    {   
+//        uint64_t ta = embot::core::now(); 
+//        embot::core::TimeFormatter tf{ta};   
+//        embot::core::print(tf.to_string());
 
 //        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RXunicast);
 //        embot::core::print("RxUnicast 1: " +std::to_string(unicast_error_number));
@@ -277,20 +277,10 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 //        
 //        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TXunicast);
 //        embot::core::print("TxUnicast 1: " +std::to_string(unicast_error_number));
-        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TXunicast);
-        embot::core::print(tf.to_string()+ " TxUnicast 2: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TXunicast);
 //        embot::core::print("TxUnicast 2: " +std::to_string(unicast_error_number));
-        
-
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
-//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
-//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
-//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
-//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-    }
+//        
+//    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -265,20 +265,26 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
     
       //test for CRC etc
 //    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
-    uint64_t unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
-    static uint8_t iii=0;
-    if((iii++)%500)
-    {   
-        
-        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
-        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
-        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
-        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
-        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-    }
+//    uint64_t unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
+//    static uint16_t iii=0;
+//    if((iii++)%10 == 0)
+//    {   
+
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
+//        embot::core::print("RxUnicast 1: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::unicast);
+//        embot::core::print("RxUnicast 2: " +std::to_string(unicast_error_number));
+
+//        
+////        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
+////        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+////        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
+////        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+////        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
+////        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+////        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
+////        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+//    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -263,27 +263,32 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
         }
     }
     
-      //test for CRC etc
+//      //test for CRC etc
 //    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
-//    uint64_t unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
+    uint64_t unicast_error_number;// = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
 //    static uint16_t iii=0;
 //    if((iii++)%10 == 0)
 //    {   
 
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RXunicast);
 //        embot::core::print("RxUnicast 1: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::unicast);
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RXunicast);
 //        embot::core::print("RxUnicast 2: " +std::to_string(unicast_error_number));
-
 //        
-////        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
-////        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-////        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
-////        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-////        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
-////        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-////        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
-////        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TXunicast);
+//        embot::core::print("TxUnicast 1: " +std::to_string(unicast_error_number));
+        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TXunicast);
+        embot::core::print("TxUnicast 2: " +std::to_string(unicast_error_number));
+        
+
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
+//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
+//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
+//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
+//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
 //    }
 }
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -12,7 +12,6 @@
 
 #include "embot_app_eth_theETHmonitor.h"
 
-
 // --------------------------------------------------------------------------------------------------------------------
 // - external dependencies
 // --------------------------------------------------------------------------------------------------------------------
@@ -20,7 +19,6 @@
 #include "embot_os.h"
 #include "embot_os_rtos.h"
 #include "embot_hw_eth.h"
-//#include "embot_app_eth_theErrorManager.h"
 #include "EOtheErrorManager.h"
 #include "EoError.h"
 #include "EOMtheEMSrunner.h"
@@ -239,7 +237,7 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
     //check for CRC errors
     if (link1isup)
     {
-        uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::crc);
+        uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxCRCerror);
         
         if(0 != CRC_error_number)
         {
@@ -252,7 +250,7 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
     if (link2isup)
     {
 
-        uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::crc);
+        uint64_t CRC_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxCRCerror);
 
         if(0 != CRC_error_number)
         {
@@ -266,9 +264,11 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 //      //test for CRC etc
 //    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
     uint64_t unicast_error_number;// = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
-//    static uint16_t iii=0;
-//    if((iii++)%10 == 0)
-//    {   
+    static uint16_t iii=0;
+    if((iii++)%10 == 0)
+    {   
+        uint64_t t = embot::core::now(); 
+        embot::core::TimeFormatter tf{t};   
 
 //        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RXunicast);
 //        embot::core::print("RxUnicast 1: " +std::to_string(unicast_error_number));
@@ -278,7 +278,8 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 //        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TXunicast);
 //        embot::core::print("TxUnicast 1: " +std::to_string(unicast_error_number));
         unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TXunicast);
-        embot::core::print("TxUnicast 2: " +std::to_string(unicast_error_number));
+        embot::core::print(tf.to_string()+ " TxUnicast 2: " +std::to_string(unicast_error_number));
+//        embot::core::print("TxUnicast 2: " +std::to_string(unicast_error_number));
         
 
 //        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
@@ -289,7 +290,7 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 //        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
 //        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
 //        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-//    }
+    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theETHmonitor.cpp
@@ -156,12 +156,13 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 	embot::app::eth::theETHmonitor::Impl *impl = reinterpret_cast<embot::app::eth::theETHmonitor::Impl*>(p);
 	
 	eOerrmanDescriptor_t errdes = {0};
+    
+    errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
+    errdes.sourceaddress    = 0;
 	
 	if(impl->first_time)
 	{
 		errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_juststarted);
-		errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-		errdes.sourceaddress    = 0;
 		errdes.par16            = 0;
 		errdes.par64            = 0;
 		eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
@@ -183,8 +184,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 			if (false == impl->link1.previsup)
 			{
 				errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_link_goes_up);
-				errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-				errdes.sourceaddress    = 0;
 				errdes.par16            = 0;
 				errdes.par64            = applstate;
 				eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
@@ -196,8 +195,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 			if (true == impl->link1.previsup)
 			{
 				errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_link_goes_down);
-				errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-				errdes.sourceaddress    = 0;
 				errdes.par16            = 0;
 				errdes.par64            = applstate;
 				eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);   
@@ -210,8 +207,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 			if (false == impl->link2.previsup)
 			{
 				errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_link_goes_up);
-				errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-				errdes.sourceaddress    = 0;
 				errdes.par16            = 1;
 				errdes.par64            = applstate;
 				eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
@@ -223,8 +218,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 			if (true == impl->link2.previsup)
 			{
 				errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_link_goes_down);
-				errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-				errdes.sourceaddress    = 0;
 				errdes.par16            = 1;
 				errdes.par64            = applstate;
 				eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes);   
@@ -237,8 +230,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
 	else if(nowTime - impl->lastreportTime >= impl->_config.reportOKperiod)
 	{					
 		errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_justverified);
-		errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-		errdes.sourceaddress    = 0;
 		errdes.par16            = link1isup | (link2isup << 1) | (true << 2);
 		errdes.par64            = applstate;
 		eo_errman_Error(eo_errman_GetHandle(), eo_errortype_info, NULL, s_eobj_ownname, &errdes);  
@@ -253,8 +244,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
         if(0 != CRC_error_number)
         {
         errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_error_rxcrc);
-        errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-        errdes.sourceaddress    = 0;
         errdes.par16            = 0;
         errdes.par64            = applstate | (CRC_error_number & 0xffffffff);    
         eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
@@ -268,8 +257,6 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
         if(0 != CRC_error_number)
         {
         errdes.code             = eoerror_code_get(eoerror_category_ETHmonitor, eoerror_value_ETHMON_error_rxcrc);
-        errdes.sourcedevice     = eo_errman_sourcedevice_localboard;
-        errdes.sourceaddress    = 0;
         errdes.par16            = 1;
         errdes.par64            = applstate | (CRC_error_number & 0xffffffff);    
         eo_errman_Error(eo_errman_GetHandle(), eo_errortype_error, NULL, s_eobj_ownname, &errdes); 
@@ -277,21 +264,21 @@ void embot::app::eth::theETHmonitor::Impl::onperiod(embot::os::Thread *t, void *
     }
     
       //test for CRC etc
-//    CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
-//    uint64_t unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
-//    static uint8_t iii=0;
-//    if((iii++)%100)
-//    {   
-//        
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
-//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
-//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
-//        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
-//        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
-//        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
-//    }
+//    uint64_t CRC_error_number = getnumberoferrors(embot::hw::PORT::three, embot::hw::eth::ERR::crc);
+    uint64_t unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::unicast);
+    static uint8_t iii=0;
+    if((iii++)%500)
+    {   
+        
+        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::RxByteCnt);
+        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+        unicast_error_number = getnumberoferrors(embot::hw::PHY::one, embot::hw::eth::ERR::TxByteCnt);
+        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::RxByteCnt);
+        embot::core::print("RxByteCnt: " +std::to_string(unicast_error_number));
+        unicast_error_number = getnumberoferrors(embot::hw::PHY::two, embot::hw::eth::ERR::TxByteCnt);
+        embot::core::print("TxByteCnt: " +std::to_string(unicast_error_number));
+    }
 }
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.cpp
@@ -251,7 +251,7 @@ bool embot::hw::chip::KSZ8563::Impl::readMIB(PORT port, MIB mib, MIBdata &data, 
     /* Read back status register until data is ready */
 	do 
 	{   
-        
+        std::memset(_TXbuffer, 0, sizeof(_TXbuffer));
         std::memmove(_TXbuffer, &address, sizeof(address));
         _TXdata.load(_TXbuffer, sizeof(address) + sizeof(rx32reverted));
         std::memset(_rxbuffer, 0, sizeof(address) + sizeof(rx32reverted));
@@ -270,7 +270,7 @@ bool embot::hw::chip::KSZ8563::Impl::readMIB(PORT port, MIB mib, MIBdata &data, 
     
     //start of step 3
     address = make_address_MIB(port, REG_MIB::REG_MIB_DR, COMMAND::READ);
-    
+    std::memset(_TXbuffer, 0, sizeof(_TXbuffer));
     std::memmove(_TXbuffer, &address, sizeof(address));
     _TXdata.load(_TXbuffer, sizeof(address) + sizeof(data.v32));
     std::memset(_rxbuffer, 0, sizeof(address) + sizeof(data.v32));

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.cpp
@@ -259,7 +259,6 @@ bool embot::hw::chip::KSZ8563::Impl::read(PHY phy, Link &link, embot::core::relT
 
 bool embot::hw::chip::KSZ8563::Impl::readMIB(PORT port, MIB mib, MIBdata &data, embot::core::relTime timeout)
 {   
-    constexpr MIBdata mibdata    {MIBdata::Size::bits30, false, 7, 0};
     constexpr MIBdata mibdataok  {MIBdata::Size::bits30, false, 0, 0};
     data = mibdataok; 
 
@@ -334,13 +333,13 @@ uint32_t embot::hw::chip::KSZ8563::Impl::make_address(PORT port, REG_MIB MIB_reg
     static constexpr uint8_t REG_SPACE_POS  = 0;
     static constexpr uint8_t PORT_FUNC_MIB_COUNTERS = 0x05;				/* MIB Counters (Management Information Base) */
     
-    /* Command pos */
+    /* Command position, first 3 bits  */
     static constexpr uint8_t COMMAND_POS = 29;
-    /* Address Pos */
+    /* Address position, i have to keep 5 bit for the turnaround of the chip, see KSZ8563R datasheet at sPI read write operation */
     static constexpr uint8_t ADDRESS_POS = 5;
     
     //port +1 bcs of chip driver
-    //1 here? better in other way?
+    //real address is a 16 bit
     uint32_t adr_32 =  ((embot::core::tointegral(port)+1) << PORT_SPACE_POS) | PORT_FUNC_MIB_COUNTERS << FUNC_SPACE_POS | (static_cast<uint8_t>(MIB_register) << REG_SPACE_POS);
     
     adr_32 = (static_cast<uint8_t>(cmd) << COMMAND_POS) | (adr_32 << ADDRESS_POS);
@@ -360,7 +359,6 @@ uint32_t embot::hw::chip::KSZ8563::Impl::MIB_data_to_send(MIB mib)
     uint32_t MIB_data_to_send = 0 | (static_cast<uint8_t>(mib) << MIB_INDEX_POS) | (1 << MIB_CSR_READ_ENABLE_POS);
     return MIB_data_to_send;
 }
-	
 
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -63,7 +63,7 @@ namespace embot::hw::chip {
 
         constexpr static size_t numberofPORTs {3};
         // we can read the MIB (Management Information Base) counters for each port
-        enum class MIB : uint8_t { RxCRCerror = 0x06, RxUnicast = 0x0C, TxUnicastPkts = 0x1A, RxByteCnt = 0x80 , TxByteCnt =0x81};
+        enum class MIB : uint8_t { RxCRCerror = 0x06, RxUnicast = 0x0C, TxUnicastPkts = 0x1A}; //, RxByteCnt = 0x80 , TxByteCnt =0x81}; this last two are not well read
         enum class REG_MIB : uint8_t { REG_MIB_CSR = 0x0000, REG_MIB_DR  = 0x0004};  /* 32 bits  - MIB Control and Status Register, 32 bits  - MIB Data Register */
         enum class COMMAND : uint8_t { WRITE = 0x2, READ  = 0x3};
         static constexpr uint32_t MIB_CSR_COUNTER_VALID = 1<<25;

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -113,10 +113,21 @@ namespace embot::hw::chip {
             }        
         };
         
+        
+        static constexpr embot::hw::spi::Config standardspiconfig
+        {
+            embot::hw::spi::Prescaler::eight,
+            embot::hw::spi::DataSize::eight,
+            embot::hw::spi::Mode::zero,
+            { {embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull,    // | miso | mosi |
+               embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull} }  // | sclk | sel  |
+        };
+        
+        
         struct Config
         {   // contains: spi bus and ... tbd            
             embot::hw::SPI spi {embot::hw::SPI::five};
-            embot::hw::spi::Config spicfg {}; // w/ Mode::zero
+            embot::hw::spi::Config spicfg = standardspiconfig; // w/ Mode::zero   
             PinControl pincontrol {};
             constexpr Config() = default;
             constexpr Config(embot::hw::SPI s, const embot::hw::spi::Config &sc, const PinControl &pc) 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -63,7 +63,7 @@ namespace embot::hw::chip {
 
         constexpr static size_t numberofPORTs {3};
         // we can read the MIB (Management Information Base) counters for each port
-        enum class MIB : uint8_t { RxCRCerror = 0x06, RxUnicast = 0x0C, RxByteCnt = 0x80 , TxByteCnt =0x81};
+        enum class MIB : uint8_t { RxCRCerror = 0x06, RxUnicast = 0x0C, TxUnicastPkts = 0x1A, RxByteCnt = 0x80 , TxByteCnt =0x81};
         enum class REG_MIB : uint8_t { REG_MIB_CSR = 0x0000, REG_MIB_DR  = 0x0004};  /* 32 bits  - MIB Control and Status Register, 32 bits  - MIB Data Register */
         enum class COMMAND : uint8_t { WRITE = 2, READ  = 3};
         static constexpr uint8_t MIB_CSR_READ_ENABLE_POS = 25;

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -65,11 +65,15 @@ namespace embot::hw::chip {
         // we can read the MIB (Management Information Base) counters for each port
         enum class MIB : uint8_t { RxCRCerror = 0x06, RxUnicast = 0x0C, TxUnicastPkts = 0x1A, RxByteCnt = 0x80 , TxByteCnt =0x81};
         enum class REG_MIB : uint8_t { REG_MIB_CSR = 0x0000, REG_MIB_DR  = 0x0004};  /* 32 bits  - MIB Control and Status Register, 32 bits  - MIB Data Register */
-        enum class COMMAND : uint8_t { WRITE = 2, READ  = 3};
-        static constexpr uint8_t MIB_CSR_READ_ENABLE_POS = 25;
-        static constexpr uint8_t MIB_INDEX_POS = 16;
+        enum class COMMAND : uint8_t { WRITE = 0x2, READ  = 0x3};
         static constexpr uint32_t MIB_CSR_COUNTER_VALID = 1<<25;
         static constexpr uint32_t MIB_CSR_OVERFLOW = 1<<31;
+        static constexpr embot::hw::chip::KSZ8563::MIB mibs[3] =
+        {
+            embot::hw::chip::KSZ8563::MIB::RxCRCerror,
+            embot::hw::chip::KSZ8563::MIB::RxUnicast,
+            embot::hw::chip::KSZ8563::MIB::TxUnicastPkts
+        };
 
         struct MIBdata
         {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_KSZ8563.h
@@ -120,7 +120,7 @@ namespace embot::hw::chip {
         
         static constexpr embot::hw::spi::Config standardspiconfig
         {
-            embot::hw::spi::Prescaler::eight,
+            embot::hw::spi::Prescaler::four,
             embot::hw::spi::DataSize::eight,
             embot::hw::spi::Mode::zero,
             { {embot::hw::gpio::Pull::nopull, embot::hw::gpio::Pull::nopull,    // | miso | mosi |

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
@@ -26,7 +26,7 @@
 namespace embot::hw::eth {
     
     enum class PORT : uint8_t { one = 0, two = 1, three = 2, none = 31, maxnumberof = 3 };
-    enum class ERR : uint8_t { crc = 0, unicast = 1, RxByteCnt = 2, TxByteCnt = 3};
+    enum class ERR  : uint8_t { crc = 0, RXunicast = 1, TXunicast = 2, RxByteCnt = 3, TxByteCnt = 4};
 
     // standard api
     bool supported(embot::hw::EtH b);    

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eth.h
@@ -26,7 +26,7 @@
 namespace embot::hw::eth {
     
     enum class PORT : uint8_t { one = 0, two = 1, three = 2, none = 31, maxnumberof = 3 };
-    enum class ERR  : uint8_t { crc = 0, RXunicast = 1, TXunicast = 2, RxByteCnt = 3, TxByteCnt = 4};
+    enum class ERR  : uint8_t { RxCRCerror = 0, RXunicast = 1, TXunicast = 2, RxByteCnt = 3, TxByteCnt = 4};
 
     // standard api
     bool supported(embot::hw::EtH b);    


### PR DESCRIPTION
`amc` SPI communication with chip `KSZ8563R`:
- moved SPI 5 initialisation in this project
- SPI 5 configuration: prescaler 4, mode 0, datasize 8 bit
- ordered the code
- corrected reading: not sending anymore messages on SPI while reading