### PR TITLE
Increase wait on initial tests for amc cm7 tests

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/test/src/testRunnerAmc_CM7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/test/src/testRunnerAmc_CM7.cpp
@@ -31,7 +31,7 @@ static constexpr uint8_t _fPatchVersion = 0;
 bool TestRunnerAmc_CM7::testCanComm(uint8_t *data)
 { 
     embot::core::print("Called method from testRunnerAmc_CM7");
-    embot::core::wait(300* embot::core::time1millisec);	
+    embot::core::wait(600* embot::core::time1millisec);	
     data[0] = 0xAA;
     return true; 
 }
@@ -52,7 +52,9 @@ bool TestRunnerAmc_CM7::testEthComm(uint8_t *data)
 
 bool TestRunnerAmc_CM7::testFwVersion(uint8_t *data)
 { 
-    // saving fw versions to data in order
+    // wait some time so that the GUI application is ready to receive the message
+    embot::core::wait(1000*embot::core::time1millisec);
+    // saving fw versions to data in order	
     data[0] = _fMajorVersion;
     data[1] = _fMinorVersion;
     data[2] = _fPatchVersion;
@@ -95,6 +97,8 @@ bool TestRunnerAmc_CM7::testMicroId(uint8_t *data)
     size_t size = (sizeof(data))/(sizeof(data[0]));
     for(uint8_t i = 0; i < size; i++) {data[i] = 0;}
     
+    // wait some time so that the GUI application is ready to receive the message
+    embot::core::wait(1000*embot::core::time1millisec);
     uint8_t rev1 = id_rev >> 8; //20
     uint8_t rev2 = id_rev;      //03
     uint8_t id1 = id_ver >> 8;  //64

--- a/emBODY/eBcode/arch-arm/board/amc2c/test/src/testRunnerAmc_CM4.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/test/src/testRunnerAmc_CM4.cpp
@@ -81,7 +81,7 @@ bool TestRunnerAmc_CM4::testCin(uint8_t *data)
     data[2] = ((cin2Int) & 0x0000ff00) >> 8;
     data[1] = ((cin2Int) & 0x000000ff);
     
-    if(cin > 0.020 && cin < 0.060) data[0] = 0xAA;          
+    if(cin > 0.020 && cin < 0.080) data[0] = 0xAA;          
     else data[0] = 0xBB;
     
     return true; 
@@ -231,8 +231,8 @@ bool TestRunnerAmc_CM4::testQuadEncoder(uint8_t *data)
 }
 
 static embot::hw::motor::Currents pwmCurrents(0, 0, 0);
-constexpr int32_t currentThresholdMin = 210; //mA
-constexpr int32_t currentThresholdMax = 270; //mA
+constexpr int32_t currentThresholdMin = 260; //mA
+constexpr int32_t currentThresholdMax = 340; //mA
 
 void onCurrents_FOC_innerloop(void *owner, const embot::hw::motor::Currents * const currents)
 {


### PR DESCRIPTION
This PR adds the following fixes:
- increases the waiting for test on amc cm7 core 
- adjust the PWM thresholds on the cm4 test procedure since the amc fed correctly the requested percentage of PWM (differently from amc_bldc. Thus it is better to check `amc_bldc` bsp)
- small adjustment on cin threshold as well


