### PR TITLE
Driver `embot::hw::motor::bldc::qenc` for `amcmj1` is validated

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_qenc_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_qenc_bsp_amcmj1.cpp
@@ -12,6 +12,7 @@
 
 #include "embot_hw_motor_bldc_qenc_bsp.h"
 
+    int64_t overflow_count {0};
 
 // --------------------------------------------------------------------------------------------------------------------
 // - external dependencies
@@ -28,6 +29,8 @@
 // - all the rest
 // --------------------------------------------------------------------------------------------------------------------
 
+
+uint32_t CNT {0};
 
 #if !defined(EMBOT_ENABLE_hw_motor_bldc_qenc)
 
@@ -186,7 +189,7 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
     
     void init(embot::hw::MOTOR m);
     void deinit(embot::hw::MOTOR m);
-    void start(embot::hw::MOTOR m, const Mode &mo);
+    bool start(embot::hw::MOTOR m, const Mode &mo);
     void stop(embot::hw::MOTOR m);
     uint8_t ticksperpulse(embot::hw::MOTOR m);
     uint32_t pulsesperrevolution(embot::hw::MOTOR m);
@@ -233,8 +236,7 @@ namespace embot::hw::motor::bldc::qenc::bsp {
 
     bool BSP::start(embot::hw::MOTOR m, const Mode &mo) const
     {
-        embot::hw::motor::bldc::qenc::bsp::impl::start(m, mo);
-        return true;
+        return embot::hw::motor::bldc::qenc::bsp::impl::start(m, mo);
     }   
 
     bool BSP::stop(embot::hw::MOTOR m) const
@@ -279,12 +281,19 @@ namespace embot::hw::motor::bldc::qenc::bsp {
 namespace embot::hw::motor::bldc::qenc::bsp::impl {
 
     // we use timer TIM1 that is a 16-bit timer
-    // on amcfoc we had TIM2 and TIM5 that are 32-bit timers
+    // so, we manage overflow and undeflow
+    
+    #define handleUPDATEinIRQhandler
+    
+    constexpr size_t maxPPM {32*1024};
 
     TIM_HandleTypeDef htim1 {};
-        
-    constexpr size_t timARR {65535+1};
-        
+       
+    constexpr size_t timARRshift {16};  // useful to speed up multiplications
+    constexpr size_t timARR {1 << timARRshift};
+    static_assert((64*1024) == timARR, "");
+    constexpr size_t timZERO {0};
+    
     constexpr uint8_t QEncMode {TIM_ENCODERMODE_TI12};
     
     // both edges are needed to determine rotation direction at the index crossing  
@@ -398,6 +407,10 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
             // CC IRQ drives the index capture callback
             HAL_NVIC_SetPriority(TIM1_CC_IRQn, 5, 0);
             HAL_NVIC_EnableIRQ(TIM1_CC_IRQn);
+            
+            // update manages overflow/underflow. priority is maximum in order to avoid delays
+            HAL_NVIC_SetPriority(TIM1_UP_IRQn, 0, 0);
+            HAL_NVIC_EnableIRQ(TIM1_UP_IRQn);
       }
     }
 
@@ -417,6 +430,7 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
             */
             HAL_GPIO_DeInit(GPIOE, MOT_ENCZ_Pin | MOT_ENCA_Pin | MOT_ENCB_Pin);          
             HAL_NVIC_DisableIRQ(TIM1_CC_IRQn);
+            HAL_NVIC_DisableIRQ(TIM1_UP_IRQn);
       }
     }  
 
@@ -426,6 +440,7 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
 
 }
 
+#undef DEBUG_AB_capture_and_log
 
 namespace embot::hw::motor::bldc::qenc::bsp::impl {
             
@@ -438,6 +453,8 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
         uint32_t ticksperrevolution {1};         
         float ticks2degreesfactor {1.0f};       // scaling factor to avoid runtime divisions
 
+        volatile int64_t overflowcount {0};
+        
         embot::core::Callback onindexcrossing {};
         
         void clear()
@@ -448,6 +465,7 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
             ticksperpulse = 4;
             ticksperrevolution = 0;
             ticks2degreesfactor = 1.0f;
+            overflowcount = 0;
         }
         
         void load(uint32_t ppr, const embot::core::Callback &onic, uint8_t div)
@@ -464,23 +482,49 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
     
     encData _encdata {};
         
+     
 
-#define TEST_CODE_fastmovingrotor
-        
-        
-#if defined(TEST_CODE_fastmovingrotor)
-        
+    int64_t cumulativeticks(void);
+
     static void EncCapture_cb(TIM_HandleTypeDef *htim)
     {
+#if defined(DEBUG_AB_capture_and_log)        
+        uint32_t dir = (TIM1->CR1 & TIM_CR1_DIR) ? 1 : 0;
+        CNT = TIM1->CNT;
+        
+        uint32_t ccr1 = TIM1->CCR1;
+        uint32_t ccr2 = TIM1->CCR2;
+        switch(htim->Channel)
+        {
+            
+            case HAL_TIM_ACTIVE_CHANNEL_1:
+                embot::core::print("A CNT=" + std::to_string(CNT) + " dir " + std::to_string(dir) + " ccr1 " + std::to_string(ccr1) + " ccr2 " + std::to_string(ccr2));
+                break;
+
+            case HAL_TIM_ACTIVE_CHANNEL_2:
+                embot::core::print("B CNT=" + std::to_string(CNT) + " dir " + std::to_string(dir) + " ccr1 " + std::to_string(ccr1) + " ccr2 " + std::to_string(ccr2));
+                break;
+
+            case HAL_TIM_ACTIVE_CHANNEL_4:
+                embot::core::print("I CNT=" + std::to_string(CNT) + " dir " + std::to_string(dir) + " ccr1 " + std::to_string(ccr1) + " ccr2 " + std::to_string(ccr2));
+                break;
+            
+            default:
+                embot::core::print("other CNT=" + std::to_string(CNT) + " dir " + std::to_string(dir) + " ccr1 " + std::to_string(ccr1) + " ccr2 " + std::to_string(ccr2));
+            break;
+        } 
+#endif // #if defined(DEBUG_AB_capture_and_log)
+
         // there must be a leading edge before trailing edge
         if(0 != __HAL_TIM_GET_FLAG(&htim1, TIM_FLAG_CC3))
-        {
+        {            
             // ok, we have both edges: leading and then trailing
             uint32_t te_u = __HAL_TIM_GetCompare(&htim1, ENC_INDEX_TRAILING_EDGE);
             uint32_t le_u = __HAL_TIM_GetCompare(&htim1, ENC_INDEX_LEADING_EDGE);
 
             // direction is retrieved from hardware, so that it is immune to wrap between le and te captures
             int dir = (__HAL_TIM_IS_TIM_COUNTING_DOWN(&htim1) != 0) ? -1 : +1;
+                                   
 
             int32_t te = static_cast<int32_t>(te_u);
             int32_t le = static_cast<int32_t>(le_u);
@@ -493,123 +537,73 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
             // important: avoid inversion of direction over the index and wraps between the two captures
             if (!wrapped && (0 != delta))
             {
-                // ---------------------------------------------------------------
-                // CALLBACK LATENCY COMPENSATION
-                //
-                // The HW capture registers (te, le) are frozen at the exact moment
-                // of each edge — they are not affected by how late this CB fires.
-                //
-                // However, the timer keeps running after the index crossing.
-                // If we blindly call SET_COUNTER(0) here, the ticks accumulated
-                // between the index (te) and the moment we actually execute are
-                // silently discarded. Those ticks would never be counted in any
-                // future cumulativeticksatindex update, corrupting the position.
-                //
-                // Fix: read the counter NOW (before touching it), compute how many
-                // ticks have elapsed since te, and restore that value after the
-                // reset.  The next period then starts from latency_ticks rather
-                // than 0, so no ticks are lost.
-                //
-                // Modular arithmetic handles counter wrap in both directions:
-                //   dir > 0:  latency = (now - te)        mod (ARR+1)
-                //   dir < 0:  latency = (te - now)        mod (ARR+1)
-                // The (a + M - b) % M form avoids signed underflow in both cases.
-                // ---------------------------------------------------------------                
-                uint32_t ARR = __HAL_TIM_GET_AUTORELOAD(&htim1);
-                uint32_t modulus = ARR + 1;
-
-                // read counter NOW before resetting, to account for callback latency
-                uint32_t counter_now = __HAL_TIM_GetCounter(&htim1);
-                
-                // compute ticks elapsed between index capture (te) and now, handling wrap
-                uint32_t latency_ticks {0};
-                if (dir > 0)
-                {
-                    // counter was counting up: counter_now >= te (modulo ARR+1)
-                    latency_ticks = (counter_now + modulus - te_u) % modulus;
-                }
-                else
-                {
-                    // counter was counting down: counter_now <= te (modulo ARR+1)
-                    latency_ticks = (te_u + modulus - counter_now) % modulus;
-                }
-
-                // convert te to signed: ticks elapsed since last __HAL_TIM_SET_COUNTER(&htim1, xxx)
-                // i.e. since last index crossing or since start()
-                int32_t signed_te = (dir > 0) ? (te) : (te - static_cast<int32_t>(ARR));
-
-                // update the cumulative number of ticks
-                _encdata.cumulativeticksatindex += static_cast<int64_t>(signed_te);
+               
+                // update the cumulative number of ticks. 
+                // i prefer using cumulativeticks() that is less precise rather than 
+                // _encdata.overflowcount * timARR + te_u
+                // uint32_t te_u = __HAL_TIM_GetCompare(&htim1, ENC_INDEX_TRAILING_EDGE);
+                // because ... cumulativeticks() has consistent values for cnt and overflowcount 
+                // and if i use te_e that is correctly captured at index it ay be that in the meantime an update has happened 
+                // 
+                _encdata.cumulativeticksatindex = cumulativeticks();
                 _encdata.numberofrevolutions += dir;
-
-                // reset counter but compensate for latency: the next period starts
-                // from latency_ticks, not from 0, so no ticks are lost
-                __HAL_TIM_SET_COUNTER(&htim1, latency_ticks);
 
                 // call any configured callback
                 _encdata.onindexcrossing.execute();
+
             }
 
             // always clear the leading-edge flag to avoid false positives
             __HAL_TIM_CLEAR_FLAG(&htim1, TIM_FLAG_CC3);
         }
-    }        
+    }  
+    
+
+
+    // commento: ok ma ... se il valore balla attorno a 0xfff ed il mio isr non e' veloce
+    // abbastanza posso avere problemi di mis-classification. quindi:
+    // 1. ridurre la probabilita' di un late irq handler per snellire il piu' possibile con:
+    //    a. mettere onupdate nel IRQ handler e non passare attraverso callback
+    //    b. alzare la priorita' del irq al max con HAL_NVIC_SetPriority(TIM1_UP_IRQn, 0, 0);
+    // 2. usare un approccio a polling che ha suggerito chatgpt. si polla con un altro timer a 1khz e si tiene traccia
         
-#else        
-        
-    // called at index crossing of the trailing edge
-    static void EncCapture_cb(TIM_HandleTypeDef *htim)
+
+    void onupdate()
     {
-        // there must be a leading edge before 
-        if(0 != __HAL_TIM_GET_FLAG(&htim1, TIM_FLAG_CC3)) 
-        {
-            // ok, we have both edges: leading and then trailing
-            uint32_t te_u = __HAL_TIM_GetCompare(&htim1, ENC_INDEX_TRAILING_EDGE);
-            uint32_t le_u = __HAL_TIM_GetCompare(&htim1, ENC_INDEX_LEADING_EDGE);  
-
-            // direction is retrieved from hardware, so that it is immune to wrap between le and te captures
-            int dir = (__HAL_TIM_IS_TIM_COUNTING_DOWN(&htim1) != 0) ? -1 : +1;            
-            
-            int32_t te = static_cast<int32_t>(te_u);
-            int32_t le = static_cast<int32_t>(le_u);
-            int32_t delta = te - le;
-            
-            // sanity check: if delta sign disagrees with dir, the counter wrapped 
-            // between the two captures, so we must discard this crossing
-            bool wrapped = (dir > 0) ? (delta < 0) : (delta > 0);
-            
-            // important: avoid inversion of direction over the index and wraps between the two captures
-            if (!wrapped && (0 != delta))
-            {
-                // convert te to signed: ticks elapsed since last call of __HAL_TIM_SET_COUNTER(&htim1, 0): in this callback or at start()
-                int32_t signed_te = (dir > 0) ? (te) : (te - static_cast<int32_t>(timARR));
-
-                // update the cumulative number of ticks 
-                _encdata.cumulativeticksatindex += static_cast<int64_t>(signed_te);
-                _encdata.numberofrevolutions += dir;
-
-                __HAL_TIM_SET_COUNTER(&htim1, 0);
-
-                // call any configured callback
-                _encdata.onindexcrossing.execute();
-                
-            }
-            
-            // always clear the leading-edge flag to avoid false positives
-            __HAL_TIM_CLEAR_FLAG(&htim1, TIM_FLAG_CC3);   
-            
+        uint16_t cnt = TIM1->CNT;
+        // no need to verify if we really are in TIM_FLAG_UPDATE as it will be executed only inside the correct irq handler
+        __HAL_TIM_CLEAR_FLAG(&htim1, TIM_FLAG_UPDATE);
+        
+        if(cnt < 0x8000)
+        {   // overflow
+            _encdata.overflowcount++;
+        }
+        else
+        {   // underflow
+            _encdata.overflowcount--;
         }
     }
 
-#endif
-
+#if !defined(handleUPDATEinIRQhandler)
     
-    HAL_StatusTypeDef start__former_EncInit(embot::hw::MOTOR m, const Mode &mo)
+    void MyTimerOverflowCb(TIM_HandleTypeDef *htim)
+    {
+        onupdate();    
+    }
+
+#endif // #if !defined(handleUPDATEinIRQhandler)
+
+    bool start__former_EncInit(embot::hw::MOTOR m, const Mode &mo)
     {
         /* Stop any pending operation */
         HAL_TIM_IC_Stop_IT(&htim1, ENC_INDEX_LEADING_EDGE);
         HAL_TIM_IC_Stop(&htim1, ENC_INDEX_TRAILING_EDGE);
         HAL_TIM_Encoder_Stop(&htim1, TIM_CHANNEL_ALL);
+        
+        if(mo.resolution > maxPPM)
+        {
+            return false;
+        }
         
         _encdata.clear();
         _encdata.load(mo.resolution, mo.onindex, ticksperpulse(m)); 
@@ -617,22 +611,35 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
         /* Register the callback function used to signal the activation of the Index pulse */
         if (HAL_OK == HAL_TIM_RegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID, EncCapture_cb))
         {
-            __HAL_TIM_SET_COUNTER(&htim1, 0);
+            __HAL_TIM_SET_COUNTER(&htim1, timZERO);
+            
+#if !defined(handleUPDATEinIRQhandler)            
+            HAL_TIM_RegisterCallback(&htim1, HAL_TIM_PERIOD_ELAPSED_CB_ID, MyTimerOverflowCb);
+#endif // #if !defined(handleUPDATEinIRQhandler)
+            
             /* Start timers in encoder mode */
             if (HAL_OK == HAL_TIM_Encoder_Start(&htim1, TIM_CHANNEL_ALL))
             {
+#if defined(DEBUG_AB_capture_and_log)                
+                __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_CC1);
+                __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_CC2);
+#endif
+                
                 /* Enable leading edge capture, without interrupts */
                 HAL_TIM_IC_Start(&htim1, ENC_INDEX_LEADING_EDGE);
                 /* Enable trailing edge capture, with interrupts */
                 // it is this one that triggers the EncCapture_cb callback
                 HAL_TIM_IC_Start_IT(&htim1, ENC_INDEX_TRAILING_EDGE);
-                return HAL_OK;
+                
+                __HAL_TIM_ENABLE_IT(&htim1, TIM_IT_UPDATE);  
+                
+                return true;
             }
             /* Failed start of the timer */
             HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID);
         }
         /* Errors detected */
-        return HAL_ERROR;
+        return false;
     }    
   
     
@@ -643,6 +650,11 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
         HAL_TIM_IC_Stop(&htim1, ENC_INDEX_LEADING_EDGE);
         HAL_TIM_Encoder_Stop(&htim1, TIM_CHANNEL_ALL);
         HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID);
+
+#if !defined(handleUPDATEinIRQhandler)        
+        HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_PERIOD_ELAPSED_CB_ID);
+#endif     
+        __HAL_TIM_DISABLE_IT(&htim1, TIM_IT_UPDATE);  
         
         _encdata.clear();
     }
@@ -664,9 +676,9 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
     }
  
     
-    void start(embot::hw::MOTOR m, const Mode &mo)
+    bool start(embot::hw::MOTOR m, const Mode &mo)
     {       
-        start__former_EncInit(m, mo);        
+        return start__former_EncInit(m, mo);        
     }
  
     
@@ -685,42 +697,36 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
     {
         return _encdata.pulsesperrevolution;
     }      
-
-    static inline int32_t cnt_to_signed(uint32_t cnt, bool counting_down)
-    {
-        // se sto contando down, cnt rappresenta un numero modulo timARR (or 65536)
-        // il signed corretto: cnt - 65536 (es: 65526 -> -10).
-        return counting_down ? (static_cast<int32_t>(cnt) - timARR) : static_cast<int32_t>(cnt);
-    }
     
-
-    static inline int32_t counter_signed_value()
+    int64_t cumulativeticks(void)
     {
-        uint32_t cnt = __HAL_TIM_GetCounter(&htim1);
-        bool down = (__HAL_TIM_IS_TIM_COUNTING_DOWN(&htim1) != 0);
-        return cnt_to_signed(cnt, down);
-    }
+        int64_t ovf {0};
+        uint16_t cnt {0};
+        
+        __disable_irq(); // yes: i keep global irq disable in here 
+        ovf = _encdata.overflowcount;
+        cnt = TIM1->CNT;
+        __enable_irq();
+        
+        return ovf * timARR + cnt;
+    }    
     
     int64_t ticks(embot::hw::MOTOR m, AngleQE a)
     {
-        int64_t cumulated {0};  // ticks cumulated so far at index detection
-        int32_t current {0};    // current signed value of the TIM counter register
-
-        // i must protect vs execution of the EncCapture_cb() callback.       
-        // i disable only the IRQ that drives EncCapture_cb leaving all other interrupts unaffected.
-        HAL_NVIC_DisableIRQ(TIM1_CC_IRQn);
-        // no: __disable_irq();
+        int64_t v {0}; 
         
-        cumulated = _encdata.cumulativeticksatindex;
         if(AngleQE::current == a)
         {
-            current  = counter_signed_value();
+            v  = cumulativeticks();
+        }
+        else
+        {
+            HAL_NVIC_DisableIRQ(TIM1_CC_IRQn);
+            v = _encdata.cumulativeticksatindex;
+            HAL_NVIC_EnableIRQ(TIM1_CC_IRQn);
         }
         
-        HAL_NVIC_EnableIRQ(TIM1_CC_IRQn);
-        // no: __enable_irq();
-
-        return cumulated + current;
+        return v;
     }
 
     int64_t pulses(embot::hw::MOTOR m) 
@@ -738,7 +744,7 @@ namespace embot::hw::motor::bldc::qenc::bsp::impl {
     { 
         return static_cast<float>(ticks(m, a)) * _encdata.ticks2degreesfactor; 
     } 
-    
+        
     
 } // namespace embot::hw::motor::bldc::qenc::bsp::impl {
 
@@ -764,576 +770,17 @@ extern "C"
     {
         HAL_TIM_IRQHandler(&embot::hw::motor::bldc::qenc::bsp::impl::htim1);
     }
-
-}
-
-#if 0 // other versions
-// --------------------------------------------------------------------------------------------------------------------
-// other versions
-// -
-
-
-namespace embot::hw::motor::bldc::qenc::bsp::impl::originalrevised {
-
-    // we use timer TIM1 that is a 16-bit timer
-    // on amcfoc we had TIM2 and TIM5 that are 32-bit timers
-
-    TIM_HandleTypeDef htim1 {};
-        
-    constexpr size_t timARR {65535+1};
-        
-    constexpr uint8_t QEncMode {TIM_ENCODERMODE_TI12};
-
-    #define MOT_ENCA_Pin GPIO_PIN_9
-    #define MOT_ENCA_GPIO_Port GPIOE
-    #define MOT_ENCB_Pin GPIO_PIN_11
-    #define MOT_ENCB_GPIO_Port GPIOE       
-    #define MOT_ENCZ_Pin GPIO_PIN_13
-    #define MOT_ENCZ_GPIO_Port GPIOE
-        
     
-    void Error_Handler() { for(;;); }
-    
-    void MX_TIM1_Init(void)
+    void TIM1_UP_IRQHandler(void)
     {
-      TIM_Encoder_InitTypeDef sConfig = {0};
-      TIM_MasterConfigTypeDef sMasterConfig = {0};
-      TIM_IC_InitTypeDef sConfigIC = {0};
-
-      htim1.Instance = TIM1;
-      htim1.Init.Prescaler = 0;
-      htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
-      htim1.Init.Period = timARR-1;
-      htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-      htim1.Init.RepetitionCounter = 0;
-      htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-      if (HAL_TIM_IC_Init(&htim1) != HAL_OK)
-      {
-        Error_Handler();
-      }
-      sConfig.EncoderMode = QEncMode;
-      sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
-      sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
-      sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-      sConfig.IC1Filter = 4;
-      sConfig.IC2Polarity = TIM_ICPOLARITY_RISING;
-      sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
-      sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-      sConfig.IC2Filter = 4;
-      if (HAL_TIM_Encoder_Init(&htim1, &sConfig) != HAL_OK)
-      {
-        Error_Handler();
-      }
-      sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
-      sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_UPDATE;
-      sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-      if (HAL_TIMEx_MasterConfigSynchronization(&htim1, &sMasterConfig) != HAL_OK)
-      {
-        Error_Handler();
-      }
-      sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
-      sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
-      sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
-      sConfigIC.ICFilter = 4;
-      if (HAL_TIM_IC_ConfigChannel(&htim1, &sConfigIC, TIM_CHANNEL_3) != HAL_OK)
-      {
-        Error_Handler();
-      }
-      sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_FALLING;
-      sConfigIC.ICSelection = TIM_ICSELECTION_INDIRECTTI;
-      sConfigIC.ICFilter = 0;
-      if (HAL_TIM_IC_ConfigChannel(&htim1, &sConfigIC, TIM_CHANNEL_4) != HAL_OK)
-      {
-        Error_Handler();
-      }
-
-    }   
-
-    
-    void MX_TIM1_DeInit(void)
-    {
-        if (HAL_TIM_Encoder_DeInit(&htim1) != HAL_OK)
-        {
-            Error_Handler();
-        }
-        
-        if(HAL_TIM_IC_DeInit(&htim1) != HAL_OK)
-        {
-            Error_Handler();            
-        }
-    }
-
-    // we use HAL_TIM_IC_MspInit() / HAL_TIM_IC_MspDeInit() 
-    // and not HAL_TIM_Encoder_MspInit() / HAL_TIM_Encoder_MspDeInit()
-
-    void HAL_TIM_IC_MspInit(void *p)
-    {
-        TIM_HandleTypeDef* tim_icHandle = reinterpret_cast<TIM_HandleTypeDef*>(p);
-
-      GPIO_InitTypeDef GPIO_InitStruct = {0};
-      if(tim_icHandle->Instance==TIM1)
-      {
-        /* TIM1 clock enable */
-        __HAL_RCC_TIM1_CLK_ENABLE();
-
-        __HAL_RCC_GPIOE_CLK_ENABLE();
-        /**TIM1 GPIO Configuration
-        PE13     ------> TIM1_CH3
-        PE9     ------> TIM1_CH1
-        PE11     ------> TIM1_CH2
-        */
-        GPIO_InitStruct.Pin = MOT_ENCZ_Pin|MOT_ENCA_Pin|MOT_ENCB_Pin;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF1_TIM1;
-        HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);
-
-        #warning ....... TIM1_BRK_IRQn+TIM1_UP_IRQn per encoder -> sicuro??? forse TIM1_IRQn oppure CC
-        /* TIM1 interrupt Init */
-        HAL_NVIC_SetPriority(TIM1_BRK_IRQn, 5, 0);
-        HAL_NVIC_EnableIRQ(TIM1_BRK_IRQn);
-        HAL_NVIC_SetPriority(TIM1_UP_IRQn, 5, 0);
-        HAL_NVIC_EnableIRQ(TIM1_UP_IRQn);
-
-      }
-    }
-
-
-    void HAL_TIM_IC_MspDeInit(void *p)
-    {
-         TIM_HandleTypeDef* tim_icHandle = reinterpret_cast<TIM_HandleTypeDef*>(p);
-
-      if(tim_icHandle->Instance==TIM1)
-      {
-      /* USER CODE BEGIN TIM1_MspDeInit 0 */
-
-      /* USER CODE END TIM1_MspDeInit 0 */
-        /* Peripheral clock disable */
-        __HAL_RCC_TIM1_CLK_DISABLE();
-
-        /**TIM1 GPIO Configuration
-        PE13     ------> TIM1_CH3
-        PE9     ------> TIM1_CH1
-        PE11     ------> TIM1_CH2
-        */
-        HAL_GPIO_DeInit(GPIOE, MOT_ENCZ_Pin|MOT_ENCA_Pin|MOT_ENCB_Pin);
-
-        /* TIM1 interrupt Deinit */
-        HAL_NVIC_DisableIRQ(TIM1_BRK_IRQn);
-        HAL_NVIC_DisableIRQ(TIM1_UP_IRQn);
-      /* USER CODE BEGIN TIM1_MspDeInit 1 */
-
-      /* USER CODE END TIM1_MspDeInit 1 */
-      }
-    }  
-
-
-    void HAL_TIM_Encoder_MspInit(void *p) {}
-    void HAL_TIM_Encoder_MspDeInit(void *p) {}         
-
-}
-
-namespace embot::hw::motor::bldc::qenc::bsp::impl::originalrevised {
-        
-
-    struct encData
-    {
-        /* Status register values */
-        static constexpr auto STATUS_IDLE  = 0;
-        static constexpr auto STATUS_WAIT  = 1;
-        static constexpr auto STATUS_READY = 2;
-        
-        
-        uint8_t  status {STATUS_IDLE};          // state of index acquisition
-        int32_t numberofrevolutions {0};
-        uint32_t encFirstIndexCross {0};
-        uint32_t absolutezero {0};              // first detected index -> reference
-        uint32_t rotorzero {0};                 // offset between timer count and real mechanical zero
-        bool firstacquisition {true};   
-        uint32_t pulsesperrevolution {1024};    // encoder pulses per revolution of datasheet 
-        uint8_t ticksperpulse {4};                    // x2 or x4 decoding   
-        float counter2degreesfactor {1.0};      // scaling factor to avoid runtime divisions
-        float degrees {0.0};                    // current angle     
-        
-        void clear()
-        {
-            status = STATUS_IDLE;
-            numberofrevolutions = 0;
-            encFirstIndexCross = 0;
-            absolutezero = 0;
-            rotorzero = 0;
-            pulsesperrevolution = 1024;
-            counter2degreesfactor = 1;
-            ticksperpulse = 4;
-            degrees = 0.0;
-            firstacquisition = true;
-        }
-        
-        void loadpulsesperrevolution(uint32_t ppr, uint8_t div)
-        {
-            pulsesperrevolution = ppr;
-            ticksperpulse = div;
-            counter2degreesfactor = 360.0f / static_cast<float>(pulsesperrevolution*ticksperpulse);
-        }
-          
-        encData() = default;
-    };
-    
-    
-    encData _encdata {};
-        
-    
-    // both edges are needed to determine rotation direction at the index crossing  
-    static constexpr auto ENC_INDEX_LEADING_EDGE = TIM_CHANNEL_3;
-    static constexpr auto ENC_INDEX_IT_LEADING_EDGE = TIM_IT_CC3;
-    static constexpr auto ENC_INDEX_TRAILING_EDGE = TIM_CHANNEL_4;
-    static constexpr auto ENC_INDEX_IT_TRAILING_EDGE = TIM_IT_CC4;
-
-    
-    /* Offset between the counting edge and the index edge */
-    static constexpr auto ENC_UP_COUNTING_OFFSET = 1;
-    static constexpr auto ENC_DOWN_COUNTING_OFFSET = 1; 
-
-    
-    // called at index crossing of the trailing edge
-    static void EncCapture_cb(TIM_HandleTypeDef *htim)
-    {
-        /* There must be a leading edge before */
-        if (0 != __HAL_TIM_GET_FLAG(&htim1, ENC_INDEX_IT_LEADING_EDGE))
-        {
-            // ok, we have both edges: leanding and then trailing
-            /* Read the index trailing edge position */
-            int32_t trailingedge = (int32_t)__HAL_TIM_GetCompare(&htim1, ENC_INDEX_TRAILING_EDGE);
-            /* Read the index leading edge position */
-            int32_t leadingedge = (int32_t)__HAL_TIM_GetCompare(&htim1, ENC_INDEX_LEADING_EDGE);
-            /* Take the difference between readings */
-            // it tells if the counter increased or decreases. if delta > 0 it counts up
-            int32_t delta = trailingedge - leadingedge;
-            /* Avoid inversion of direction over the index */
-            if (0 != delta)
-            {
-                /* Update the index position */
-                _encdata.rotorzero = (uint32_t)((delta>=0)? (leadingedge + ENC_UP_COUNTING_OFFSET) : (leadingedge - ENC_DOWN_COUNTING_OFFSET));
-
-                /* Mark the absolute zero position */
-                // we do that only once when the status is in WAIT
-                if (encData::STATUS_WAIT == _encdata.status)
-                {
-                    /* Store the absolute zero */
-                    _encdata.absolutezero = _encdata.rotorzero;
-                    /* Do not repeat again */
-                    _encdata.status = encData::STATUS_READY;
-                }
-            }
-        }
-    }
-    
-    
-    HAL_StatusTypeDef start__former_EncInit(embot::hw::MOTOR m, const Mode &mo)
-    {
-        /* Stop any pending operation */
-        HAL_TIM_IC_Stop_IT(&htim1, ENC_INDEX_LEADING_EDGE);
-        HAL_TIM_IC_Stop(&htim1, ENC_INDEX_TRAILING_EDGE);
-        HAL_TIM_Encoder_Stop(&htim1, TIM_CHANNEL_ALL);
-        
-        _encdata.clear();
-        _encdata.loadpulsesperrevolution(mo.resolution, ticksperpulse(m)); 
-
-        /* Register the callback function used to signal the activation of the Index pulse */
-        if (HAL_OK == HAL_TIM_RegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID, EncCapture_cb))
-        {
-            __HAL_TIM_SET_COUNTER(&htim1, 0);
-            /* Start timers in encoder mode */
-            if (HAL_OK == HAL_TIM_Encoder_Start(&htim1, TIM_CHANNEL_ALL))
-            {
-                /* Enable leading edge capture, without interrupts */
-                HAL_TIM_IC_Start(&htim1, ENC_INDEX_LEADING_EDGE);
-                /* Enable trailing edge capture, with interrupts */
-                // it is this one that triggers the EncCapture_cb callback
-                HAL_TIM_IC_Start_IT(&htim1, ENC_INDEX_TRAILING_EDGE);
-                return HAL_OK;
-            }
-            /* Failed start of the timer */
-            HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID);
-        }
-        /* Errors detected */
-        return HAL_ERROR;
-    }    
-  
-    
-    void stop__former_Enc1DeInit(void)
-    {
-        /* Stop any pending operation */
-        HAL_TIM_IC_Stop_IT(&htim1, ENC_INDEX_TRAILING_EDGE);
-        HAL_TIM_IC_Stop(&htim1, ENC_INDEX_LEADING_EDGE);
-        HAL_TIM_Encoder_Stop(&htim1, TIM_CHANNEL_ALL);
-        HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID);
-        
-        _encdata.clear();
-    }
-
-    
-    void init(embot::hw::MOTOR m)
-    {
-        // may call stop
-        stop(m);
-        // init the timer plus its linked gpios inside the called _MspInit()
-        MX_TIM1_Init();     
-    }
-    
-    void deinit(embot::hw::MOTOR m)
-    {
-        // surely stop. then deinit timer and pins
-        stop(m); 
-        MX_TIM1_DeInit();        
-    }
- 
-    
-    void start(embot::hw::MOTOR m, const Mode &mo)
-    {       
-        start__former_EncInit(m, mo);        
-    }
- 
-    
-    void stop(embot::hw::MOTOR m)
-    { 
-        stop__former_Enc1DeInit();              
-    } 
-
-    
-    uint8_t ticksperpulse(embot::hw::MOTOR m)
-    {
-        return (TIM_ENCODERMODE_TI12 == QEncMode) ? 4 : 2;        
-    }
- 
-    uint32_t pulsesperrevolution(embot::hw::MOTOR m)
-    {
-        return _encdata.pulsesperrevolution;
-    }  
-    
-    int64_t ticks(embot::hw::MOTOR m)
-    { 
-        return __HAL_TIM_GetCounter(&htim1) - _encdata.rotorzero;              
-    } 
- 
-    
-    int64_t indexcrossings(embot::hw::MOTOR m)
-    { 
-        return _encdata.numberofrevolutions;              
-    }  
-
-    
-    float angle(embot::hw::MOTOR m, AngleQE a)
-    { 
-        return _encdata.counter2degreesfactor * static_cast<float>(ticks(m));              
-    } 
-    
-    
-} // namespace embot::hw::motor::bldc::qenc::bsp::impl {
-
-
-namespace embot::hw::motor::bldc::qenc::bsp::impl::multiturn_buggy {
-        
-
-    struct encData
-    {
-        int32_t numberofrevolutions {0};
-        int64_t totalcounts {0};
-        uint32_t pulsesperrevolution {1024};    // encoder pulses per revolution of datasheet 
-        uint8_t ticksperpulse {4};                    // x2 or x4 decoding 
-        uint32_t countsperrevolution {1};         
-        float counter2degreesfactor {1.0f};      // scaling factor to avoid runtime divisions
-
-        
-        void clear()
-        {
-            numberofrevolutions = 0;
-            totalcounts = 0;
-            pulsesperrevolution = 1024;            
-            ticksperpulse = 4;
-            countsperrevolution = 0;
-            counter2degreesfactor = 1.0f;
-        }
-        
-        void loadpulsesperrevolution(uint32_t ppr, uint8_t div)
-        {
-            pulsesperrevolution = ppr;
-            ticksperpulse = div;
-            countsperrevolution = pulsesperrevolution*ticksperpulse;
-            counter2degreesfactor = 360.0f / static_cast<float>(countsperrevolution);
-        }        
-          
-        encData() = default;
-    };
-    
-    
-    encData _encdata {};
-        
-    
-    // both edges are needed to determine rotation direction at the index crossing  
-    static constexpr auto ENC_INDEX_LEADING_EDGE = TIM_CHANNEL_3;
-    static constexpr auto ENC_INDEX_IT_LEADING_EDGE = TIM_IT_CC3;
-    static constexpr auto ENC_INDEX_TRAILING_EDGE = TIM_CHANNEL_4;
-    static constexpr auto ENC_INDEX_IT_TRAILING_EDGE = TIM_IT_CC4;
-
-       
-    // called at index crossing of the trailing edge
-    static void EncCapture_cb(TIM_HandleTypeDef *htim)
-    {
-        /* There must be a leading edge before */
-        if (0 != __HAL_TIM_GET_FLAG(&htim1, ENC_INDEX_IT_LEADING_EDGE))
-        {
-            // ok, we have both edges: leading and then trailing
-            // read the index trailing edge position
-            int32_t trailingedge = (int32_t)__HAL_TIM_GetCompare(&htim1, ENC_INDEX_TRAILING_EDGE);
-            // read the index leading edge position 
-            int32_t leadingedge = (int32_t)__HAL_TIM_GetCompare(&htim1, ENC_INDEX_LEADING_EDGE);
-            // get the difference between readings
-            // it tells if the counter increased or decreases. if delta > 0 it counts up
-            int32_t delta = trailingedge - leadingedge;
-            // important: avoid inversion of direction over the index 
-            if (0 != delta)
-            {
-                int dir = (delta >= 0) ? +1 : -1;
-                _encdata.numberofrevolutions += dir;                
-                
-                // reset counter at index
-                __HAL_TIM_SET_COUNTER(&htim1, 0);
-            }
-        }
-    }
-    
-    
-    HAL_StatusTypeDef start__former_EncInit(embot::hw::MOTOR m, const Mode &mo)
-    {
-        /* Stop any pending operation */
-        HAL_TIM_IC_Stop_IT(&htim1, ENC_INDEX_LEADING_EDGE);
-        HAL_TIM_IC_Stop(&htim1, ENC_INDEX_TRAILING_EDGE);
-        HAL_TIM_Encoder_Stop(&htim1, TIM_CHANNEL_ALL);
-        
-        _encdata.clear();
-        _encdata.loadpulsesperrevolution(mo.resolution, ticksperpulse(m)); 
-
-        /* Register the callback function used to signal the activation of the Index pulse */
-        if (HAL_OK == HAL_TIM_RegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID, EncCapture_cb))
-        {
-            __HAL_TIM_SET_COUNTER(&htim1, 0);
-            /* Start timers in encoder mode */
-            if (HAL_OK == HAL_TIM_Encoder_Start(&htim1, TIM_CHANNEL_ALL))
-            {
-                /* Enable leading edge capture, without interrupts */
-                HAL_TIM_IC_Start(&htim1, ENC_INDEX_LEADING_EDGE);
-                /* Enable trailing edge capture, with interrupts */
-                // it is this one that triggers the EncCapture_cb callback
-                HAL_TIM_IC_Start_IT(&htim1, ENC_INDEX_TRAILING_EDGE);
-                return HAL_OK;
-            }
-            /* Failed start of the timer */
-            HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID);
-        }
-        /* Errors detected */
-        return HAL_ERROR;
-    }    
-  
-    
-    void stop__former_Enc1DeInit(void)
-    {
-        /* Stop any pending operation */
-        HAL_TIM_IC_Stop_IT(&htim1, ENC_INDEX_TRAILING_EDGE);
-        HAL_TIM_IC_Stop(&htim1, ENC_INDEX_LEADING_EDGE);
-        HAL_TIM_Encoder_Stop(&htim1, TIM_CHANNEL_ALL);
-        HAL_TIM_UnRegisterCallback(&htim1, HAL_TIM_IC_CAPTURE_CB_ID);
-        
-        _encdata.clear();
-    }
-
-    
-    void init(embot::hw::MOTOR m)
-    {
-        // may call stop
-        stop(m);
-        // init the timer plus its linked gpios inside the called _MspInit()
-        MX_TIM1_Init();     
-    }
-    
-    void deinit(embot::hw::MOTOR m)
-    {
-        // surely stop. then deinit timer and pins
-        stop(m); 
-        MX_TIM1_DeInit();        
-    }
- 
-    
-    void start(embot::hw::MOTOR m, const Mode &mo)
-    {       
-        start__former_EncInit(m, mo);        
-    }
- 
-    
-    void stop(embot::hw::MOTOR m)
-    { 
-        stop__former_Enc1DeInit();              
-    } 
-
-    
-    uint8_t ticksperpulse(embot::hw::MOTOR m)
-    {
-        return (TIM_ENCODERMODE_TI12 == QEncMode) ? 4 : 2;        
-    }
- 
-    uint32_t pulsesperrevolution(embot::hw::MOTOR m)
-    {
-        return _encdata.pulsesperrevolution;
-    }  
-    
-    // has values in range [0, countsperrevolution)
-    int32_t modcounter(embot::hw::MOTOR m)
-    { 
-        return __HAL_TIM_GetCounter(&htim1);              
-    } 
- 
-    
-    int64_t ticks(embot::hw::MOTOR m)
-    { 
-#define counterPROTECTisr 
-
-#if defined(counterPROTECTisr)
-        
-        int32_t revs {0};
-        int32_t cnt {0};
-
-        // _encdata.numberofrevolutions and counter of TIM1 are chenged in an ISR, so i had better protect it
-        __disable_irq();
-        revs = _encdata.numberofrevolutions;
-        cnt  = __HAL_TIM_GetCounter(&htim1);
-        __enable_irq();
-
-        return cnt + revs * _encdata.countsperrevolution;
+#if defined(handleUPDATEinIRQhandler)          
+        embot::hw::motor::bldc::qenc::bsp::impl::onupdate();
 #else        
-        return modcounter(m) + _encdata.numberofrevolutions * _encdata.countsperrevolution;    
-#endif        
-    } 
-    
-    
-    int64_t indexcrossings(embot::hw::MOTOR m)
-    { 
-        return _encdata.numberofrevolutions;              
-    }  
+        HAL_TIM_IRQHandler(&embot::hw::motor::bldc::qenc::bsp::impl::htim1);
+#endif            
+    }
 
-    
-    float angle(embot::hw::MOTOR m, AngleQE a)
-    { 
-        return ticks(m) * _encdata.counter2degreesfactor; 
-    } 
-    
-    
-} // namespace embot::hw::motor::bldc::qenc::bsp::impl::multiturn::multiturn_buggy {
-
-    // multiturn_buggy does not manage the initial count when we start un-aligned to index and
-    // also doe not manage properly when we go backwards
-
-#endif // #if 0 // other versions
+}
 
 #endif // #if defined(EMBOT_HW_MOTOR_BLDC_board_use_fake_implementation__hw_motor_bldc_qenc)
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-motor/proj/amcmj1.motor-embot-os.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-motor/proj/amcmj1.motor-embot-os.uvoptx
@@ -621,7 +621,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ARMRTXEVENTFLAGS</Key>
-          <Name>-L200 -Z10 -C0 -M1 -T1</Name>
+          <Name>-L113 -Z24 -C0 -M1 -T1</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -644,12 +644,17 @@
         <Ww>
           <count>0</count>
           <WinNumber>1</WinNumber>
-          <ItemText>AinAdc1BufferF,0x0A</ItemText>
+          <ItemText>_items</ItemText>
         </Ww>
         <Ww>
           <count>1</count>
           <WinNumber>1</WinNumber>
-          <ItemText>oncurs</ItemText>
+          <ItemText>nextclockwise</ItemText>
+        </Ww>
+        <Ww>
+          <count>2</count>
+          <WinNumber>1</WinNumber>
+          <ItemText>increment</ItemText>
         </Ww>
       </WatchWindow1>
       <WatchWindow2>
@@ -687,7 +692,7 @@
         <AscS3>0</AscS3>
         <aSer3>0</aSer3>
         <eProf>0</eProf>
-        <aLa>0</aLa>
+        <aLa>1</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
         <aSer4>1</aSer4>
@@ -709,6 +714,23 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <LogicAnalyzers>
+        <Wi>
+          <IntNumber>0</IntNumber>
+          <FirstString>`QEangle</FirstString>
+          <SecondString>0080000000000000008086BF000000805A678840000000000000000000000000000000005145616E676C6500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000070000000100000046A1D9BF40BCE23F190000000000000000000000000000000000000080840008</SecondString>
+        </Wi>
+        <Wi>
+          <IntNumber>1</IntNumber>
+          <FirstString>`QEangleoflastindex</FirstString>
+          <SecondString>000000000000000000000000000000802C4D8540000000000000000000000000000000005145616E676C656F666C617374696E6465780000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000200000058479BF7292EC93F190000000000000000000000000000000000000028B20008</SecondString>
+        </Wi>
+        <Wi>
+          <IntNumber>2</IntNumber>
+          <FirstString>`CNTmain</FirstString>
+          <SecondString>00008000000000000000000000000000E0FFEF4000000000000000000000000000000000434E546D61696E0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000030000008F33FE08D3E0CB3F1900000000000000000000000000000000000000BACD0008</SecondString>
+        </Wi>
+      </LogicAnalyzers>
       <SystemViewers>
         <Entry>
           <Name>OS Support\Event Viewer</Name>
@@ -971,7 +993,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1507,7 +1529,7 @@
 
   <Group>
     <GroupName>embot::hw::motor::bldc</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1595,7 +1617,7 @@
 
   <Group>
     <GroupName>embot::hw::motor::bldc::bsp</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-motor/proj/amcmj1.motor-embot-os.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-motor/proj/amcmj1.motor-embot-os.uvprojx
@@ -2210,7 +2210,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>1</interw>
-            <Optim>1</Optim>
+            <Optim>6</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-motor/src/cmx-motor-main.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-motor/src/cmx-motor-main.cpp
@@ -18,7 +18,7 @@
 
 
 constexpr embot::os::Event evtTick = embot::core::binary::mask::pos2mask<embot::os::Event>(0);
-constexpr embot::core::relTime tickperiod = 1000*embot::core::time1millisec;
+constexpr embot::core::relTime tickperiod = 2*embot::core::time1millisec;
 
 
 void ONE(){};
@@ -171,14 +171,9 @@ int main(void)
     constexpr embot::core::Callback onOSerror = { };
     constexpr embot::os::Config osconfig 
     {
-        embot::core::time1millisec, initcfg, idlecfg, onOSerror, 
-#if defined(STM32HAL_BOARD_AMCFOC_1CM7)        
-        embot::hw::FLASHpartitionID::eapplication01
-#elif defined(STM32HAL_BOARD_AMCFOC_2CM4)
-        embot::hw::FLASHpartitionID::eloader
-#else        
+        embot::core::time1millisec, initcfg, idlecfg, onOSerror,      
         embot::hw::FLASHpartitionID::none // so that it does not add any offset to the flash location
-#endif        
+     
     };
     
     // embot::os::init() internally calls embot::hw::bsp::init() which also calls embot::core::init()
@@ -198,7 +193,14 @@ int main(void)
 
 // choose one of them only
 //    #define TEST_6steps
-    #define TEST_hall
+//    #define TEST_hall
+#define TEST_qenc
+
+#if defined(TEST_hall)
+
+    #define TEST_hall_6step
+
+#endif
 
 #include "embot_hw_motor_bldc.h"
 
@@ -243,7 +245,7 @@ int main(void)
         curr3ma = 1000 * currs->w;        
     }
     
-    //#define TEST_QENC_only
+    #define TEST_QENC_only
     // #define TEST_QENC_only
     
     
@@ -307,27 +309,88 @@ int main(void)
 
 #endif     
     
-    float hallmechnagle {0};
+    float hallmechnagle {-10};
+    float hallelecangle {-10};
+    uint8_t hallstatus {10};
+    uint8_t hallsector {10};
     
     void onhallchange(embot::hw::MOTOR m, float mechangle, float elecangle, uint8_t status, uint8_t sector, void *owner)
     {
-        // log in here the changes.
+        // log in here the changes, so that we can plot on the sygnal analyser
         hallmechnagle = mechangle;
+        hallelecangle = elecangle;
+        hallstatus = status;
+        hallsector = sector;
+        
+        
+        #if defined(TEST_hall_6step)
+        
+        constexpr float dutycyclepercent {5.0}; // 5%
+        constexpr float pwm {dutycyclepercent};
+        constexpr float hiz {dutycyclepercent/2.0};
+        
+        constexpr std::array<embot::hw::motor::bldc::PWM3, 8> thepwms
+        {{
+            {0.0, 0.0, 0.0}, // 0 not valid
+            {0.0, hiz, pwm}, // 1 0b001
+            {hiz, pwm, 0.0}, // 2 0b010
+            {0.0, pwm, hiz}, // 3 0b011
+            {pwm, 0.0, hiz}, // 4 0b100
+            {hiz, 0.0, pwm}, // 5
+            {pwm, hiz, 0.0}, // 6
+            {0.0, 0.0, 0.0}, // 7 not valid                       
+        }};
+        
+        
+        embot::hw::motor::bldc::pwm::set(embot::hw::MOTOR::one, thepwms[status & 0b111]);
+                               
+        #endif
+    }
+
+        float angle {0};
+        float angleoflastindex {0};    
+        
+    void fnonindex(void *p)
+    { 
+        static float prevlin {0};
+        
+
+        
+        prevlin = angleoflastindex;
+        angle = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::current);
+        angleoflastindex = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::oflatestindexcrossing);           
+        embot::core::print("angle = " + std::to_string(angle) + ", angleoflastindex = " + std::to_string(angleoflastindex) + 
+                           ", delta = " + std::to_string(angleoflastindex-prevlin));
     }
     
+    uint32_t CNTmain {0};
+    int32_t CNTdelta {0};
+    static uint32_t cntpr = TIM1->CNT;
+    
+    float QEangle {0};
+    float QEangleoflastindex {0};
     
     void test_motor_bldc_init()
     {
  
 #if defined(TEST_hall)
 
-        constexpr embot::hw::motor::bldc::hall::Mode mode {
-            embot::hw::motor::bldc::hall::Mode::Order::H3H2H1, // standard order
-            1, // 1 polar pair
-            {embot::hw::MOTOR::one, onhallchange, nullptr}
-        };     
-        embot::hw::motor::bldc::hall::init(embot::hw::MOTOR::one, {});
-        embot::hw::motor::bldc::hall::start(embot::hw::MOTOR::one, mode);
+    constexpr embot::hw::motor::bldc::hall::Mode mode {
+        embot::hw::motor::bldc::hall::Mode::Order::H3H2H1, // standard order
+        7, // 14 MotorPoles
+        {embot::hw::MOTOR::one, onhallchange, nullptr}
+    };     
+    embot::hw::motor::bldc::hall::init(embot::hw::MOTOR::one, {});
+    embot::hw::motor::bldc::hall::start(embot::hw::MOTOR::one, mode);
+        
+    #if defined(TEST_hall_6step)
+        
+        embot::hw::motor::bldc::adc::init(embot::hw::MOTOR::one, {});   
+//        embot::hw::motor::bldc::OnCurrents oncurs {embot::hw::MOTOR::one, do6steps, nullptr};
+//        embot::hw::motor::bldc::adc::set(embot::hw::MOTOR::one, oncurs);            
+        embot::hw::motor::bldc::pwm::init(embot::hw::MOTOR::one, {});
+
+    #endif        
         
 #elif defined(TEST_6steps)
 
@@ -345,13 +408,28 @@ int main(void)
         embot::hw::motor::bldc::pwm::init(embot::hw::MOTOR::one, {});
 
 #elif defined(TEST_QENC_only)
+
+
+
+        constexpr embot::core::Callback onindex {fnonindex, nullptr};
         
         constexpr embot::hw::motor::bldc::qenc::Mode encmode {
-            1024,       // resolution
-            {}          // onindex
+            8*1024,             // resolution
+            onindex             // onindex
         };     
         embot::hw::motor::bldc::qenc::init(embot::hw::MOTOR::one, {});
         embot::hw::motor::bldc::qenc::start(embot::hw::MOTOR::one, encmode);
+            
+        
+//        for(;;)    
+//        {
+//            CNTmain = TIM1->CNT;
+//            CNTdelta = cntpr - CNTmain;
+//            cntpr = CNTmain;
+//            QEangle = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::current);
+//            QEangleoflastindex = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::oflatestindexcrossing);
+//            
+//        }
         
 #else        
         
@@ -374,9 +452,7 @@ int main(void)
 //        //embot::hw::motor::bldc::set(embot::hw::MOTOR::two, {embot::hw::MOTOR::two, onCurrents, nullptr});             
         
     }
-    
-    float angle {0};
-    float angleoflastindex {0};
+
     
     float anglehall {0};
     
@@ -399,8 +475,15 @@ int main(void)
         anglehall = embot::hw::motor::bldc::hall::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::AngleType::hall_mechanical);
 
 #elif defined(TEST_QENC_only)
-        angle = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::current);
-        angleoflastindex = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::oflatestindexcrossing);
+        
+            CNTmain = TIM1->CNT;
+            CNTdelta = cntpr - CNTmain;
+            cntpr = CNTmain;
+            QEangle = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::current);
+            QEangleoflastindex = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::oflatestindexcrossing);
+         
+//        QEangle = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::current);
+//        QEangleoflastindex = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::oflatestindexcrossing);
 #else         
         
         if((n-tt) >= delta)

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc_hall.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc_hall.cpp
@@ -66,14 +66,14 @@ namespace embot::hw::motor::bldc::hall::impl {
             there are 6 sectors, each of 360/6 = 60 degrees and centred around i*60, i = [0, 5]
             sectors are defined by a number, a centre, an interval, a h3h2h1 value as in followiung table
             
-            | sector | centre | interval   | h3h2h1   |
-            | ------ | ------ | ---------- | -------- |
-            | s0     | 0      | [-30, +30) | 100b = 4 |
-            | s1     | 60     | [30, 90)   | 110b = 6 |
-            | s2     | 120    | [90, 150)  | 010b = 2 |
-            | s3     | 180    | [150, 210) | 011b = 3 |
-            | s4     | 240    | [210, 270) | 001b = 1 |
-            | s5     | 300    | [270, 330) | 101b = 5 |
+            | sector | centre | interval   | h3h2h1    |
+            | ------ | ------ | ---------- | --------- |
+            | s0     | 0      | [-30, +30) | 0b100 = 4 |
+            | s1     | 60     | [30, 90)   | 0b110 = 6 |
+            | s2     | 120    | [90, 150)  | 0b010 = 2 |
+            | s3     | 180    | [150, 210) | 0b011 = 3 |
+            | s4     | 240    | [210, 270) | 0b001 = 1 |
+            | s5     | 300    | [270, 330) | 0b101 = 5 |
             
             ```text
             
@@ -137,6 +137,8 @@ namespace embot::hw::motor::bldc::hall::impl {
         
         // mechanical angle (computed in incremental steps of deltamechanical 
         float mechanicalangle {0.0};    
+        
+        int64_t mechanicalsteps {0}; // mechanicalangle = mechanicalsteps * deltamechanical;
         
 
         static constexpr bool isH3H2H1valid(uint8_t v)
@@ -215,6 +217,7 @@ namespace embot::hw::motor::bldc::hall::impl {
         {
             electricalangle = 0.0f;
             mechanicalangle = 0.0f;
+            mechanicalsteps = 0;
             deltamechanical = 60.0/1.0f;
             sector = 0;
             h3h2h1[hallData::CURR] = h3h2h1[hallData::PREV] = 0;
@@ -368,9 +371,13 @@ namespace embot::hw::motor::bldc::hall::impl {
                 // i assign angles
                 _items[embot::core::tointegral(m)].data.electricalangle = hallData::status2degrees(_items[embot::core::tointegral(m)].data.h3h2h1[hallData::CURR]);
                 _items[embot::core::tointegral(m)].data.sector = hallData::status2sector(_items[embot::core::tointegral(m)].data.h3h2h1[hallData::CURR]);
+//                #warning in order to avoid rounding errors we could use a new variable int64_t countsteps and then    
+//                float delta = _items[embot::core::tointegral(m)].data.deltamechanical * static_cast<float>(increment);
+//                _items[embot::core::tointegral(m)].data.mechanicalangle += delta;
                 
-                float delta = _items[embot::core::tointegral(m)].data.deltamechanical * static_cast<float>(increment);
-                _items[embot::core::tointegral(m)].data.mechanicalangle += delta;
+                _items[embot::core::tointegral(m)].data.mechanicalsteps += increment;
+                
+                _items[embot::core::tointegral(m)].data.mechanicalangle = _items[embot::core::tointegral(m)].data.deltamechanical * _items[embot::core::tointegral(m)].data.mechanicalsteps;
                 
                 _items[embot::core::tointegral(m)].mode.onhall.execute(
                     _items[embot::core::tointegral(m)].data.mechanicalangle, 


### PR DESCRIPTION
As per title.

The driver `embot::hw::motor::bldc::qenc` is validated.

## Brief details of the implementation

The implementation manages both limited resolution of the 16-bit timer and also multiturn in this way:
- we overcome overflow of the 16-bits TIM1 timer with the `TIM1_UPDATE` interrupt handler to detect overflow and undeflow to increment /  decrement a int64_t variable that we use to offset the `TIM1->CNT` value;
- the above already measures angles over very many turns, but we also count the number of turns using `TIM1_CC` to capture the index crossing.

## Tests

I use an encoder w/ a resolution of 8192 ppr (pulses per revolution) and I update every 2 ms the values of three variables:
- the cumulative angle obtained w/ `QEangle =embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::current)`;
- the angle the last time the encoder met the index w/ `QEangleoflastindex = embot::hw::motor::bldc::qenc::angle(embot::hw::MOTOR::one, embot::hw::motor::bldc::qenc::AngleQE::oflatestindexcrossing)`;
- the raw value of the counter of the `TIM1`: `CNTmain = TIM1->CNT`;
 
The obtained waveforms are coherent w/ the rotations I applied and cover some corner cases.

So, I can say that the driver is OK. 

<img width="1979" height="922" alt="Image" src="https://github.com/user-attachments/assets/c95c5dad-32f8-4231-bf0e-5514d4d5b456" />

**Figure**. Some multi turns. All is OK. The value of `CNTmain` shows discontinuities when the counter goes in overflow or underflow. That is easy as for each turn we count 8196*4 (T12 quadruplicates the original resolution) so we need two turns to overflow.  The big hole in `CNTmain` is correct because at first it goes in overflow and goes flat to zero, then it increases a bit to 32  and stays still and then the rotation changes and it goes in underflow.


<img width="1947" height="988" alt="Image" src="https://github.com/user-attachments/assets/fe08c7e1-65b8-4505-bda7-16bbf377f4c3" />


**Figure**. Some multi turns plus oscillations around the index. The log is overlayed with the timing of the two IRQ handler that we use for the driver. Explanation below.

<img width="1969" height="1051" alt="Image" src="https://github.com/user-attachments/assets/16de31d7-97a4-4089-9d2f-73bc963544fb" />

**Figure**.  Explanation.


