### PR TITLE
Added the propagation to the MBD of the `amcfoc` of a `SET<POS_TARGET, position, withvelocity>`

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theMC2agent.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/bldc/embot_app_bldc_theMC2agent.cpp
@@ -436,20 +436,16 @@ bool embot::app::bldc::theMC2agent::Impl::get(const embot::prot::can::motor::pol
         case embot::prot::can::motor::generic::ID::TargetPOS:
         {
             vvgTargetPOS[motor].load(info.descriptor.getdata());
+            // but also it is passed to the MBD interface using a Targets item properly initted
+            embot::app::bldc::mbd::interface::Targets t {};        
+            t.position = vvgTargetPOS[motor].value().position;
+            t.velocity = vvgTargetPOS[motor].value().withvelocity;
+            io2handle.event_pushback(t, motor);            
         } break;
         
         default: {} break;
     }             
-    
-#if 0      
-    // 2. copy from info into the relevant mbd::interface type     
-    embot::app::bldc::mbd::interface::XXX xxx {};    
-    embot::app::bldc::mbd::interface::Converter::fromcan(vvGENERIC, xxx);
-    
-    // 3. load the object into mbd for a given motor
-    io2handle.event_pushback(xxx, motor);    
-#endif
-    
+       
     return true;
 } 
 


### PR DESCRIPTION
as per title.

This completes the fifth point of https://github.com/robotology/icub-firmware/pull/642:

> - generic `SET` / `GET` able for now to set a position target: not yet to MBD code as not used yet;.

