### PR TITLE
Fix amc encoder none bug in configuration file

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 33},
-            {2025, Month::Nov, Day::nineteen, 17, 17}
+            {2, 34},
+            {2026, Month::Apr, Day::nineteen, 17, 17}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -39,7 +39,7 @@ namespace embot { namespace app { namespace eth {
         {
             Process::eApplication,
             {2, 34},
-            {2026, Month::Apr, Day::nineteen, 17, 17}
+            {2026, Month::Apr, Day::twentyone, 16, 16}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -384,9 +384,12 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
             case eomc_enc_aksim2:
             {
                 cfg.type = embot::hw::encoder::Type::chipMB049;
-            } break;
-            case eomc_enc_unknown:
+            } break; 
             case eomc_enc_none:
+            {
+                cfg.type = embot::hw::encoder::Type::none;
+            } break; 
+            case eomc_enc_unknown:
             default:
             {
                 //unknown/no/unsupported encoder

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -560,7 +560,7 @@ bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth
                
             } break;
             
-            case none:
+            case eomc_enc_none:
             {
                 
             } break;

--- a/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
+++ b/emBODY/eBcode/arch-arm/embot/app/eth/embot_app_eth_theEncoderReader.cpp
@@ -384,7 +384,7 @@ bool embot::app::eth::theEncoderReader::Impl::Activate(const Config &config)
             case eomc_enc_aksim2:
             {
                 cfg.type = embot::hw::encoder::Type::chipMB049;
-            } break; 
+            } break;
             case eomc_enc_none:
             {
                 cfg.type = embot::hw::encoder::Type::none;
@@ -560,6 +560,11 @@ bool embot::app::eth::theEncoderReader::Impl::Read(uint8_t jomo, embot::app::eth
                
             } break;
             
+            case none:
+            {
+                
+            } break;
+                
             default:
             {   // we have not recognised any valid encoder type
                 prop.valueinfo->errortype = embot::app::eth::encoder::v1::Error::GENERIC;   
@@ -601,18 +606,17 @@ bool embot::app::eth::theEncoderReader::Impl::TestRead(const Config &config)
        
         if(resNOK == embot::hw::encoder::read(enc, pos, 5*embot::core::time1millisec))     
         {                        
-            diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par16 | (1<<i);
             switch(_implconfig.jomo_cfg[i].encoder1des.type)
             {
+                case eomc_enc_none:
+                {  
+                    continue;
+                }break;
                 case eomc_enc_aea:
                 case eomc_enc_aea3:
                 {
                     diagnostics.errorDescriptor.par64 = diagnostics.errorDescriptor.par64 | (embot::core::tointegral(embot::app::eth::encoder::v1::Error::AEA_READING)<<(i*4));
                 } break;
-                case eomc_enc_none:
-                {  
-                    continue;
-                }break;
                 case eomc_enc_aksim2:
                 case eomc_enc_unknown:
                 default:
@@ -620,6 +624,7 @@ bool embot::app::eth::theEncoderReader::Impl::TestRead(const Config &config)
                     diagnostics.errorDescriptor.par64 = diagnostics.errorDescriptor.par64 | (embot::core::tointegral(embot::app::eth::encoder::v1::Error::GENERIC)<<(i*4));
                 } break;
             }
+            diagnostics.errorDescriptor.par16 = diagnostics.errorDescriptor.par16 | (1<<i);
 //            embot::core::print("theEncoderReader: encoder test reading fails");   
             ret = false;            
         }

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -152,7 +152,7 @@ namespace embot::hw::encoder {
         }
         else if(embot::hw::encoder::Type::none == cfg.type)
         {
-            
+            return resOK;
         }
         else
         {

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_encoder.cpp
@@ -150,6 +150,10 @@ namespace embot::hw::encoder {
                         } 
             );
         }
+        else if(embot::hw::encoder::Type::none == cfg.type)
+        {
+            
+        }
         else
         {
             //this error message is for debugging on keil


### PR DESCRIPTION
fix amc encoder none bug: yarprobotinterface didn't started correctly when using encoder type none in configuration file.
Resolved this issue affecting amc board.
