### PR TITLE
Improved the `eloader` for dualcore boards so that it is more robust vs EEPROM initialization failure

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/environment/eloader/src/info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc/environment/eloader/src/info.cpp
@@ -30,16 +30,16 @@ constexpr eEmoduleExtendedInfo_t s_loader_info_extended __attribute__((section(E
                 .signature  = ee_procLoader,
                 .version    = 
                 { 
-                    .major = 3, 
-                    .minor = 3
+                    .major = 4, 
+                    .minor = 0
                 },  
                 .builddate  = 
                 {
-                    .year  = 2025,
-                    .month = 10,
-                    .day   = 02,
+                    .year  = 2026,
+                    .month = 3,
+                    .day   = 3,
                     .hour  = 11,
-                    .min   = 11
+                    .min   = 34
                 }
             },
             .rom        = 

--- a/emBODY/eBcode/arch-arm/board/common/env/dualcore/eLoader/eloader-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/common/env/dualcore/eLoader/eloader-main.cpp
@@ -1,7 +1,7 @@
 
 
 /*
- * Copyright (C) 2025 iCub Tech - Istituto Italiano di Tecnologia
+ * Copyright (C) 2026 iCub Tech - Istituto Italiano di Tecnologia
  * Author:  Marco Accame
  * email:   marco.accame@iit.it
 */
@@ -13,17 +13,80 @@ this file can be used by the dualcore boards for the loader and it supports both
 - the one specified by EMBOT_ENABLE_hw_dualcore defined inside embot_hw_bsp_config.h (by amcfoc and others) 
 
 moreover, the flash addresses can be obtained by using macros inside eEmemorymap.h but also by calling 
-embot::hw::sys::partition(embot::hw::flash::Partition::ID::whatever).address which however cannot be used as constexpr 
+embot::hw::sys::partition(embot::hw::flash::Partition::ID::whatever).address which however cannot be used as 
+constexpr 
+
+this new version of the eloader simplify the stream of execution and take sint account possible errors in EEPROM 
+initialization 
 
 #endif
 
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// macros that should typically stay undefined
+
+// if defined, every time the loader runs, it will force the eeprom to have def2run = application
+// caveat: best using this macro just for one run
+#undef DEBUG_forceEEPROM_DEF2RUNequalAPPLICATION
+// if defined, the loader does not jump and forces execution of defaultapplication() 
+#undef DEBUG_stayinhere
+// if defined, the loader enables and starts the other core inside embot::hw::init()
+#undef DEBUG_startOtherCOREnow
+// if defined, every time the loader runs after reset (not forced by IPC) it forces the erase of the EEPROM 
+// and its reinitalization. 
+// caveat: best using this macro just for one run
+#undef DEBUG_eraseEEPROM
+
+// --------------------------------------------------------------------------------------------------------------------
+// macros that are defined by external definition of others
+
+// macro shaper for having the code of the loader that acts as a launcher of the other core
+#if defined(CM7launcher) || defined(CM4launcher)
+#define OtherCORElauncher
+#endif
+
+// the OtherCORElauncher starts the other core and does not force a jump
+#if defined(OtherCORElauncher)
+#define DEBUG_startOtherCOREnow
+#define DEBUG_stayinhere
+#endif
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// macros that can be used for extra feature or for debug
+
+#define attemptFIXeeprom
+
+#if defined(attemptFIXeeprom)
+// if defined, in case the eeprom is initted correctly but than not read correctly it avoids to force a value of
+// def2run = updater. the disadvantage is that when EEPROM is erased the FirmwareUpdater tells the def2run is None
+#define DONTFORCE_def2run
+#define DEBUG_log2eeprom
+//#define continuousRESET
+#endif
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// includes
+
+#include "stm32hal.h"
 #include "embot_core.h"
 #include "embot_hw.h"
 #include "embot_hw_sys.h"
 #include "embot_hw_led.h"
 #include "embot_hw_bsp_config.h"
+#include "embot_hw_eeprom.h"
 
+#include "eEsharedServices.h" 
+#include "board-info.h"
+#include "module-info.h"
 
+// --------------------------------------------------------------------------------------------------------------------
+// hw config
+
+namespace eloader::hw::config {
+    
 // in here we run the baremetal embot::hw application.
 // for the required get1microtime() we can either use a very naked approach or even the systick
 
@@ -31,7 +94,6 @@ embot::hw::sys::partition(embot::hw::flash::Partition::ID::whatever).address whi
 
 #if defined(USE_SYSTICK_AS_TIME_BASE)
 
-#include "stm32hal.h"
 
 static volatile uint64_t s_1mstickcount = 0; // it must be volatile
 constexpr uint32_t s_rate1khz = 1000;
@@ -79,38 +141,21 @@ constexpr embot::hw::Config hwCFG {nullptr, get1microtime2};
 
 #endif // USE_SYSTICK_AS_TIME_BASE
 
-
-// principal debug macros
-
+} // namespace eloader::hw::config {
 
 
-// if defined it forces the eeprom to have def2run = application, so that the eupdater will jump to application 
-#undef DEBUG_forceEEPROM_DEF2RUNequalAPPLICATION
-// if defined it does not jump and forces execution of defaultapplication() 
-#undef DEBUG_stayinhere
-// if defined it enables the other core after clock initialization inside embot::hw::init()
-#undef DEBUG_startOtherCOREnow
-#undef DEBUG_eraseEEPROM
-
-#if defined(CM7launcher) || defined(CM4launcher)
-#define OtherCORElauncher
-#endif
+// --------------------------------------------------------------------------------------------------------------------
+// some constants
 
 #if defined(OtherCORElauncher)
-#define DEBUG_startOtherCOREnow
-#define DEBUG_stayinhere
 constexpr embot::core::relTime applblinkrate {250*embot::core::time1millisec};
 #else
 constexpr embot::core::relTime applblinkrate {100*embot::core::time1millisec};
 #endif
 
 
-// used functions
-
-void thejumper(); 
-
-[[noreturn]] void defaultapplication(embot::core::relTime blinkrate = applblinkrate);
-
+// --------------------------------------------------------------------------------------------------------------------
+// some functions
 
 #if defined(EMBOT_ENABLE_hw_dualcore)
 #warning EMBOT_ENABLE_hw_dualcore is defined
@@ -138,21 +183,67 @@ void prepareHWinit()
 }
 #endif
 
+void initHWbasic();
+void thejumper(); 
+[[noreturn]] void defaultapplication(embot::core::relTime blinkrate = applblinkrate);
 
+// --------------------------------------------------------------------------------------------------------------------
+// main
     
 int main(void)
-{ 
-    // actions required before call of embot::hw::init()
-    prepareHWinit();
-    
-    embot::hw::init(hwCFG);
+{  
+    initHWbasic();
     
 #if !defined(DEBUG_stayinhere) 
-    // eval jump
     thejumper();
-#endif    
-    // run default application
+#endif  
+    
+    // only if the jump fails, then run default application
     defaultapplication();         
+}
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// other functions
+
+void initHWbasic()
+{
+    // actions required before call of embot::hw::init()
+    prepareHWinit();        
+    embot::hw::init(eloader::hw::config::hwCFG); 
+}
+
+void ipcJUMP();
+void eepromJUMP();
+void blindJUMP();
+
+static void s_loader_manage_error(embot::core::relTime rate = 100*embot::core::time1millisec)
+{
+    defaultapplication(rate);
+}
+    
+void thejumper()
+{ 
+    // attempt an ipc jump. that means that is the updater or application that order to jump somewhere. 
+    // for here we just need to use ipc ram, no eeprom is needed 
+    // if there is an ipc command ipcJUMP() does not return     
+    ipcJUMP();
+
+    // there was not an ipc jump. i now need eeprom, but i want to be sure that we can init it, so ...   
+    // init eeprom just now and keep result
+    embot::hw::result_t r = embot::hw::eeprom::init(embot::hw::EEPROM::one, {});
+    
+    // keep it commented. uncomment it just for test         
+//    r = embot::hw::resNOK;
+        
+    if(embot::hw::resOK == r)
+    {   // the eeprom is available. i use it to synch some info to it and then i do a jump to def2run
+        eepromJUMP();
+    }
+    else
+    {   // the eeprom fails initialization. i attempt a jump w/out reading from eeprom where to jump
+        blindJUMP();
+    }
 }
 
 
@@ -167,56 +258,109 @@ int main(void)
 }
 
 
-// - dependencies
-
-#include "embot_hw_eeprom.h"
-#include "eEsharedServices.h" 
-#include "board-info.h"
-#include "module-info.h"
-
+// --------------------------------------------------------------------------------------------------------------------
+// other functions
 
 static void s_loader_shared_services_init(void);
-static void s_loader_manage_error(embot::core::relTime rate = 100*embot::core::time1millisec);
+static void s_loader_shared_services_synch(void);
 static void s_loader_exec_loader(void);
-static void s_loader_eval_jump_request_from_an_eproc(void);
-static void s_loader_attempt_jump(eEprocess_t proc, uint32_t adr_in_case_proc_fails);
+enum class attemptJUMPmode { dontuseSTORAGEinfo, useSTORAGEinfo };
+static void s_loader_attempt_jump(eEprocess_t proc, attemptJUMPmode ajm, uint32_t adr_in_case_proc_fails);
 
 constexpr uint32_t LOADER_ADR_INVALID {0xffffffff};
 
 
-void thejumper()
+// it checks if an eproc requests a jump. no eeprom is needed in here
+void ipcJUMP()
 {
-//	#warning asfidanken must verify this
-#if defined(DEBUG_eraseeeprom)
-    embot::hw::eeprom::init(embot::hw::EEPROM::one, {});
+    // important:
+    // we can use shalbase_ipc_*() and shalbase_system_*() functions w/out a shalbase_init()
+    
+    eEprocess_t pr = ee_procNone;
+
+    if(ee_res_OK == ee_sharserv_ipc_gotoproc_get(&pr))
+    {
+        ee_sharserv_ipc_gotoproc_clr();
+        
+        if(ee_procUpdater == pr)
+        {   // we communicate to the updater to stay forever and not to jump to default after the 5 (or what) seconds
+            ee_sharserv_ipc_gotoproc_set(ee_procUpdater);
+        }
+        
+        // attempt only to the requested process and dontuseSTORAGEinfo because EEPROM is not initted yet
+        s_loader_attempt_jump(pr, attemptJUMPmode::dontuseSTORAGEinfo, LOADER_ADR_INVALID);
+        
+        // if in here ... the jump failed, thus ... behave as if no order at all
+        ee_sharserv_ipc_gotoproc_clr();        
+    }
+    
+    // else we dont have a process to jump to but maybe an address ....
+    uint32_t address2jump = 0;
+    if(ee_res_OK == ee_sharserv_ipc_jump2addr_get(&address2jump))
+    {
+        ee_sharserv_ipc_jump2addr_clr();
+           
+        if(ee_res_OK == ee_sharserv_sys_canjump(address2jump))
+        {
+            ee_sharserv_sys_jumpnow(address2jump);
+        }          
+    }
+    
+    // else ... we dont have any ipc or we have but we have failed to jump there.
+    // so: we attempt something else
+        
+}
+
+void blindJUMP()
+{    
+    // we dont know anything from eeprom, so we attempt a jump to ee_procUpdater
+    uint32_t address = embot::hw::sys::partition(embot::hw::flash::Partition::ID::eupdater).address;
+    
+    if(ee_res_OK == ee_sharserv_sys_canjump(address))
+    {
+        ee_sharserv_sys_jumpnow(address);
+    }     
+}
+
+
+void eepromJUMP()
+{    
+    // we have the eeprom already activated, so we use the shared services to operate w/ that 
+        
+#if defined(DEBUG_eraseEEPROM)
     embot::hw::eeprom::erase(embot::hw::EEPROM::one, 3*embot::core::time1millisec); // 0, 8*1024);   
-#endif    
+#endif  
+    
+    // inits the complete shared services: 
+    // - shalbase 
+    //    - w/ eeprom storage that if already initted does not reinit itself again;
+    //    - w/ ipc
+    // - shalpart that loads the partition table from eeprom to cached ram
+    
     s_loader_shared_services_init();
     
-    s_loader_eval_jump_request_from_an_eproc();
-    
+    // in here we uses the eeprom storage to enforce synchronization of some data (uinque id, board type, eloader version)
+    s_loader_shared_services_synch();    
+
+    // and finally we attempt jumping by getting the startup process from the eeprom storage or to the default
+        
     eEprocess_t startup = ee_procNone;
-    eEresult_t eeres = ee_sharserv_part_proc_startup_get(&startup);
-    if(ee_res_NOK_generic == eeres)
+    if(ee_res_NOK_generic == ee_sharserv_part_proc_startup_get(&startup))
     {
         startup = ee_procUpdater;
     }
-    s_loader_attempt_jump(startup, LOADER_ADR_INVALID);
+    s_loader_attempt_jump(startup, attemptJUMPmode::useSTORAGEinfo, LOADER_ADR_INVALID);
     
     // if it fails a jump to startup ... do a last attempt to jump to eUpdater
-    s_loader_attempt_jump(ee_procUpdater, LOADER_ADR_INVALID);
+    s_loader_attempt_jump(ee_procUpdater, attemptJUMPmode::useSTORAGEinfo, LOADER_ADR_INVALID);
 
     // if we are in here we cannot jump to the startup and not even to the updater.
-    s_loader_manage_error();        
+    // the error will be managed elsewhere
 }
 
 
-// - static functions
-
-static void s_loader_manage_error(embot::core::relTime rate)
-{
-    defaultapplication(rate);
-}
+// --------------------------------------------------------------------------------------------------------------------
+// other functions
 
 static void s_on_sharserv_error(void)
 {
@@ -224,11 +368,7 @@ static void s_on_sharserv_error(void)
 }
 
 static void s_loader_shared_services_init(void)
-{
-
-    eEprocess_t defproc = ee_procNone;
-    eEprocess_t startup = ee_procNone;
-    
+{    
     sharserv_mode_t sharservmode = 
     {
         .onerror    = s_on_sharserv_error,
@@ -248,9 +388,16 @@ static void s_loader_shared_services_init(void)
         }        
     }
     
-    // now all are initted. then ...
+}
 
-    // put signature in partition table
+static void s_loader_shared_services_synch(void)
+{   
+    // now all are initted. then ...
+    
+    eEprocess_t defproc = ee_procNone;
+    eEprocess_t startup = ee_procNone;    
+      
+    // make sure signature of eloader in partition table is ok
     if(ee_res_OK != ee_sharserv_part_proc_synchronise(ee_procLoader, (const eEmoduleInfo_t *)env::dualcore::module::info::get()))
     {
         s_loader_manage_error();
@@ -259,88 +406,88 @@ static void s_loader_shared_services_init(void)
     // impose unique id
     env::dualcore::board::info::set(embot::hw::sys::uniqueid());
     
+    // make sure info of the board stored in eeprom is correct
     if(ee_res_OK != ee_sharserv_info_boardinfo_synchronise(env::dualcore::board::info::get()))
     {
         s_loader_manage_error();
-    }    
+    }  
+
+#if defined(DEBUG_log2eeprom)
+    bool log2eeprom {false};
+#endif    
        
-    // impose startup process
+    // makes sure that the startup process is in partition table.
+    // after the EEPROM is erased (or first time ever the eloader runs) the startup is not imposed, 
+    // function returns NOK, so we need to set it to updater
     if(ee_res_OK != ee_sharserv_part_proc_startup_get(&startup))
     {
         // we impose that the startup process is the updater
         ee_sharserv_part_proc_startup_set(ee_procUpdater);
+#if defined(DEBUG_log2eeprom)
+        log2eeprom = true;
+#endif          
     }  
     
-    // impose def2run process
+    // makes sure that the def2run process is in partition table.
+    // after the EEPROM is erased (or first time ever the eloader runs) the def2run is not imposed, 
+    // function returns NOK, so we need to set it to ... updater
+    // the macro DONTFORCE_def2run does not force any value for it. 
     if(ee_res_OK != ee_sharserv_part_proc_def2run_get(&defproc))
     {
+#if defined(DONTFORCE_def2run)
+        // we dont impose a defproc ... 
+#else
         // we impose that the default process is the updater     
         ee_sharserv_part_proc_def2run_set(ee_procUpdater);      
-    } 
+#endif  
+
+#if defined(DEBUG_log2eeprom)
+        log2eeprom = true;
+#endif                
+    }
+    
+#if defined(DEBUG_log2eeprom)
+    if(true == log2eeprom)
+    {
+        char buffer[64] = {0};
+        snprintf(buffer, sizeof(buffer), "happened: st=0x%02X, dp=0x%02X", startup, defproc);         
+        ee_sharserv_info_deviceinfo_item_set(sharserv_info_page32, buffer);      
+    }
+#endif       
+ 
 
 #if defined(DEBUG_forceEEPROM_DEF2RUNequalAPPLICATION)
     // we impose that the application is the def2run
     ee_sharserv_part_proc_def2run_set(ee_procApplication);
-#endif    
-}
-
-// used to eval the jump request coming from another process
-static void s_loader_eval_jump_request_from_an_eproc(void)
-{
-    eEprocess_t pr = ee_procNone;
-
-    if(ee_res_OK == ee_sharserv_ipc_gotoproc_get(&pr))
-    {
-        ee_sharserv_ipc_gotoproc_clr();
-        
-        if(ee_procUpdater == pr)
-        {   // we communicate to the updater to stay forever and not to jump to default after the 5 (or what) seconds
-            ee_sharserv_ipc_gotoproc_set(ee_procUpdater);
-        }
-        
-        // attempt only to the requested process.
-        s_loader_attempt_jump(pr, LOADER_ADR_INVALID);
-        
-        // if in here ... the jump failed, thus ... behave as if no order at all
-        ee_sharserv_ipc_gotoproc_clr();
-        
-//        // if in here ... the jump failed, thus ... it is better to go to the updater and stay there forever
-//        ee_sharserv_ipc_gotoproc_set(ee_procUpdater);
-//        s_loader_attempt_jump(ee_procUpdater, LOADER_ADR_INVALID);
-        
-    }
-    
-    uint32_t address2jump = 0;
-    if(ee_res_OK == ee_sharserv_ipc_jump2addr_get(&address2jump))
-    {
-        ee_sharserv_ipc_jump2addr_clr();
-           
-        if(ee_res_OK == ee_sharserv_sys_canjump(address2jump))
-        {
-            ee_sharserv_sys_jumpnow(address2jump);
-        }   
-       
-    }    
+#endif 
+   
 }
 
 // used to attempt a jump to a process 
-static void s_loader_attempt_jump(eEprocess_t proc, uint32_t adr_in_case_proc_fails)
+static void s_loader_attempt_jump(eEprocess_t proc, attemptJUMPmode ajm, uint32_t adr_in_case_proc_fails)
 {
     uint32_t address = LOADER_ADR_INVALID;
 
     if(ee_procNone != proc)
     {
-
         if(ee_procLoader == proc)
         {
             // avoid recursive bootstraps
             s_loader_exec_loader();
         }
-     
+        
+        // now we get an address to jump to
+        
+        // if we are allowed we
         // attempt to get the address of the proc from partition table.
         // it works only if the process already run before and register itself in the partition table.
-        // if it fails ... use brute force mode
-        if(ee_res_NOK_generic == ee_sharserv_part_proc_runaddress_get(proc, &address))
+        if(attemptJUMPmode::useSTORAGEinfo == ajm)
+        {
+            ee_sharserv_part_proc_runaddress_get(proc, &address);
+        }
+        
+        // if we are not allowed or if the previous fails then we  ... use brute force mode
+        if(LOADER_ADR_INVALID == address)
         {
             switch(proc)
             {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_chip_M95512DF.cpp
@@ -223,13 +223,36 @@ bool embot::hw::chip::M95512DF::Impl::init(const Config &cfg)
     
     initpincontrol();
     
+    // i wait mainly to be sure that the chip is stable after a powerup
+    embot::core::wait(3*embot::core::time1millisec);
+    
     hold(false);
     writeprotect(false);
-    if(resOK == embot::hw::spi::init(_config.spi, _config.spicfg))
+    if(resOK != embot::hw::spi::init(_config.spi, _config.spicfg))
     {
-        _initted =  true;
+        // i deinit and then return false. i need _initted true however
+        _initted = true;
+        deinit();
+        return false;
     }
     
+    // spi is ok. now i see if the chip is ok as well    
+    // test reading of status register
+    uint8_t status {1};
+    cmdrx(CMD::RDSR, status);
+        
+    if((status & 0x03) == 0x00)
+    {
+        _initted = true;
+    }
+    else
+    {
+        // cannot read. i deinit and then return false. i need _initted true however
+        _initted = true;
+        deinit();
+        return false;
+    }
+              
     return _initted; 
 }
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eeprom.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_eeprom.cpp
@@ -130,7 +130,14 @@ namespace embot { namespace hw { namespace eeprom {
         if(embot::hw::eeprom::Type::chipM95512DF == type)
         {
             s_privatedata.chipM95512DF[index] = new embot::hw::chip::M95512DF;
-            s_privatedata.chipM95512DF[index]->init(eeprombsp.getPROP(ee)->multi.chipM95512DFcfg);
+            bool chipisOK = s_privatedata.chipM95512DF[index]->init(eeprombsp.getPROP(ee)->multi.chipM95512DFcfg);
+            if(false == chipisOK)
+            {
+                // deinit() works only if initialised(), so...
+                embot::core::binary::bit::set(initialisedmask, index);
+                deinit(ee);
+                return resNOK;            
+            }
         }
                 
         embot::core::binary::bit::set(initialisedmask, index);

--- a/emBODY/eBcode/arch-arm/libs/highlevel/services/embenv/src/eEsharedServices.c
+++ b/emBODY/eBcode/arch-arm/libs/highlevel/services/embenv/src/eEsharedServices.c
@@ -202,7 +202,9 @@ extern eEresult_t ee_sharserv_isvalid(void)
     // nothing as i have used inline functions defined in header
 #endif
 
-//#define MOVEIT
+// better define it because in this way we call shalbase_init() before
+// we call shalbase_storage_get() after
+#define MOVEIT
 extern eEresult_t ee_sharserv_init(const sharserv_mode_t* mode)
 {
 


### PR DESCRIPTION
This PR improves the `eloader` of the dualcore boards so that if the EEPROM is detected to fail its initialization the 
code doe not attempt to regularize it anymore.

That has solved (so far) the rare phenomenon of `amc` boards seldom found in maintenance mode despite nobody changed the def-to-run process to `eupdater`.

The mode the `eloader` is more robust is:
- the `embot::hw::eeprom` driver detects any failure of initializing the used EEPROM chip
- the driver for the `M95512DF` chip (teh EEPOM used in the dualcore boards) now returns OK only if we can correctly read its status register
- the `eloader` program  implements an improved workflow:
   - if it detects in IPC RAM a jump command it only jumps
   - if not: at first it initializes the EEPROM. 
   - In case EEPROM is OK it performs as usual (checks its regular structure, jumps to start process)
   - In case EEPROM is not OK, it does NOT attempts to write to EEPROM. It just jumps to updater.


The `eloader` has been extensively tested on different `amc` boards which showed the rare phenomenon of auto set of maintenance mode and did never showed it.

