### PR TITLE
Current measure filtering added to MC4+ boards.

### DIFF
--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOCurrentsWatchdog.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOCurrentsWatchdog.c
@@ -313,7 +313,8 @@ extern void eo_currents_watchdog_Tick(EOCurrentsWatchdog* p, int16_t voltage, in
 #endif
     
     int16_t current_value = 0;
-
+    int16_t current_value_filt = 0;
+    
     for (uint8_t i = 0; i < s_eo_currents_watchdog.numberofmotors; i++)
     {
         //get current value
@@ -321,13 +322,13 @@ extern void eo_currents_watchdog_Tick(EOCurrentsWatchdog* p, int16_t voltage, in
         
         //Update currents broadcasted
         //s_eo_currents_watchdog_UpdateMotorCurrents(i, current_value);
-        MController_update_motor_current_fbk(i, current_value);
+        current_value_filt = MController_update_motor_current_fbk(i, current_value);
         
         // moved into s_eo_currents_watchdog_UpdateMotorCurrents
         //error flags signalling is done internally
         //s_eo_currents_watchdog_CheckSpike(i, current_value);
         
-        s_eo_currents_watchdog_CheckI2T(i, current_value);
+        s_eo_currents_watchdog_CheckI2T(i, current_value_filt);
         
 
         //added following code only 4 debug purpose

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,7 +84,7 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          111
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          112
 
 //  </h>version
 
@@ -92,9 +92,9 @@ extern "C" {
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          07
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          01
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.c
@@ -1450,9 +1450,9 @@ void MController_update_motor_pos_fbk(int m, int32_t position_raw)
     Motor_update_pos_fbk(smc->motor+m, position_raw);
 }
 
-void MController_update_motor_current_fbk(int m, int16_t current)
+int16_t MController_update_motor_current_fbk(int m, int16_t current)
 {
-    Motor_update_current_fbk(smc->motor+m, current);
+    return Motor_update_current_fbk(smc->motor+m, current);
 }
 
 void MController_update_motor_temperature_fbk(int m, int16_t temperature)

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Controller.h
@@ -84,7 +84,7 @@ extern void MController_get_pid_state(int j, eOmc_joint_status_ofpid_t* pid_stat
 extern void MController_get_motor_state(int m, eOmc_motor_status_t* motor_status);
 extern void MController_update_joint_targets(int j);
 extern void MController_update_motor_pos_fbk(int m, int32_t position_raw);
-extern void MController_update_motor_current_fbk(int m, int16_t current);
+extern int16_t MController_update_motor_current_fbk(int m, int16_t current);
 extern void MController_update_motor_temperature_fbk(int m, int16_t temperature);
 extern void MController_config_motor_friction(int m, eOmc_motor_params_t* params); //
 extern void MController_config_joint_impedance(int j, eOmc_impedance_t* impedance); //

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -281,6 +281,7 @@ void JointSet_do_odometry(JointSet* o) //
                 else
                 {
                     o->joint[j].vel_fbk = AbsEncoder_velocity(o->absEncoder+j);
+                    o->motor[j].vel_raw_fbk = o->joint[j].vel_fbk * o->motor[j].GEARBOX;  
                 }
             }
         }

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor.h
@@ -89,7 +89,7 @@ extern void Motor_set_vel_ref(Motor* o, int32_t vel_ref);
 extern void Motor_get_pid_state(Motor* o, eOmc_joint_status_ofpid_t* pid_state);
 extern void Motor_get_state(Motor* o, eOmc_motor_status_t* motor_status);
 extern void Motor_update_pos_fbk(Motor* o, int32_t position_raw);
-extern void Motor_update_current_fbk(Motor* o, int16_t current);
+extern int16_t Motor_update_current_fbk(Motor* o, int16_t current);
 extern void Motor_update_temperature_fbk(Motor* o, int16_t temperature);
 
 extern void Motor_set_i2t_fault(Motor* o);

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Motor_hid.h
@@ -87,6 +87,8 @@ typedef struct //HardStopCalibData
     
 } HardStopCalibData;
 
+#define NCURRENT_SAMPLES (20)
+
 ////first order moving average
 //constexpr float NUM_SAMPLE_MOV_AVERAGE = 100.0;
 //constexpr float FACTOR_A = 1.0/NUM_SAMPLE_MOV_AVERAGE;
@@ -204,6 +206,8 @@ struct Motor_hid
     int32_t Iqq_ref;
     int32_t Iqq_fbk;
     int32_t Iqq_ovl;
+    int32_t Iqq_peak;
+    int32_t Iqq_nom;
     int32_t Iqq_err;
     int32_t Iqq_fbk_mean;
     
@@ -243,6 +247,11 @@ struct Motor_hid
     uint8_t can_motor_config[7];
     //BOOL outOfLimitsSignaled;
     MovingAverage mv_avg={100,0};
+
+    int16_t current_samples[NCURRENT_SAMPLES];
+    int16_t current_sample_index;
+    float Kbemf;
+    float InvElRes;
 
 #if defined(SENSORLESS_TORQUE)
     float torque;


### PR DESCRIPTION
The filter makes a moving average on 20 samples removing the max and min values. 
The firmware can estimate the current instead of measuring it if motor parameters Kbemf and Resistance are sent.