### PR TITLE
Improvement in `embot::hw::init()`

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm4/embot_hw_bsp_amcfoc_2cm4.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcfoc/bsp/cm4/embot_hw_bsp_amcfoc_2cm4.cpp
@@ -111,7 +111,7 @@ bool embot::hw::bsp::specialize()
 constexpr embot::hw::eeprom::ADR uidloc {4096};
 uint64_t embot::hw::sys::uniqueid()
 {
-    static uint64_t val {0};
+    static uint64_t val {embot::hw::sys::UIDinvalid};
     
     embot::core::Data d {&val, 8};
     embot::hw::eeprom::read(embot::hw::EEPROM::one, uidloc, d, 10*embot::core::time1millisec);

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw.cpp
@@ -41,12 +41,10 @@ using namespace std;
 
 namespace embot { namespace hw {
         
-    static bool initted = false; 
 
-    
     bool initialised()
     {
-        return initted;
+        return embot::hw::bsp::initialised();
     }   
         
 
@@ -70,8 +68,7 @@ namespace embot { namespace hw {
         
         embot::core::init({{nullptr, config.get1microtime}, {embot::hw::bsp::print}});        
         embot::hw::bsp::init(config);
-                      
-        initted = true;
+
         return true;
     }
     

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.cpp
@@ -40,6 +40,18 @@ using namespace embot::core::binary;
     
 namespace embot::hw::bsp {
     
+    bool _initted {false};
+    
+    bool initialised()
+    {
+        return _initted;
+    }
+    
+    void initialised(bool v)
+    {
+        _initted = v;
+    }
+    
     static uint32_t _get1millitick()
     {
         return embot::core::now() / 1000;        
@@ -48,6 +60,8 @@ namespace embot::hw::bsp {
     bool init(const embot::hw::Config &config)
     {                  
         embot::hw::bsp::DRIVER::init(config);
+        
+        embot::hw::bsp::initialised(true);
         
         // perform further initialization defined board by board        
         specialize();

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.h
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_bsp.h
@@ -41,6 +41,8 @@ namespace embot::hw::bsp {
                 
     bool initialised();
     
+    void initialised(bool v);
+    
     // it is used by embot::hw::init().
     // it calls the proper initialisations for the chosen HAL (e.g., stm32hal) etc. 
     bool init(const embot::hw::Config &config); 


### PR DESCRIPTION
This PR improves that initialization phase of the `embot::hw` environment so that it is now possible to initialize any `embot::hw` device also inside `embot::hw::specialize()` that is called by `embot::hw::init()` to serve special needs of a board.

This is useful because on the `amcfoc` board we need to call embot::hw::eeprom::init() inside `embot::hw::specialize()` so that we can start reading the `EEPROM` straight away.


