### PR TITLE
amc: fix ICC discovery when only CAN protocol is available

### DIFF
--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_AGENTadvfoc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_Service_impl_mc_AGENTadvfoc.cpp
@@ -801,6 +801,10 @@ bool AGENTadvfoc::iccdiscovery(void *tHIS)
                         {
                             
                         }
+                        else if(0 == (target.firmware.major + target.firmware.minor + target.firmware.build))
+                        {
+                            
+                        }
                         else
                         {
                             desc.par16 |= 0x2;


### PR DESCRIPTION
as per title. Tested on amc lego setup.