### PR TITLE
Updates for fix of calibration type 7 absEncoder-EoEncoderReader sign inconsistency

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+++ b/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
@@ -38,8 +38,8 @@ namespace embot { namespace app { namespace eth {
         .property =
         {
             Process::eApplication,
-            {2, 31},
-            {2025, Month::Nov, Day::seven, 17, 17}
+            {2, 34},
+            {2026, Month::Jun, Day::five, 17, 17}
         },
         .OStick = 1000*embot::core::time1microsec,
         .OSstacksizeinit = 10*1024,

--- a/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+++ b/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
@@ -39,9 +39,9 @@ namespace embot::app::board::amc2c::info {
     {
         embot::app::boards::Board::amc2c,
         {embot::app::msg::BUS::icc1, address},
-        {3, 12, 0, 0},   // application version
+        {3, 13, 0, 0},   // application version
         {2, 0},         // protocol version
-        {2025, embot::app::eth::Month::Aug, embot::app::eth::Day::eleven, 10, 47}
+        {2026, embot::app::eth::Month::Jun, embot::app::eth::Day::five, 13, 13}
     };
     
     constexpr embot::app::msg::Location icclocation {signature.location};

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -81,20 +81,20 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          112
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          113
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2026
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        2
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          027
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          3
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          14
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MIN          11
 //  </h>build date
 // </h>Info 
 

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
@@ -492,7 +492,6 @@ extern eOresult_t eo_encoderreader_Read(EOtheEncoderReader *p, uint8_t jomo, eOe
     {
         return(eores_NOK_generic);
     }
-
     eOresult_t res = eo_appEncReader_GetValue(s_eo_theencoderreader.reader, jomo, primary, secondary); 
     
     return(res);

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheEncoderReader.c
@@ -561,6 +561,10 @@ extern eOresult_t eo_encoderreader_Scale(EOtheEncoderReader* p, uint8_t jomo, eO
     if((primary == eomc_enc_mais) || (secondary == eomc_enc_mais))
     {
         r = eo_appEncReader_UpdatedMaisConversionFactors(eo_appEncReader_GetHandle(), jomo, scaler->scale);
+        if(eores_OK == r)
+        {
+            r = eo_appEncReader_UpdatedMaisOffsets(eo_appEncReader_GetHandle(), jomo, scaler->offset);
+        }
     }
     else if((primary == eomc_enc_absanalog) || (secondary == eomc_enc_absanalog))
     {

--- a/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
+++ b/emBODY/eBcode/arch-arm/board/ems004/appl/v2/src/eoappservices/EOtheMotionController.c
@@ -619,7 +619,13 @@ extern eOresult_t eo_motioncontrol_Verify(EOtheMotionController *p, const eOmn_s
         // marco.accame.TODO: fix it. we must be sure that in encoder-reader the read from adc is ok during its _Verify()
         // for now this call is inside eo_motioncontrol_Activate(), just before eo_encoderreader_Activate() ... 
         // marco.accame: it is required to read adc values if the encoder is absanalog (aka adc).
-        // s_eo_motioncontrol_mc4plusbased_hal_init_motors_adc_feedbacks();
+        
+        // we need to init the adc before Encoderreader::Verify() otherwise the encreader_err_ABSANALOG_GENERIC will be risen because the encoder reader needs to read adc values to verify the absanalog encoders.
+        // For future we should split the init of adc feedbacks from the init of motors, because in some cases we might have encoders which are not absanalog and hence dont require adc init, but for now we keep it simple and we call this function which init both motors and adc feedbacks.
+        // this should prevent from having the error encreader_err_ABSANALOG_GENERIC during the verify of encoders in case that some of them are absanalog.
+        // the call in the Activate() is not a problem since the helper has a static initted guard that would prevent re-initialisation
+        // however we should not remove it since the pipeline of the motion control might be different
+        s_eo_motioncontrol_mc4plusbased_hal_init_motors_adc_feedbacks();
         
         // for now verify the encoder reader. 
         // we dont verify the pwm actuators. only way to do that is to add a hal_pwm_supported_is()
@@ -641,7 +647,8 @@ extern eOresult_t eo_motioncontrol_Verify(EOtheMotionController *p, const eOmn_s
         
         // marco.accame.TODO: fix it. we must be sure that in encoder-reader the read from adc is ok during its _Verify()
         // marco.accame: it is required to read adc values if the encoder is absanalog (aka adc).
-        // s_eo_motioncontrol_mc4plusbased_hal_init_motors_adc_feedbacks();       
+        // same as group above
+        s_eo_motioncontrol_mc4plusbased_hal_init_motors_adc_feedbacks();       
         
         p->service.onverify = onverify;
         p->service.onverifyarg = p;

--- a/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -75,17 +75,17 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          3
 //  <o> minor           <0-255> 
 //  <o> minor           <0-255>
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          90
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          92
 
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
+#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2026
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        11
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        06
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          07
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          03
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+++ b/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
@@ -84,17 +84,17 @@ extern "C" {
 #define EOMTHEEMSAPPLCFG_VERSION_MAJOR          (VERSION_MAJOR_OFFSET+3)
 //  <o> minor           <0-255> 
 
-#define EOMTHEEMSAPPLCFG_VERSION_MINOR          112
+#define EOMTHEEMSAPPLCFG_VERSION_MINOR          114
 
 //  </h>version
 
 //  <h> build date
 //  <o> year            <2010-2030>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2025
+#define EOMTHEEMSAPPLCFG_BUILDDATE_YEAR         2026
 //  <o> month           <1-12>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        12
+#define EOMTHEEMSAPPLCFG_BUILDDATE_MONTH        6
 //  <o> day             <1-31>
-#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          01
+#define EOMTHEEMSAPPLCFG_BUILDDATE_DAY          3
 //  <o> hour            <0-23>
 #define EOMTHEEMSAPPLCFG_BUILDDATE_HOUR         11
 //  <o> minute          <0-59>

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
@@ -978,14 +978,13 @@ extern eOresult_t eo_appEncReader_GetValue(EOappEncReader *p, uint8_t jomo, eOen
                 if(hal_NA32 != rawValue)
                 {   // the hal reading is ok. it is the voltage from the motor port (0 - 3300mV). i just need to rescale it
                     // GOOD VALUE
-                    prop.valueinfo->value[0] = s_eo_appEncReader_hallAdc_rescale2icubdegrees(p, rawValue, jomo);                        
+                    prop.valueinfo->value[0] = s_eo_appEncReader_hallAdc_rescale2icubdegrees(p, rawValue, jomo);
                 }  
                 else 
                 {   // the hal has detected a problem
                      prop.valueinfo->errortype = encreader_err_ABSANALOG_GENERIC;  
-                     errorparam = rawValue & 0xffff;                    
-                }              
-               
+                     errorparam = rawValue & 0xffff;                
+                }                
             } break;  
             
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.c
@@ -198,7 +198,8 @@ static EOappEncReader s_eo_theappencreader =
         EO_INIT(.par64              ) {0},
         EO_INIT(.par16              ) {0}
     },
-    EO_INIT(.maisConversionFactors   ) {1.0, 1.0, 1.0, 1.0},
+    EO_INIT(.maisConversionFactors  ) {1.0, 1.0, 1.0, 1.0},
+    EO_INIT(.maisOffsets            ) {0, 0, 0, 0},
     EO_INIT(.hallAdcConversionData  ) 
     {
         EO_INIT(.factors            ) {1.0f, 1.0f, 1.0f, 1.0f},
@@ -411,6 +412,25 @@ extern eOresult_t eo_appEncReader_UpdatedMaisConversionFactors(EOappEncReader *p
     return(eores_OK);
 }
 
+extern eOresult_t eo_appEncReader_UpdatedMaisOffsets(EOappEncReader *p, uint8_t jomo, int32_t offset)
+{
+    if(NULL == p)
+    {
+        return(eores_NOK_nullpointer);
+    }
+    
+    eOappEncReader_jomoconfig_t this_jomoconfig = p->config.jomoconfig[jomo];    
+
+    // check existence for primary encoder
+    if((eomc_enc_mais != this_jomoconfig.encoder1des.type) && (eomc_enc_mais != this_jomoconfig.encoder2des.type))
+    {
+        return(eores_NOK_unsupported);
+    }
+    
+    p->maisOffsets[jomo] = offset;
+    
+    return(eores_OK);
+}
 
 extern eOresult_t eo_appEncReader_UpdatedHallAdcConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor)
 {
@@ -1737,9 +1757,7 @@ static void s_eo_appEncReader_configure_NONSPI_encoders(EOappEncReader *p)
 }
 
 static uint32_t s_eo_appEncReader_mais_rescale2icubdegrees(EOappEncReader* p, uint32_t val_raw, uint8_t jomo)
-{
-    uint32_t retval = val_raw;
-    
+{    
     float divider = p->maisConversionFactors[jomo];
     
     if(0.0f == divider)
@@ -1752,9 +1770,20 @@ static uint32_t s_eo_appEncReader_mais_rescale2icubdegrees(EOappEncReader* p, ui
         divider = -divider;
     }
 
-    retval = (float)val_raw / divider;
+    int32_t retval = (int32_t)((float)val_raw / divider);
+    retval -= p->maisOffsets[jomo];
     
-    return(retval);
+    if(retval < 0)
+    {
+        return 0;
+    }
+    
+    if(retval > 65535)
+    {
+        return 65535;
+    }
+    
+    return (uint32_t)retval;
 }
 
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader.h
@@ -90,6 +90,7 @@ extern eOresult_t eo_appEncReader_Diagnostics_Tick(EOappEncReader *p);
 extern eOresult_t eo_appEncReader_GetEncoderType(EOappEncReader *p, uint8_t jomo, eOmc_encoder_t *primary, eOmc_encoder_t *secondary);
 
 extern eOresult_t eo_appEncReader_UpdatedMaisConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor);
+extern eOresult_t eo_appEncReader_UpdatedMaisOffsets(EOappEncReader *p, uint8_t jomo, int32_t offset);
 extern eOresult_t eo_appEncReader_UpdatedHallAdcConversionFactors(EOappEncReader *p, uint8_t jomo, float convFactor);
 extern eOresult_t eo_appEncReader_UpdatedHallAdcOffset(EOappEncReader *p, uint8_t jomo, int32_t offset);
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/board/EOappEncodersReader_hid.h
@@ -146,7 +146,8 @@ struct EOappEncReader_hid
     eOappEncReader_cfg_t                    config;       
     eOappEncReader_stream_t                 SPI_streams[hal_spiencoder_streams_number];  // SPI streams; must be coherent with what inside cfg
     eo_appEncReader_diagnostics_t           diagnostics;
-    float                                   maisConversionFactors[eOappEncReader_jomos_maxnumberof];
+    float                                   maisConversionFactors[eOappEncReader_jomos_maxnumberof]; // mais raw2icubdegrees conversion factors storage
+    int32_t                                 maisOffsets[eOappEncReader_jomos_maxnumberof]; // mais offsets storage
     eOappEncReader_hallAdc_conversionData_t hallAdcConversionData;
     eo_appEncReader_amodiag_t               amodiag;
     eOappEncReader_Aksim2_DiagnosticError_Counters_t aksim2DiagnerrorCounters;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/AbsEncoder.c
@@ -226,12 +226,10 @@ void AbsEncoder_config_resolution(AbsEncoder* o, float resolution)
 {
     if (!o->fake)
     {
-        //o->sign = resolution >= 0 ? 1 : -1;
         o->mul = resolution >= 0 ? 1 : -1;
     }
     else
     {
-        //o->sign = 1;
         o->mul = o->div = 1;
     }
 }
@@ -279,7 +277,7 @@ void AbsEncoder_calibrate_absolute(AbsEncoder* o, int32_t offset, int32_t zero)
     o->zero = zero;
     
     uint16_t position = o->position_sure;
-    position -= o->offset;
+    position -= o->offset; //if offset is greater than uint16_t it will wrap around and this might be an issue
     o->distance = position;
     
     o->state.bits.not_calibrated  = FALSE;
@@ -500,8 +498,6 @@ void AbsEncoder_update(AbsEncoder* o, uint16_t position)
     if (o->fake) return;
     
     if (o->state.bits.not_configured) return;
-    
-    //if (o->state.bits.not_calibrated) return;
     
     o->invalid_cnt = 0;
     o->timeout_cnt = 0;

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -286,10 +286,15 @@ static eOresult_t JointSet_do_wait_calibration_7_singleJoint(Joint *j, Motor* m,
         case calibtype7_st_jntCheckLimits:
         {
             int32_t curr_pos = AbsEncoder_position(e);
+            //// debug code
+            char info[80];
+            snprintf(info, sizeof(info), "calib7:chkLim: cp%d mx%.1f mn%.1f", curr_pos, j->pos_max, j->pos_min);
+            JointSet_send_debug_message(info, j->ID, 0, 0);
+            ////debug code ended
+
             if((curr_pos > j->pos_max+CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD) || (curr_pos < j->pos_min-CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD))
             {
                 //// debug code
-                char info[80];
                 snprintf(info, sizeof(info), "calib7:outLim: cp%d mx%.1f mn%.1f",curr_pos, j->pos_max, j->pos_min);
                 JointSet_send_debug_message(info, j->ID, 0, 0);
                 ////debug code ended

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.c
@@ -55,9 +55,6 @@
 
 #include "hal_adc.h"
 
-#define CALIB_TYPE_6_POS_TRHESHOLD 730 //= 4 deg //1820 //2730 //546=3 degree //91.02f // = 0.5 degree
-#define CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD 14563 //= 80 deg express in icubDeg
-#define ROTOR_LIMIT_DELTA (159.0f/360.0f)*65536.0f  // small amount of iCubdegree on the rotor to be slightly distant from hard-stop
 
 BOOL JointSet_do_wait_calibration_3(JointSet* o)
 {

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.h
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/Calibrators.h
@@ -24,6 +24,9 @@
 
 #include "EOemsControllerCfg.h"
 
+#define CALIB_TYPE_6_POS_TRHESHOLD 730 //= 4 deg //1820 //2730 //546=3 degree //91.02f // = 0.5 degree
+#define CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD 14563 //= 80 deg express in icubDeg
+#define ROTOR_LIMIT_DELTA (159.0f/360.0f)*65536.0f  // small amount of iCubdegree on the rotor to be slightly distant from hard-stop
 
 extern BOOL JointSet_do_wait_calibration_3(JointSet* o);
 extern BOOL JointSet_do_wait_calibration_5(JointSet* o);

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -2018,16 +2018,43 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             o->joint[e].running_calibration.data.type7.state = calibtype7_st_inited;
             o->joint[e].running_calibration.data.type7.is_active = TRUE;
             
-//            o->joint[e].calib_type7_data.is_active = TRUE;
-//            o->joint[e].calib_type7_data.state = calibtype7_st_inited;
-//            o->joint[e].calibration_in_progress = (eOmc_calibration_type_t)calibrator->type;
-            
-            
             // 2) calculate new joint encoder factor and param_zero
             eOmc_joint_config_t *jconfig = &o->joint[e].eo_joint_ptr->config;
             float computedJntEncoderResolution = (float)(calibrator->params.type7.vmax - calibrator->params.type7.vmin) / (float) (jconfig->userlimits.max  - jconfig->userlimits.min);
-            
-            int32_t offset = (((float)calibrator->params.type7.vmin)/computedJntEncoderResolution) - jconfig->userlimits.min;
+            float absComputedJntEncoderResolution = (computedJntEncoderResolution >= 0) ? computedJntEncoderResolution : -computedJntEncoderResolution;
+
+            float jntRange = (float)(jconfig->userlimits.max - jconfig->userlimits.min);
+            // Keep the normalized reader value away from zero to avoid unsigned underflow on endpoint drift.
+            // Same margin used by the type 6/7 calibration limit check: 80 degrees in iCubDegrees.
+            const int32_t normalizedDistanceMargin = 14563;
+            int32_t offset = 0;
+            int32_t computedJntEncoderZero = 0;
+
+            if((0.0f == absComputedJntEncoderResolution) || (jntRange <= 0.0f) || ((jntRange + 2.0f*normalizedDistanceMargin) >= 65535.0f))
+            {
+                char info[70];
+                snprintf(info, 70, "calib7: invalid params");
+                JointSet_send_debug_message(info, e, 0, 0);
+                return;
+            }
+
+            if(computedJntEncoderResolution >= 0)
+            {
+                offset = (((float)calibrator->params.type7.vmin) / absComputedJntEncoderResolution) - normalizedDistanceMargin;
+                computedJntEncoderZero =  normalizedDistanceMargin -((int32_t)jconfig->userlimits.min);
+            }
+            else
+            {
+                offset = (((float)calibrator->params.type7.vmax) / absComputedJntEncoderResolution) - normalizedDistanceMargin;
+                computedJntEncoderZero = -((int32_t)jconfig->userlimits.max) - normalizedDistanceMargin;
+            }
+
+            {
+                char info[80];
+                snprintf(info, sizeof(info), "calib7:T res%.4f off%d z%d m%d", computedJntEncoderResolution, offset, computedJntEncoderZero, normalizedDistanceMargin);
+                JointSet_send_debug_message(info, e, 0, 0);
+            }
+           
             
 
 #if 1
@@ -2060,13 +2087,10 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             
             //Now I need to re init absEncoder because I chenged hallADCConversionFactor, therefore the values returned by EOappEncoreReder are changed.
             o->absEncoder[e].state.bits.not_initialized = TRUE;
-            
-            float computedJntEncoderZero =  (((float)calibrator->params.type7.vmin) / computedJntEncoderResolution) - ((float)(jconfig->userlimits.min)) - offset;
 
             
             o->joint[e].running_calibration.data.type7.computedZero = computedJntEncoderZero;
             o->joint[e].running_calibration.data.type7.state = calibtype7_st_jntEncResComputed;
-            
         }
         break;
 

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -1946,7 +1946,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 ////debug code ended
                 return;
             } 
-            //if I'm here I can perform calib type 6.
+            // if I'm here I can perform calib type 6.
             
             // 2) set state
             o->calibration_timeout = 0;
@@ -1963,28 +1963,56 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             {
                 float computedJntEncoderResolution = (float)(calibrator->params.type6.vmax - calibrator->params.type6.vmin) / (float) (jconfig->userlimits.max  - jconfig->userlimits.min);
 
-#if 1
-                embot::app::eth::theEncoderReader::getInstance().Scale({e, embot::app::eth::encoder::v1::Position::every}, {computedJntEncoderResolution, 0});
-#else
-                eOresult_t res = eo_appEncReader_UpdatedMaisConversionFactors(eo_appEncReader_GetHandle(), e, computedJntEncoderResolution);
-                if(eores_OK != res)
-                {    
-                    ////debug code
+                float absComputedJntEncoderResolution = (computedJntEncoderResolution >= 0.0f) ? computedJntEncoderResolution : -computedJntEncoderResolution;
+                
+                // 4) calculate a sage margin to avoid unsigned overflow/underflow on endpoint drift.
+                // Keep the normalized reader value away from zero to avoid unsigned underflow on endpoint drift.
+                // Same margin used by the type 6/7 calibration limit check: 80 degrees in iCubDegrees.
+                float jntRange = (float)(jconfig->userlimits.max - jconfig->userlimits.min);
+                const float maxMargin = (65535.0f - jntRange) / 2.0f;
+                const float normalizedDistanceSafety = 182.0f;
+                const int32_t maxNormalizedDistanceMargin = (int32_t)(maxMargin - normalizedDistanceSafety);
+                
+                int32_t normalizedDistanceMargin = CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD;
+                if(normalizedDistanceMargin > maxNormalizedDistanceMargin)
+                {
+                    normalizedDistanceMargin = maxNormalizedDistanceMargin;
+                }
+
+                if((0.0f == absComputedJntEncoderResolution) || (jntRange <= 0.0f) || (normalizedDistanceMargin <= 0))
+                {
                     char info[70];
-                    snprintf(info, sizeof(info), "calib6: error updating Mais conversion factor j%d", e);
+                    snprintf(info, sizeof(info), "calib6: invalid params");
                     JointSet_send_debug_message(info, e, 0, 0);
-                    ////debug code ended
                     return;
                 }
-#endif 
+                
+                int32_t offset = 0;
+                int32_t computedJntEncoderZero = 0;
+                
+                if(computedJntEncoderResolution >= 0.0f)
+                {
+                    offset = (int32_t)(((float)calibrator->params.type6.vmin) / absComputedJntEncoderResolution) - normalizedDistanceMargin;
+                    computedJntEncoderZero = normalizedDistanceMargin - (int32_t)jconfig->userlimits.min;
+                }
+                else
+                {
+                    offset = (int32_t)(((float)calibrator->params.type6.vmax) / absComputedJntEncoderResolution) - normalizedDistanceMargin;
+                    computedJntEncoderZero = -((int32_t)jconfig->userlimits.max) - normalizedDistanceMargin;
+                }
+                
+                embot::app::eth::theEncoderReader::getInstance().Scale({e, embot::app::eth::encoder::v1::Position::every}, {computedJntEncoderResolution, offset});
+
                 AbsEncoder_config_resolution(o->absEncoder+e, computedJntEncoderResolution);
             
                 //Now I need to re-init absEncoder because I chenged maisConversionFactor, therefore the values returned by EOappEncoreReder are changed.
                 o->absEncoder[e].state.bits.not_initialized = TRUE;
 
-                float computedJntEncoderZero =  - (float)(jconfig->userlimits.min) + ((float)(calibrator->params.type6.vmin) / computedJntEncoderResolution);
+                float normalizedTarget = ((float)target_pos / absComputedJntEncoderResolution) - offset;
+                float signedTarget = (computedJntEncoderResolution >= 0.0f) ? normalizedTarget : -normalizedTarget;
+                
                 o->joint[e].running_calibration.data.type6.computedZero = computedJntEncoderZero;
-                o->joint[e].running_calibration.data.type6.targetpos = target_pos / computedJntEncoderResolution - computedJntEncoderZero; //convert target pos from mais unit to icub deegre
+                o->joint[e].running_calibration.data.type6.targetpos = signedTarget - computedJntEncoderZero; //convert target pos from mais unit to icub deegre
 
             }
             else if (eo_pos_isAlive(eo_pos_GetHandle()))
@@ -2009,7 +2037,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
 
         case eomc_calibration_type7_hall_sensor:
         {
-            //1) check params: nothinh to do
+            // 1) check params: nothing to do
             
             // 2) set state
             o->calibration_timeout = 0;
@@ -2018,19 +2046,28 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
             o->joint[e].running_calibration.data.type7.state = calibtype7_st_inited;
             o->joint[e].running_calibration.data.type7.is_active = TRUE;
             
-            // 2) calculate new joint encoder factor and param_zero
+            // 3) calculate new joint encoder factor and param_zero
             eOmc_joint_config_t *jconfig = &o->joint[e].eo_joint_ptr->config;
             float computedJntEncoderResolution = (float)(calibrator->params.type7.vmax - calibrator->params.type7.vmin) / (float) (jconfig->userlimits.max  - jconfig->userlimits.min);
             float absComputedJntEncoderResolution = (computedJntEncoderResolution >= 0) ? computedJntEncoderResolution : -computedJntEncoderResolution;
 
-            float jntRange = (float)(jconfig->userlimits.max - jconfig->userlimits.min);
+            // 4) calculate a sage margin to avoid unsigned overflow/underflow on endpoint drift.
             // Keep the normalized reader value away from zero to avoid unsigned underflow on endpoint drift.
             // Same margin used by the type 6/7 calibration limit check: 80 degrees in iCubDegrees.
-            const int32_t normalizedDistanceMargin = 14563;
+            float jntRange = (float)(jconfig->userlimits.max - jconfig->userlimits.min);
+            const float maxMargin = (65535.0f - jntRange) / 2.0f;
+            const float normalizedDistanceSafety = 182.0f; // about 1 degree in iCubDegrees
+            const int32_t maxNormalizedDistanceMargin = (int32_t)(maxMargin - normalizedDistanceSafety);
+            int32_t normalizedDistanceMargin = CALIB_TYPE_6_7_POS_ERROR_TRHESHOLD;
+            if(normalizedDistanceMargin > maxNormalizedDistanceMargin)
+            {
+                normalizedDistanceMargin = maxNormalizedDistanceMargin;
+            }
+
+            // 5) evaluate actual offset and zero for subsequents AbsEcoder position estimation
             int32_t offset = 0;
             int32_t computedJntEncoderZero = 0;
-
-            if((0.0f == absComputedJntEncoderResolution) || (jntRange <= 0.0f) || ((jntRange + 2.0f*normalizedDistanceMargin) >= 65535.0f))
+            if((0.0f == absComputedJntEncoderResolution) || (jntRange <= 0.0f) || (normalizedDistanceMargin <= 0))
             {
                 char info[70];
                 snprintf(info, 70, "calib7: invalid params");

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -2119,7 +2119,7 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 ////debug code ended
                 return;
             }
-#endif       
+#endif      
             AbsEncoder_config_resolution(o->absEncoder+e, computedJntEncoderResolution);
             
             //Now I need to re init absEncoder because I chenged hallADCConversionFactor, therefore the values returned by EOappEncoreReder are changed.

--- a/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
+++ b/emBODY/eBcode/arch-arm/embobj/plus/mc/JointSet.c
@@ -2091,35 +2091,9 @@ void JointSet_calibrate(JointSet* o, uint8_t e, eOmc_calibrator_t *calibrator)
                 snprintf(info, sizeof(info), "calib7:T res%.4f off%d z%d m%d", computedJntEncoderResolution, offset, computedJntEncoderZero, normalizedDistanceMargin);
                 JointSet_send_debug_message(info, e, 0, 0);
             }
-           
             
-
-#if 1
             embot::app::eth::theEncoderReader::getInstance().Scale({e, embot::app::eth::encoder::v1::Position::every}, {computedJntEncoderResolution, offset});
-#else            
-            eOresult_t res = eo_appEncReader_UpdatedHallAdcOffset(eo_appEncReader_GetHandle(), e, offset);
-            if(eores_OK != res)
-            {    
-                ////debug code 
-                char info[70];
-                snprintf(info, 70, "calib7: error updating HallADC offset j%d", e);
-                JointSet_send_debug_message(info, e, 0, 0);
-                ////debug code ended
-                return;
-            }
-            
-            
-            res = eo_appEncReader_UpdatedHallAdcConversionFactors(eo_appEncReader_GetHandle(), e, computedJntEncoderResolution);
-            if(eores_OK != res)
-            {    
-                ////debug code 
-                char info[70];
-                snprintf(info, 70, "calib7: error updating HallADC conversion factor j%d", e);
-                JointSet_send_debug_message(info, e, 0, 0);
-                ////debug code ended
-                return;
-            }
-#endif      
+  
             AbsEncoder_config_resolution(o->absEncoder+e, computedJntEncoderResolution);
             
             //Now I need to re init absEncoder because I chenged hallADCConversionFactor, therefore the values returned by EOappEncoreReder are changed.


### PR DESCRIPTION
This PR aims at fixing a problem, more a corner case problem, that might generate during the calibration of the hand joints that use calibration `type7` and `type6`. The problem can be detailed shortly as follows:

**Problem / Root Cause**

Calibration type 7 could underflow in the Hall ADC reader path because the reader removes the sign from the conversion factor, applies an unsigned offset subtraction, and only later the abs encoder reintroduces the sign. Near endpoint values, this could wrap the normalized encoder reading.

Calibration type 6 had a similar edge risk with MAIS readings: the normalized MAIS value could exceed the `uint16_t` range before reaching `AbsEncoder_update()`, depending on raw MAIS limits and current encoder position.

**Solution**

For type 7, the calibration now computes the reader offset using the absolute resolution and a safe margin, selecting the correct endpoint depending on the resolution sign. This keeps the normalized Hall ADC value away from unsigned underflow/overflow boundaries.

For type 6, MAIS scaling now supports an offset, and calibration applies the same safe-margin approach before values reach the abs encoder path. The MAIS reader also clamps normalized values to the valid `uint16_t` range to prevent wrapping.

The following diagram can help in the points where the problem generated before the update:

```mermaid
flowchart TD
    A["JointSet_calibrate()\n\ncomputedResolution = (vmax - vmin) / (jmax - jmin)\nabsResolution = abs(computedResolution)\noffset = endpoint / absResolution - safeMargin\ncomputedZero = sign-dependent zero"]

    B["embot::app::eth::theEncoderReader::Scale()\n\nScale(target, scaler)\nscaler.scale = computedResolution\nscaler.offset = offset"]

    C["embot_app_eth_theEncoderReaderLegacy.cpp\nImpl::Scale()\n\neOencoderreader_Scaler sca {scaler.scale, scaler.offset}\neo_encoderreader_Scale(..., &sca)"]

    D["EOtheEncoderReader.c\neo_encoderreader_Scale()\n\nif encoder is absanalog:\n  UpdatedHallAdcConversionFactors(scale)\n  UpdatedHallAdcOffset(offset)\n\nif encoder is MAIS:\n  UpdatedMaisConversionFactors(scale)"]

    E["EOappEncodersReader.c\neo_appEncReader_UpdatedHallAdcConversionFactors()\n\nhallAdcConversionData.factors[jomo] = convFactor"]

    F["EOappEncodersReader.c\neo_appEncReader_UpdatedHallAdcOffset()\n\nhallAdcConversionData.offsets[jomo] = offset"]

    G["EOappEncodersReader.c\ns_eo_appEncReader_hallAdc_rescale2icubdegrees()\n\nuint32_t retval = val_raw\nfloat divider = factor\nif(divider < 0) divider = -divider\nretval = (float)retval / divider\nretval -= offset"]

    H["EOtheMotionController.c\ns_eo_motioncontrol_updatePositionFromEncoder()\n\nMController_update_absEncoder_fbk(index, valueinfo->value)"]

    I["Controller.c\nMController_update_absEncoder_fbk()\n\nAbsEncoder_update(enc + k, (uint16_t)positions[k])"]

    J["AbsEncoder.c\nAbsEncoder_update(uint16_t position)\n\nposition_sure = position\nint16_t delta = position - position_sure\ndistance += delta"]

    K["AbsEncoder.c\nAbsEncoder_position()\n\nposition = mul * distance / div - zero"]

    A -->|"float scale\nint32_t offset"| B
    B -->|"Scaler {float scale, int32_t offset}"| C
    C -->|"eOencoderreader_Scaler"| D
    D -->|"absanalog scale"| E
    D -->|"absanalog offset"| F
    E -->|"float factor"| G
    F -->|"int32_t offset"| G
    G -->|"uint32_t value[0]\nunderflow can happen here"| H
    H -->|"uint32_t* positions"| I
    I -->|"cast to uint16_t\nwrap can happen here"| J
    J -->|"int32_t distance"| K
```

This PR is related to:
- icub-firmware-shared: https://github.com/robotology/icub-firmware-shared/pull/125
- icub-main: https://github.com/robotology/icub-main/pull/1065
- icub-firmware-build: https://github.com/robotology/icub-firmware-build/pull/234