### PR TITLE
amcmj1 - improved FDCAN 

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm4/embot_hw_bsp_amcmj1_2cm4.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm4/embot_hw_bsp_amcmj1_2cm4.cpp
@@ -53,6 +53,7 @@ using namespace embot::core::binary;
 #include "embot_hw_bsp_amcmj1_2cm4.h"
 
 #include "embot_hw_eeprom.h"
+#include "embot_hw_can.h"
 #include "embot_hw_sys.h"
 
 
@@ -64,6 +65,10 @@ bool embot::hw::bsp::specialize()
 {
 #if defined(EMBOT_ENABLE_hw_eeprom)    
     embot::hw::eeprom::init(embot::hw::EEPROM::one, {});
+#endif
+        
+#if defined(EMBOT_ENABLE_hw_can)    
+    embot::hw::can::init(embot::hw::CAN::one, {});
 #endif
 
     return true;  

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm4/embot_hw_bsp_amcmj1_2cm4.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm4/embot_hw_bsp_amcmj1_2cm4.cpp
@@ -55,6 +55,7 @@ using namespace embot::core::binary;
 #include "embot_hw_eeprom.h"
 #include "embot_hw_can.h"
 #include "embot_hw_sys.h"
+#include "embot_hw_gpio.h"
 
 
 #if     !defined(EMBOT_ENABLE_hw_bsp_specialize)
@@ -66,9 +67,20 @@ bool embot::hw::bsp::specialize()
 #if defined(EMBOT_ENABLE_hw_eeprom)    
     embot::hw::eeprom::init(embot::hw::EEPROM::one, {});
 #endif
+    
+#if defined(EMBOT_ENABLE_hw_can_5V) //embot::can::init enables the 5V line, but if we need it before calling it we can use this macro
         
-#if defined(EMBOT_ENABLE_hw_can)    
-    embot::hw::can::init(embot::hw::CAN::one, {});
+    constexpr embot::hw::GPIO candrivergpiovauxen = 
+            {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::thirteen};    // PWR_VAUXEN_GPIO_Port, PWR_VAUXEN_Pin
+            
+    constexpr embot::hw::gpio::Config cfgvauxen {
+            embot::hw::gpio::Mode::OUTPUTpushpull, 
+            embot::hw::gpio::Pull::pulldown, 
+            embot::hw::gpio::Speed::low };
+    
+    embot::hw::gpio::init(candrivergpiovauxen, cfgvauxen);
+    embot::hw::gpio::set(candrivergpiovauxen, embot::hw::gpio::State::SET);
+    
 #endif
 
     return true;  

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm4/embot_hw_bsp_amcmj1_2cm4_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm4/embot_hw_bsp_amcmj1_2cm4_config.h
@@ -66,7 +66,7 @@
     
 #else 
 
-    #include "embot_hw_bsp_amcmj1_app_examples_config.h"
+    #include "embot_hw_bsp_amcmj1_examples_config.h"
     
 #endif
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm7/embot_hw_bsp_amcmj1_1cm7.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm7/embot_hw_bsp_amcmj1_1cm7.cpp
@@ -52,6 +52,8 @@ using namespace embot::core::binary;
 
 #include "embot_hw_bsp_amcmj1_1cm7.h"
 
+#include "embot_hw_gpio.h"
+
 
 namespace embot::hw::bsp::amcmj1::cm7 {
         
@@ -65,6 +67,22 @@ bool embot::hw::bsp::specialize() { return true; }
 
     bool embot::hw::bsp::specialize()
     {    
+        
+#if defined(EMBOT_ENABLE_hw_can_5V) //embot::can::init enables the 5V line, but if we need it before calling it we can use this macro
+        
+        constexpr embot::hw::GPIO candrivergpiovauxen = 
+                {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::thirteen};    // PWR_VAUXEN_GPIO_Port, PWR_VAUXEN_Pin
+                
+        constexpr embot::hw::gpio::Config cfgvauxen {
+                embot::hw::gpio::Mode::OUTPUTpushpull, 
+                embot::hw::gpio::Pull::pulldown, 
+                embot::hw::gpio::Speed::low };
+        
+        embot::hw::gpio::init(candrivergpiovauxen, cfgvauxen);
+        embot::hw::gpio::set(candrivergpiovauxen, embot::hw::gpio::State::SET);
+    
+#endif        
+        
         return true;
     }
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm7/embot_hw_bsp_amcmj1_1cm7_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/cm7/embot_hw_bsp_amcmj1_1cm7_config.h
@@ -66,7 +66,7 @@
 
 #else 
 
-    #include "embot_hw_bsp_amcmj1_app_examples_config.h"
+    #include "embot_hw_bsp_amcmj1_examples_config.h"
     
 #endif
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_can_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_can_bsp_amcmj1.cpp
@@ -1,7 +1,7 @@
 
 /*
- * Copyright (C) 2025 iCub Tech - Istituto Italiano di Tecnologia
- * Author:  Marco Accame
+ * Copyright (C) 2026 iCub Tech - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame, Kevin Sangalli
  * email:   marco.accame@iit.it
 */
 
@@ -168,6 +168,38 @@ namespace embot::hw::can {
         embot::hw::gpio::set(candrivergpiosstandby[embot::core::tointegral(h)], embot::hw::gpio::State::RESET);
         embot::hw::gpio::set(candrivergpioshutdown, embot::hw::gpio::State::RESET);
         HAL_Delay(10);
+            
+            
+            
+        //pin connected to chip AP2151FMG-7: PWR_VAUXEN and PWR_VAUXOK
+            
+        constexpr embot::hw::GPIO candrivergpiovauxen = 
+            {embot::hw::GPIO::PORT::C, embot::hw::GPIO::PIN::thirteen};    // PWR_VAUXEN_GPIO_Port, PWR_VAUXEN_Pin
+            
+        constexpr embot::hw::gpio::Config cfgvauxen {
+            embot::hw::gpio::Mode::OUTPUTpushpull, 
+            embot::hw::gpio::Pull::pulldown, 
+            embot::hw::gpio::Speed::low };
+            
+      
+        constexpr embot::hw::GPIO candrivergpiovauxok = 
+            {embot::hw::GPIO::PORT::F, embot::hw::GPIO::PIN::four};        // PWR_VAUXOK_GPIO_Port, PWR_VAUXOK_Pin   
+            
+        constexpr embot::hw::gpio::Config cfgvauxok {
+            embot::hw::gpio::Mode::EXTIfalling, 
+            embot::hw::gpio::Pull::pullup, 
+            embot::hw::gpio::Speed::low };
+
+            
+        // init the pins
+        embot::hw::gpio::init(candrivergpiovauxen, cfgvauxen);
+        embot::hw::gpio::init(candrivergpiovauxok, cfgvauxok);
+        
+        //set the pin
+        embot::hw::gpio::set(candrivergpiovauxen, embot::hw::gpio::State::SET);
+        HAL_Delay(10);
+            
+            
     }
     
     void BSP::init(embot::hw::CAN h) const 
@@ -211,110 +243,60 @@ extern "C"
     constexpr uint16_t vCAN1_TXD_Pin {GPIO_PIN_1};
     GPIO_TypeDef *vCAN1_TXD_GPIO_Port {GPIOD};  
     
-//    constexpr uint16_t vCAN2_TXD_Pin {GPIO_PIN_6};
-//    GPIO_TypeDef *vCAN2_TXD_GPIO_Port {GPIOB};
-    
     constexpr uint16_t vCAN1_RXD_Pin {GPIO_PIN_0};
-    GPIO_TypeDef *vCAN1_RXD_GPIO_Port {GPIOD};
-    
-//    constexpr uint16_t vCAN2_RXD_Pin {GPIO_PIN_12};
-//    GPIO_TypeDef *vCAN2_RXD_GPIO_Port {GPIOB};
+    GPIO_TypeDef *vCAN1_RXD_GPIO_Port {GPIOD};   
     
     static uint32_t HAL_RCC_FDCAN_CLK_ENABLED=0;
 
     void HAL_FDCAN_MspInit(FDCAN_HandleTypeDef* fdcanHandle)
     {
         
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
-  if(fdcanHandle->Instance==FDCAN1)
-  {
-  /* USER CODE BEGIN FDCAN1_MspInit 0 */
+      GPIO_InitTypeDef GPIO_InitStruct = {0};
+      RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
+      if(fdcanHandle->Instance==FDCAN1)
+      {
+          /* USER CODE BEGIN FDCAN1_MspInit 0 */
 
-  /* USER CODE END FDCAN1_MspInit 0 */
+          /* USER CODE END FDCAN1_MspInit 0 */
 
-  /** Initializes the peripherals clock
-  */
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_FDCAN;
-    PeriphClkInitStruct.FdcanClockSelection = RCC_FDCANCLKSOURCE_PLL;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
-    {
-      embot::hw::can::Error_Handler("mspinit 1");
-    }
+          /** Initializes the peripherals clock
+          */
+          PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_FDCAN;
+          PeriphClkInitStruct.FdcanClockSelection = RCC_FDCANCLKSOURCE_PLL;
+          if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+          {
+            embot::hw::can::Error_Handler("mspinit 1");
+          }
+          
+          /* FDCAN1 clock enable */
+          HAL_RCC_FDCAN_CLK_ENABLED++;
+          if(HAL_RCC_FDCAN_CLK_ENABLED==1){
+            __HAL_RCC_FDCAN_CLK_ENABLE();
+          }
+          
+          __HAL_RCC_GPIOD_CLK_ENABLE();
+          /**FDCAN1 GPIO Configuration
+          PD1     ------> FDCAN1_TX
+          PD0     ------> FDCAN1_RX
+          */
+          GPIO_InitStruct.Pin = vCAN1_TXD_Pin|vCAN1_RXD_Pin;
+          GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+          GPIO_InitStruct.Pull = GPIO_NOPULL;
+          GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+          GPIO_InitStruct.Alternate = GPIO_AF9_FDCAN1;
+          HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+          
+          /* FDCAN1 interrupt Init */
+          HAL_NVIC_SetPriority(FDCAN1_IT0_IRQn, 5, 0);
+          HAL_NVIC_EnableIRQ(FDCAN1_IT0_IRQn);
+          HAL_NVIC_SetPriority(FDCAN1_IT1_IRQn, 5, 0);
+          HAL_NVIC_EnableIRQ(FDCAN1_IT1_IRQn);
+          HAL_NVIC_SetPriority(FDCAN_CAL_IRQn, 5, 0);
+          HAL_NVIC_EnableIRQ(FDCAN_CAL_IRQn);
+          /* USER CODE BEGIN FDCAN1_MspInit 1 */
 
-    /* FDCAN1 clock enable */
-    HAL_RCC_FDCAN_CLK_ENABLED++;
-    if(HAL_RCC_FDCAN_CLK_ENABLED==1){
-      __HAL_RCC_FDCAN_CLK_ENABLE();
-    }
-
-    __HAL_RCC_GPIOD_CLK_ENABLE();
-    /**FDCAN1 GPIO Configuration
-    PD1     ------> FDCAN1_TX
-    PD0     ------> FDCAN1_RX
-    */
-    GPIO_InitStruct.Pin = vCAN1_TXD_Pin|vCAN1_RXD_Pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF9_FDCAN1;
-    HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
-
-    /* FDCAN1 interrupt Init */
-    HAL_NVIC_SetPriority(FDCAN1_IT0_IRQn, 5, 0);
-    HAL_NVIC_EnableIRQ(FDCAN1_IT0_IRQn);
-    HAL_NVIC_SetPriority(FDCAN1_IT1_IRQn, 5, 0);
-    HAL_NVIC_EnableIRQ(FDCAN1_IT1_IRQn);
-    HAL_NVIC_SetPriority(FDCAN_CAL_IRQn, 5, 0);
-    HAL_NVIC_EnableIRQ(FDCAN_CAL_IRQn);
-  /* USER CODE BEGIN FDCAN1_MspInit 1 */
-
-  /* USER CODE END FDCAN1_MspInit 1 */
-  }
-//  else if(fdcanHandle->Instance==FDCAN2)
-//  {
-//  /* USER CODE BEGIN FDCAN2_MspInit 0 */
-
-//  /* USER CODE END FDCAN2_MspInit 0 */
-
-//  /** Initializes the peripherals clock
-//  */
-//    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_FDCAN;
-//    PeriphClkInitStruct.FdcanClockSelection = RCC_FDCANCLKSOURCE_PLL;
-//    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
-//    {
-//      embot::hw::can::Error_Handler("mspinit 1");
-//    }
-
-//    /* FDCAN2 clock enable */
-//    HAL_RCC_FDCAN_CLK_ENABLED++;
-//    if(HAL_RCC_FDCAN_CLK_ENABLED==1){
-//      __HAL_RCC_FDCAN_CLK_ENABLE();
-//    }
-
-//    __HAL_RCC_GPIOB_CLK_ENABLE();
-//    /**FDCAN2 GPIO Configuration
-//    PB6     ------> FDCAN2_TX
-//    PB12     ------> FDCAN2_RX
-//    */
-//    GPIO_InitStruct.Pin = vCAN2_TXD_Pin|vCAN2_RXD_Pin;
-//    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-//    GPIO_InitStruct.Pull = GPIO_NOPULL;
-//    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-//    GPIO_InitStruct.Alternate = GPIO_AF9_FDCAN2;
-//    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-//    /* FDCAN2 interrupt Init */
-//    HAL_NVIC_SetPriority(FDCAN2_IT0_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(FDCAN2_IT0_IRQn);
-//    HAL_NVIC_SetPriority(FDCAN2_IT1_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(FDCAN2_IT1_IRQn);
-//    HAL_NVIC_SetPriority(FDCAN_CAL_IRQn, 5, 0);
-//    HAL_NVIC_EnableIRQ(FDCAN_CAL_IRQn);
-//  /* USER CODE BEGIN FDCAN2_MspInit 1 */
-
-//  /* USER CODE END FDCAN2_MspInit 1 */
-//  }        
+          /* USER CODE END FDCAN1_MspInit 1 */
+      }
 
     }
 
@@ -352,39 +334,7 @@ extern "C"
 
   /* USER CODE END FDCAN1_MspDeInit 1 */
   }
-//  else if(fdcanHandle->Instance==FDCAN2)
-//  {
-//  /* USER CODE BEGIN FDCAN2_MspDeInit 0 */
-
-//  /* USER CODE END FDCAN2_MspDeInit 0 */
-//    /* Peripheral clock disable */
-//    HAL_RCC_FDCAN_CLK_ENABLED--;
-//    if(HAL_RCC_FDCAN_CLK_ENABLED==0){
-//      __HAL_RCC_FDCAN_CLK_DISABLE();
-//    }
-
-//    /**FDCAN2 GPIO Configuration
-//    PB6     ------> FDCAN2_TX
-//    PB12     ------> FDCAN2_RX
-//    */
-//    HAL_GPIO_DeInit(GPIOB, vCAN2_TXD_Pin|vCAN2_RXD_Pin);
-
-//    /* FDCAN2 interrupt Deinit */
-//    HAL_NVIC_DisableIRQ(FDCAN2_IT0_IRQn);
-//    HAL_NVIC_DisableIRQ(FDCAN2_IT1_IRQn);
-//  /* USER CODE BEGIN FDCAN2:FDCAN_CAL_IRQn disable */
-//    /**
-//    * Uncomment the line below to disable the "FDCAN_CAL_IRQn" interrupt
-//    * Be aware, disabling shared interrupt may affect other IPs
-//    */
-//    /* HAL_NVIC_DisableIRQ(FDCAN_CAL_IRQn); */
-//  /* USER CODE END FDCAN2:FDCAN_CAL_IRQn disable */
-
-//  /* USER CODE BEGIN FDCAN2_MspDeInit 1 */
-
-//  /* USER CODE END FDCAN2_MspDeInit 1 */
-//  }
-  
+ 
   
     }    
     

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_can_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_can_bsp_amcmj1.cpp
@@ -52,6 +52,8 @@ using namespace embot::core::binary;
 #include "embot_hw_can_bsp.h"
 
 #include "embot_hw_gpio.h" // for the pin init ... 
+#include "embot_hw_gpio_bsp_amcmj1.h"
+
 
 #if !defined(EMBOT_ENABLE_hw_can)
 
@@ -239,12 +241,6 @@ extern "C"
 
 
     // the msp init / deinit
-
-    constexpr uint16_t vCAN1_TXD_Pin {GPIO_PIN_1};
-    GPIO_TypeDef *vCAN1_TXD_GPIO_Port {GPIOD};  
-    
-    constexpr uint16_t vCAN1_RXD_Pin {GPIO_PIN_0};
-    GPIO_TypeDef *vCAN1_RXD_GPIO_Port {GPIOD};   
     
     static uint32_t HAL_RCC_FDCAN_CLK_ENABLED=0;
 
@@ -255,12 +251,9 @@ extern "C"
       RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
       if(fdcanHandle->Instance==FDCAN1)
       {
-          /* USER CODE BEGIN FDCAN1_MspInit 0 */
 
-          /* USER CODE END FDCAN1_MspInit 0 */
-
-          /** Initializes the peripherals clock
-          */
+          /* Initializes the peripherals clock */
+          
           PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_FDCAN;
           PeriphClkInitStruct.FdcanClockSelection = RCC_FDCANCLKSOURCE_PLL;
           if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
@@ -275,11 +268,11 @@ extern "C"
           }
           
           __HAL_RCC_GPIOD_CLK_ENABLE();
-          /**FDCAN1 GPIO Configuration
+          /* FDCAN1 GPIO Configuration
           PD1     ------> FDCAN1_TX
           PD0     ------> FDCAN1_RX
           */
-          GPIO_InitStruct.Pin = vCAN1_TXD_Pin|vCAN1_RXD_Pin;
+          GPIO_InitStruct.Pin = CAN1_TX_Pin| CAN1_RX_Pin;
           GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
           GPIO_InitStruct.Pull = GPIO_NOPULL;
           GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
@@ -293,9 +286,7 @@ extern "C"
           HAL_NVIC_EnableIRQ(FDCAN1_IT1_IRQn);
           HAL_NVIC_SetPriority(FDCAN_CAL_IRQn, 5, 0);
           HAL_NVIC_EnableIRQ(FDCAN_CAL_IRQn);
-          /* USER CODE BEGIN FDCAN1_MspInit 1 */
 
-          /* USER CODE END FDCAN1_MspInit 1 */
       }
 
     }
@@ -304,9 +295,7 @@ extern "C"
     {
   if(fdcanHandle->Instance==FDCAN1)
   {
-  /* USER CODE BEGIN FDCAN1_MspDeInit 0 */
 
-  /* USER CODE END FDCAN1_MspDeInit 0 */
     /* Peripheral clock disable */
     HAL_RCC_FDCAN_CLK_ENABLED--;
     if(HAL_RCC_FDCAN_CLK_ENABLED==0){
@@ -317,7 +306,7 @@ extern "C"
     PD1     ------> FDCAN1_TX
     PD0     ------> FDCAN1_RX
     */
-    HAL_GPIO_DeInit(GPIOD, vCAN1_TXD_Pin|vCAN1_RXD_Pin);
+    HAL_GPIO_DeInit(GPIOD, CAN1_TX_Pin| CAN1_RX_Pin);
 
     /* FDCAN1 interrupt Deinit */
     HAL_NVIC_DisableIRQ(FDCAN1_IT0_IRQn);
@@ -330,9 +319,6 @@ extern "C"
     /* HAL_NVIC_DisableIRQ(FDCAN_CAL_IRQn); */
   /* USER CODE END FDCAN1:FDCAN_CAL_IRQn disable */
 
-  /* USER CODE BEGIN FDCAN1_MspDeInit 1 */
-
-  /* USER CODE END FDCAN1_MspDeInit 1 */
   }
  
   

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_can_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_can_bsp_amcmj1.cpp
@@ -121,7 +121,7 @@ namespace embot::hw::can {
         hfdcan1.Init.MessageRAMOffset = 0;
         hfdcan1.Init.StdFiltersNbr = 8;
         hfdcan1.Init.ExtFiltersNbr = 0;
-        hfdcan1.Init.RxFifo0ElmtsNbr = 1;
+        hfdcan1.Init.RxFifo0ElmtsNbr = 32;
         hfdcan1.Init.RxFifo0ElmtSize = FDCAN_DATA_BYTES_8;
         hfdcan1.Init.RxFifo1ElmtsNbr = 0;
         hfdcan1.Init.RxFifo1ElmtSize = FDCAN_DATA_BYTES_8;
@@ -129,7 +129,7 @@ namespace embot::hw::can {
         hfdcan1.Init.RxBufferSize = FDCAN_DATA_BYTES_8;
         hfdcan1.Init.TxEventsNbr = 0;
         hfdcan1.Init.TxBuffersNbr = 1;
-        hfdcan1.Init.TxFifoQueueElmtsNbr = 1;
+        hfdcan1.Init.TxFifoQueueElmtsNbr = 32;
         hfdcan1.Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
         hfdcan1.Init.TxElmtSize = FDCAN_DATA_BYTES_8;
         if (HAL_FDCAN_Init(&hfdcan1) != HAL_OK)

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_motor_bldc_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/embot_hw_motor_bldc_bsp_amcmj1.cpp
@@ -274,7 +274,7 @@ namespace embot::hw::motor::bldc::bsp::impl {
     {
         // i want to be sure that pwm and others are not active, so i do a deinit before any other thing 
         // boh, i think it may be redundant. but for sure it does not hurt and it is done at startup of amcmj1        
-        embot::hw::motor::bldc::bsp::impl::deinit(m);
+        //embot::hw::motor::bldc::bsp::impl::deinit(m);
         
         // adc acquisition of the phase currents (and of voltages) is initialized here but it starts w/ pwm::init()
         // because it is triggered by the TIMx of the pwm

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_examples_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_examples_config.h
@@ -20,8 +20,7 @@
 #if defined(STM32HAL_BOARD_AMCMJ1_2CM4) || defined(STM32HAL_BOARD_AMCMJ1_1CM7)
 
     #warning this is the bsp config of STM32HAL_BOARD_AMCMJ1_EXAMPLES_YRI, which is not a real bsp. 
-    #warning It is not meant to be used in production. 
-    #warning It is meant to be used only for testing and development purposes.
+    #warning It is not meant to be used in production. It is meant to be used only for testing and development purposes.
 
     
     #define EMBOT_ENABLE_hw_sys_emulateRAND
@@ -30,35 +29,33 @@
     // not minimal section
     
     // shared
-    #define EMBOT_ENABLE_hw_mtx
-    #define EMBOT_ENABLE_hw_icc_sig
-    #define EMBOT_ENABLE_hw_icc_mem
-    #define EMBOT_ENABLE_hw_icc_ltr
+//    #define EMBOT_ENABLE_hw_mtx
+//    #define EMBOT_ENABLE_hw_icc_sig
+//    #define EMBOT_ENABLE_hw_icc_mem
+//    #define EMBOT_ENABLE_hw_icc_ltr
 
     // portable  
     // cm7: spi, eeprom
 
+//    #define EMBOT_ENABLE_hw_timer
 
-    #define EMBOT_ENABLE_hw_timer
-
-
-// so far can, if not commented out, is assigned to the slave core
-    #if defined(EMBOT_CORE_slave)
         #define EMBOT_ENABLE_hw_can    
-    #else
         #define EMBOT_ENABLE_hw_eth
         #define EMBOT_ENABLE_hw_eeprom
+        
         #define EMBOT_ENABLE_hw_spi
-        #define EMBOT_ENABLE_hw_spi_two
-        #define EMBOT_ENABLE_hw_spi_three
+        #if defined(EMBOT_ENABLE_hw_can)
+            //#define EMBOT_ENABLE_hw_spi_one
+            #define EMBOT_ENABLE_hw_spi_two
+            #define EMBOT_ENABLE_hw_spi_three
+        #endif  
     
-    #endif // EMBOT_CORE_slave 
+
     #define EMBOT_ENABLE_hw_can
     // so far can is assigned to the slave core
     #if defined(EMBOT_ENABLE_hw_can)
         #define EMBOT_ENABLE_hw_can_one
     #endif  
-#endif
 
 
 #else

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
@@ -41,6 +41,10 @@
         #define EMBOT_ENABLE_hw_spi_three
     #endif 
     
+    
+    #define EMBOT_ENABLE_hw_can 
+    
+    
     #define EMBOT_ENABLE_hw_eeprom
 
     #if defined(STM32HAL_CORE_CM4) 
@@ -51,6 +55,11 @@
     
     // and also eth is assigned to master
     #define EMBOT_ENABLE_hw_eth
+    
+    #if defined(_MAINTAINER_APPL_)
+        #undef EMBOT_ENABLE_hw_can
+    #endif
+    
     
 #endif // EMBOT_CORE_master
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
@@ -41,10 +41,6 @@
         #define EMBOT_ENABLE_hw_spi_three
     #endif 
     
-    
-    #define EMBOT_ENABLE_hw_can 
-    
-    
     #define EMBOT_ENABLE_hw_eeprom
 
     #if defined(STM32HAL_CORE_CM4) 
@@ -60,6 +56,10 @@
         #undef EMBOT_ENABLE_hw_can
     #endif
     
+    #undef EMBOT_ENABLE_hw_can
+    #if defined(EMBOT_ENABLE_hw_can)
+        #define EMBOT_ENABLE_hw_can_5V
+    #endif
     
 #endif // EMBOT_CORE_master
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-test-hw/proj/amcmj1.2cm4-hw.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-test-hw/proj/amcmj1.2cm4-hw.uvoptx
@@ -421,7 +421,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>1</aSer4>
+        <aSer4>0</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -458,7 +458,7 @@
 
   <Group>
     <GroupName>main</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -478,7 +478,7 @@
 
   <Group>
     <GroupName>stm32hal</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -1062,7 +1062,7 @@
 
   <Group>
     <GroupName>embot::hw::bsp-shared</GroupName>
-    <tvExp>1</tvExp>
+    <tvExp>0</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-test-hw/proj/amcmj1.2cm4-hw.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/examples/cmx-test-hw/proj/amcmj1.2cm4-hw.uvprojx
@@ -16,7 +16,7 @@
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.4.1.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.1.3</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
@@ -866,13 +866,13 @@
       <TargetName>amcmj1.2cm4-master</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
-      <pCCUsed>6240000::V6.24::ARMCLANG</pCCUsed>
+      <pCCUsed>6230000::V6.23::ARMCLANG</pCCUsed>
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>STM32H745IIKx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
-          <PackID>Keil.STM32H7xx_DFP.4.1.0</PackID>
+          <PackID>Keil.STM32H7xx_DFP.4.1.3</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
           <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/cfg/amcmj1.appl.mot-2cm4.sct
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/cfg/amcmj1.appl.mot-2cm4.sct
@@ -1,15 +1,15 @@
-; amcmj1-appl.mot running on cm7. it uses following FLASH and RAM resources:
+; amcmj1-appl.mot running on cm4. it uses following FLASH and RAM resources:
 ; 
 ; - FLASH: 1st bank @ 0x08000000 for a size of 512k
 ; 
-; - RAM: AXI SRAM @ 0x24000000 for a size of 512k
+; - RAM: RAM: SRAM1-SRAM2 @ 0x10000000 for a size of 256K - 64
 ; 
 ; the memory for IPC is @ 0x1003FFC0, on the top 64 bytes of SRAM1-SRAM2 used by the CM4
 
-LoadRegion_BANK2_applmot 0x08200000 0x00080000  {  
+LoadRegion_BANK2_applmot 0x08100000 0x00080000  {  
   
   ; execution region is in flash
-  ExecutionRegion_BANK2_applmot 0x08200000 0x00080000  {  
+  ExecutionRegion_BANK2_applmot 0x08100000 0x00080000  {  
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvoptx
@@ -103,7 +103,7 @@
         <bEvRecOn>1</bEvRecOn>
         <bSchkAxf>0</bSchkAxf>
         <bTchkAxf>0</bTchkAxf>
-        <nTsel>0</nTsel>
+        <nTsel>1</nTsel>
         <sDll></sDll>
         <sDllPa></sDllPa>
         <sDlgDll></sDlgDll>
@@ -114,18 +114,18 @@
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
         <tIfile></tIfile>
-        <pMon>BIN\UL2CM3.DLL</pMon>
+        <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>UL2CM3</Key>
-          <Name>UL2CM3(-S0 -C0 -P0 )  -FN1 -FC8000 -FD10000000 -FF0STM32H7x_2048 -FL0200000 -FS08000000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>UL2CM3(-S0 -C0 -P0 )  -FN1 -FC8000 -FD10000000 -FF0STM32H7x_2048 -FL0200000 -FS08000000 -FP0($$Device:STM32H747AIIx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>UL2CM3(-S0 -C0 -P0 )  -FN1 -FC8000 -FD10000000 -FF0STM32H7x_2048 -FL0200000 -FS08000000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
+          <Name>-UP2214491 -O206 -S12 -C0 -P00000003 -N00("ARM CoreSight SW-DP") -D00(6BA02477) -L00(0) -TO65554 -TC200000000 -TT10000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO7 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048.FLM -FS08000000 -FL0200000 -FP0($$Device:STM32H747AIIx$CMSIS\Flash\STM32H7x_2048.FLM)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -135,7 +135,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>DLGTARM</Key>
-          <Name>(1010=-1,-1,-1,-1,0)(6017=-1,-1,-1,-1,0)(1008=-1,-1,-1,-1,0)(6016=-1,-1,-1,-1,0)(1012=-1,-1,-1,-1,0)</Name>
+          <Name>(1010=-1,-1,-1,-1,0)(1007=-1,-1,-1,-1,0)(1008=-1,-1,-1,-1,0)(1009=-1,-1,-1,-1,0)(1012=-1,-1,-1,-1,0)</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -148,47 +148,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>290</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134276726</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>C:\ace\!mar\icub-firmware\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot.wip\src\main-dualcore.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\cm7master\../src/main-dualcore.cpp\290</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>197</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134237418</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\..\..\..\embot\hw\embot_hw_dualcore.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\cm7master\../../../../../embot/hw/embot_hw_dualcore.cpp\197</Expression>
-        </Bp>
-      </Breakpoint>
-      <WatchWindow1>
-        <Ww>
-          <count>0</count>
-          <WinNumber>1</WinNumber>
-          <ItemText>SystemCoreClock,0x0A</ItemText>
-        </Ww>
-      </WatchWindow1>
+      <Breakpoint/>
       <WatchWindow2>
         <Ww>
           <count>0</count>
@@ -210,7 +170,7 @@
       <DebugFlag>
         <trace>0</trace>
         <periodic>0</periodic>
-        <aLwin>1</aLwin>
+        <aLwin>0</aLwin>
         <aCover>0</aCover>
         <aSer1>0</aSer1>
         <aSer2>0</aSer2>
@@ -227,7 +187,7 @@
         <aLa>0</aLa>
         <aPa1>0</aPa1>
         <AscS4>0</AscS4>
-        <aSer4>0</aSer4>
+        <aSer4>1</aSer4>
         <StkLoc>0</StkLoc>
         <TrcWin>0</TrcWin>
         <newCpu>0</newCpu>
@@ -389,14 +349,14 @@
           <Type>0</Type>
           <LineNumber>83</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134260714</Address>
+          <Address>134260842</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
           <BreakIfRCount>1</BreakIfRCount>
-          <Filename>C:\Users\ksangalli\Desktop\Kevin_repo\icub-firmware - Copy\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot\src\app-board\embot_app_board_theCANagentCORE.cpp</Filename>
+          <Filename>C:\Users\ksangalli\Desktop\Kevin_repo\icub-firmware\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot\src\app-board\embot_app_board_theCANagentCORE.cpp</Filename>
           <ExecCommand></ExecCommand>
           <Expression>\\cm7slave\../src/app-board/embot_app_board_theCANagentCORE.cpp\83</Expression>
         </Bp>
@@ -405,16 +365,16 @@
           <Type>0</Type>
           <LineNumber>77</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
+          <Address>134260802</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
           <SizeOfObject>0</SizeOfObject>
           <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>C:\Users\ksangalli\Desktop\Kevin_repo\icub-firmware - Copy\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot\src\app-board\embot_app_board_theCANagentCORE.cpp</Filename>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>C:\Users\ksangalli\Desktop\Kevin_repo\icub-firmware\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot\src\app-board\embot_app_board_theCANagentCORE.cpp</Filename>
           <ExecCommand></ExecCommand>
-          <Expression></Expression>
+          <Expression>\\cm7slave\../src/app-board/embot_app_board_theCANagentCORE.cpp\77</Expression>
         </Bp>
       </Breakpoint>
       <WatchWindow1>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvoptx
@@ -75,7 +75,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -270,7 +270,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -343,40 +343,7 @@
           <Name></Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>83</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134260842</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>C:\Users\ksangalli\Desktop\Kevin_repo\icub-firmware\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot\src\app-board\embot_app_board_theCANagentCORE.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\cm7slave\../src/app-board/embot_app_board_theCANagentCORE.cpp\83</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>77</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134260802</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>C:\Users\ksangalli\Desktop\Kevin_repo\icub-firmware\emBODY\eBcode\arch-arm\board\amcmj1\procs\appl.mot\src\app-board\embot_app_board_theCANagentCORE.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\cm7slave\../src/app-board/embot_app_board_theCANagentCORE.cpp\77</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvprojx
@@ -14,14 +14,14 @@
       <uAC6>1</uAC6>
       <TargetOption>
         <TargetCommonOption>
-          <Device>STM32H745IIKx:CM4</Device>
+          <Device>STM32H747AIIx:CM4</Device>
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32H7xx_DFP.4.1.3</PackID>
           <PackURL>https://www.keil.com/pack/</PackURL>
-          <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IRAM(0x10000000,0x00048000) IROM(0x08100000,0x00100000) CPUTYPE("Cortex-M4") FPU2 DSP CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
-          <FlashDriverDll>UL2CM3(-S0 -C0 -P0 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048 -FS08000000 -FL0200000 -FP0($$Device:STM32H745IIKx$CMSIS\Flash\STM32H7x_2048.FLM))</FlashDriverDll>
+          <FlashDriverDll>UL2CM3(-S0 -C0 -P0 -FD10000000 -FC8000 -FN1 -FF0STM32H7x_2048 -FS08000000 -FL0200000 -FP0($$Device:STM32H747AIIx$CMSIS\Flash\STM32H7x_2048.FLM))</FlashDriverDll>
           <DeviceId>0</DeviceId>
           <RegisterFile></RegisterFile>
           <MemoryEnv></MemoryEnv>
@@ -33,7 +33,7 @@
           <SLE66CMisc></SLE66CMisc>
           <SLE66AMisc></SLE66AMisc>
           <SLE66LinkerMisc></SLE66LinkerMisc>
-          <SFDFile>$$Device:STM32H745IIKx$CMSIS\SVD\STM32H745_CM4.svd</SFDFile>
+          <SFDFile>$$Device:STM32H747AIIx$CMSIS\SVD\STM32H747_CM4.svd</SFDFile>
           <bCustSvd>0</bCustSvd>
           <UseEnv>0</UseEnv>
           <BinPath></BinPath>
@@ -138,7 +138,7 @@
           </Flash1>
           <bUseTDR>1</bUseTDR>
           <Flash2>BIN\UL2CM3.DLL</Flash2>
-          <Flash3></Flash3>
+          <Flash3>"" ()</Flash3>
           <Flash4></Flash4>
           <pFcarmOut></pFcarmOut>
           <pFcarmGrp></pFcarmGrp>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/loader/proj/amcmj1.loader.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/loader/proj/amcmj1.loader.uvoptx
@@ -75,7 +75,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>
@@ -277,7 +277,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <DebugOpt>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/loader/proj/amcmj1.loader.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/loader/proj/amcmj1.loader.uvprojx
@@ -1091,6 +1091,57 @@
               <FileName>embot_hw_can.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_can.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_hw_mtx.cpp</FileName>
@@ -1151,6 +1202,57 @@
               <FileName>embot_hw_can_bsp_amcmj1.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\portable\embot_hw_can_bsp_amcmj1.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_hw_spi_bsp_amcmj1.cpp</FileName>
@@ -2281,6 +2383,57 @@
               <FileName>embot_hw_can.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\..\..\embot\hw\embot_hw_can.cpp</FilePath>
+              <FileOption>
+                <CommonProperty>
+                  <UseCPPCompiler>2</UseCPPCompiler>
+                  <RVCTCodeConst>0</RVCTCodeConst>
+                  <RVCTZI>0</RVCTZI>
+                  <RVCTOtherData>0</RVCTOtherData>
+                  <ModuleSelection>0</ModuleSelection>
+                  <IncludeInBuild>0</IncludeInBuild>
+                  <AlwaysBuild>2</AlwaysBuild>
+                  <GenerateAssemblyFile>2</GenerateAssemblyFile>
+                  <AssembleAssemblyFile>2</AssembleAssemblyFile>
+                  <PublicsOnly>2</PublicsOnly>
+                  <StopOnExitCode>11</StopOnExitCode>
+                  <CustomArgument></CustomArgument>
+                  <IncludeLibraryModules></IncludeLibraryModules>
+                  <ComprImg>1</ComprImg>
+                </CommonProperty>
+                <FileArmAds>
+                  <Cads>
+                    <interw>2</interw>
+                    <Optim>0</Optim>
+                    <oTime>2</oTime>
+                    <SplitLS>2</SplitLS>
+                    <OneElfS>2</OneElfS>
+                    <Strict>2</Strict>
+                    <EnumInt>2</EnumInt>
+                    <PlainCh>2</PlainCh>
+                    <Ropi>2</Ropi>
+                    <Rwpi>2</Rwpi>
+                    <wLevel>0</wLevel>
+                    <uThumb>2</uThumb>
+                    <uSurpInc>2</uSurpInc>
+                    <uC99>2</uC99>
+                    <uGnu>2</uGnu>
+                    <useXO>2</useXO>
+                    <v6Lang>0</v6Lang>
+                    <v6LangP>0</v6LangP>
+                    <vShortEn>2</vShortEn>
+                    <vShortWch>2</vShortWch>
+                    <v6Lto>2</v6Lto>
+                    <v6WtE>2</v6WtE>
+                    <v6Rtti>2</v6Rtti>
+                    <VariousControls>
+                      <MiscControls></MiscControls>
+                      <Define></Define>
+                      <Undefine></Undefine>
+                      <IncludePath></IncludePath>
+                    </VariousControls>
+                  </Cads>
+                </FileArmAds>
+              </FileOption>
             </File>
             <File>
               <FileName>embot_hw_mtx.cpp</FileName>

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
@@ -619,12 +619,12 @@ void can::callbackOnRXcompletion(embot::hw::can::CAN_Handle* hcan, uint32_t RxFi
 
     if((RxFifo0ITs & FDCAN_IT_RX_FIFO0_FULL) != 0)
     {
-        embot::core::print("fifo0-full");
+        //embot::core::print("fifo0-full");
     }
     
     if((RxFifo0ITs & FDCAN_IT_RX_FIFO0_MESSAGE_LOST) != 0)
     {
-         embot::core::print("fifo0-msglost");
+         //embot::core::print("fifo0-msglost");
     }
 }
 #endif

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
@@ -56,7 +56,7 @@ using namespace std;
 
 // in here we manage the case of no can module being present in stm32hal
 
-namespace embot { namespace hw { namespace can {
+namespace embot::hw::can {
 
     bool supported(embot::hw::CAN p) { return false; }
     
@@ -84,12 +84,12 @@ namespace embot { namespace hw { namespace can {
 
     result_t setfilters(embot::hw::CAN p, std::uint8_t address) { return resNOK; }
     
-}}} // namespace embot { namespace hw { namespace can {
+} // namespace embot::hw::can {
 
 #else
 
 
-namespace embot { namespace hw { namespace can {
+namespace embot::hw::can {
                          
     static std::uint32_t initialisedmask = 0;
     
@@ -164,11 +164,10 @@ namespace embot { namespace hw { namespace can {
     constexpr uint8_t cls_as_polling = 2;
     constexpr uint8_t cls_bootloader = 7;
     
-    void s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame);   
-    
+    void s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame);       
     void s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame);
-      
-}}};
+  
+} // namespace embot::hw::can {
 
 
 using namespace embot::hw;      
@@ -1021,6 +1020,44 @@ static bool can::s_startdriver(embot::hw::can::CAN_Handle *hcan)
 }  
 
 
+#if defined(HAL_FDCAN_MODULE_ENABLED)
+
+// the HAL library is definde by type (e.g., STM32HAL_STM32G4 / STM32HAL_STM32H7) and version number expressed by STM32HAL_DRIVER_VERSION (e.g., 0x1B5)
+#if defined(STM32HAL_STM32H7) && (STM32HAL_DRIVER_VERSION >= 0x1B5)
+    #undef STM32HAL_HAS_API_with_shifted_datalenght
+    static_assert(FDCAN_DLC_BYTES_1 == ((uint32_t)0x00000001U), "error: API use datalenght w/ no shift");
+#else
+    // this is sadly the normal case until we found out that H7 HAL version 1B5 has become normal w/ no shift
+    // but maybe some other HAL do the change, for instance STM32HAL_STM32G4
+    #define STM32HAL_HAS_API_with_shifted_datalenght
+    static_assert(FDCAN_DLC_BYTES_1 == ((uint32_t)0x00010000U), "error: API use datalenght shifter by 16");
+#endif
+
+
+namespace stm32utils {
+    
+uint32_t todatalength(uint8_t framesize)
+{
+    uint32_t r {framesize};     
+#if defined(STM32HAL_HAS_API_with_shifted_datalenght)
+    r = static_cast<uint32_t>(framesize) << 16; // uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16
+#endif    
+    return r;
+}
+
+uint8_t toframesize(uint32_t datalength)
+{
+    uint32_t r {datalength};
+#if defined(STM32HAL_HAS_API_with_shifted_datalenght)
+    r = datalength >> 16;
+#endif    
+    return static_cast<uint8_t>(r);
+}
+
+} // namespace stm32utils {
+
+#endif // #if defined(HAL_FDCAN_MODULE_ENABLED)
+
 
 void can::s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
 {
@@ -1044,13 +1081,7 @@ void can::s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
     headertx.Identifier = frame.id & 0x7FF;
     headertx.IdType = FDCAN_STANDARD_ID;
     headertx.TxFrameType = FDCAN_DATA_FRAME;
-    
-    #if defined(STM32HAL_DRIVER_V1B5)
-        headertx.DataLength= static_cast<uint32_t>(frame.size); //from stm32h7xx-hal driver version 1B3
-    #else  
-        headertx.DataLength = static_cast<uint32_t>(frame.size) << 16; // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16
-    #endif
-
+    headertx.DataLength = stm32utils::todatalength(frame.size);
     headertx.ErrorStateIndicator = FDCAN_ESI_ACTIVE; // or FDCAN_ESI_PASSIVE ???
     headertx.BitRateSwitch = FDCAN_BRS_OFF;
     headertx.FDFormat = FDCAN_CLASSIC_CAN;
@@ -1074,13 +1105,7 @@ void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame
     FDCAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK   
     HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, frame.data);
     frame.id = headerRX.Identifier & 0x7ff;
-    
-    #if defined(STM32HAL_DRIVER_V1B5)
-        frame.size = headerRX.DataLength; //from stm32h7xx-hal driver version 1B3
-    #else 
-        frame.size = headerRX.DataLength >> 16;   // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
-    #endif 
-    
+    frame.size = stm32utils::toframesize(headerRX.DataLength);   
 #endif  
     
 }
@@ -1101,7 +1126,8 @@ void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame
 #endif // EMBOT_ENABLE_hw_can
 
 
-    
+
+
 
 
 

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
@@ -620,12 +620,12 @@ void can::callbackOnRXcompletion(embot::hw::can::CAN_Handle* hcan, uint32_t RxFi
 
     if((RxFifo0ITs & FDCAN_IT_RX_FIFO0_FULL) != 0)
     {
-        //embot::core::print("fifo0-full");
+        embot::core::print("fifo0-full");
     }
     
     if((RxFifo0ITs & FDCAN_IT_RX_FIFO0_MESSAGE_LOST) != 0)
     {
-         //embot::core::print("fifo0-msglost");
+         embot::core::print("fifo0-msglost");
     }
 }
 #endif
@@ -1044,7 +1044,13 @@ void can::s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
     headertx.Identifier = frame.id & 0x7FF;
     headertx.IdType = FDCAN_STANDARD_ID;
     headertx.TxFrameType = FDCAN_DATA_FRAME;
-    headertx.DataLength = static_cast<uint32_t>(frame.size) << 16; // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16
+    
+    #if defined(STM32HAL_DRIVER_V1A0)
+        headertx.DataLength = static_cast<uint32_t>(frame.size) << 16; // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16
+    #else //from stm32h7xx-hal driver version 1B3
+        headertx.DataLength= static_cast<uint32_t>(frame.size);
+    #endif
+
     headertx.ErrorStateIndicator = FDCAN_ESI_ACTIVE; // or FDCAN_ESI_PASSIVE ???
     headertx.BitRateSwitch = FDCAN_BRS_OFF;
     headertx.FDFormat = FDCAN_CLASSIC_CAN;
@@ -1056,6 +1062,28 @@ void can::s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
         
 }
 
+//void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
+//{
+//        
+//#if defined(HAL_CAN_MODULE_ENABLED)      
+//    CAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK        
+//    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &headerRX, frame.data);
+//    frame.id = headerRX.StdId;
+//    frame.size = headerRX.DLC;   
+//#elif defined(HAL_FDCAN_MODULE_ENABLED)  
+//    FDCAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK   
+//    HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, frame.data);
+//    frame.id = headerRX.Identifier & 0x7ff;
+//    #if defined(STM32HAL_DRIVER_V1A0)
+//        frame.size = headerRX.DataLength >> 16;   // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
+//    #else //from stm32h7xx-hal driver version 1B3
+//        frame.size = headerRX.DataLength;
+//    #endif    
+//#endif  
+//    
+//}
+
+
 void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
 {
         
@@ -1064,13 +1092,43 @@ void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame
     HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &headerRX, frame.data);
     frame.id = headerRX.StdId;
     frame.size = headerRX.DLC;   
-#elif defined(HAL_FDCAN_MODULE_ENABLED)  
-    FDCAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK   
-    HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, frame.data);
+#elif defined(HAL_FDCAN_MODULE_ENABLED)
+
+    FDCAN_RxHeaderTypeDef headerRX = {0};
+    uint8_t rxdata[8] = {0};
+
+    HAL_StatusTypeDef r = HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, rxdata);
+
     frame.id = headerRX.Identifier & 0x7ff;
-    frame.size = headerRX.DataLength >> 16;   // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
-#endif  
-    
+
+   
+    #if defined(STM32HAL_DRIVER_V1A0)
+        frame.size = headerRX.DataLength >> 16; // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
+    #else //from stm32h7xx-hal driver version 1B3
+        frame.size = headerRX.DataLength;
+    #endif   
+
+    for(uint8_t i = 0; i < 8; i++)
+    {
+        frame.data[i] = rxdata[i];
+    }
+
+    embot::core::print(
+        "rx id=" + std::to_string(frame.id) +
+        " size=" + std::to_string(frame.size) +
+        " data=" +
+        std::to_string(frame.data[0]) + " " +
+        std::to_string(frame.data[1]) + " " +
+        std::to_string(frame.data[2]) + " " +
+        std::to_string(frame.data[3]) + " " +
+        std::to_string(frame.data[4]) + " " +
+        std::to_string(frame.data[5]) + " " +
+        std::to_string(frame.data[6]) + " " +
+        std::to_string(frame.data[7]) +
+        " hal=" + std::to_string(r)
+    );
+
+#endif
 }
  
 // not used, so far

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_can.cpp
@@ -1045,10 +1045,10 @@ void can::s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
     headertx.IdType = FDCAN_STANDARD_ID;
     headertx.TxFrameType = FDCAN_DATA_FRAME;
     
-    #if defined(STM32HAL_DRIVER_V1A0)
+    #if defined(STM32HAL_DRIVER_V1B5)
+        headertx.DataLength= static_cast<uint32_t>(frame.size); //from stm32h7xx-hal driver version 1B3
+    #else  
         headertx.DataLength = static_cast<uint32_t>(frame.size) << 16; // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16
-    #else //from stm32h7xx-hal driver version 1B3
-        headertx.DataLength= static_cast<uint32_t>(frame.size);
     #endif
 
     headertx.ErrorStateIndicator = FDCAN_ESI_ACTIVE; // or FDCAN_ESI_PASSIVE ???
@@ -1057,32 +1057,10 @@ void can::s_addtxmessagetoqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
     headertx.TxEventFifoControl = FDCAN_NO_TX_EVENTS; // or FDCAN_STORE_TX_EVENTS ??
     headertx.MessageMarker = 0; //  Specifies the message marker to be copied into Tx Event FIFO ... between 0 and 0xFF   
     rr = HAL_FDCAN_AddMessageToTxFifoQ(hcan, &headertx, frame.data);
-    rr = rr;
+    //rr = rr;
 #endif 
         
 }
-
-//void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
-//{
-//        
-//#if defined(HAL_CAN_MODULE_ENABLED)      
-//    CAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK        
-//    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &headerRX, frame.data);
-//    frame.id = headerRX.StdId;
-//    frame.size = headerRX.DLC;   
-//#elif defined(HAL_FDCAN_MODULE_ENABLED)  
-//    FDCAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK   
-//    HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, frame.data);
-//    frame.id = headerRX.Identifier & 0x7ff;
-//    #if defined(STM32HAL_DRIVER_V1A0)
-//        frame.size = headerRX.DataLength >> 16;   // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
-//    #else //from stm32h7xx-hal driver version 1B3
-//        frame.size = headerRX.DataLength;
-//    #endif    
-//#endif  
-//    
-//}
-
 
 void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame)
 {
@@ -1092,44 +1070,21 @@ void can::s_getrxmessagefromqueue(embot::hw::can::CAN_Handle *hcan, Frame& frame
     HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &headerRX, frame.data);
     frame.id = headerRX.StdId;
     frame.size = headerRX.DLC;   
-#elif defined(HAL_FDCAN_MODULE_ENABLED)
-
-    FDCAN_RxHeaderTypeDef headerRX = {0};
-    uint8_t rxdata[8] = {0};
-
-    HAL_StatusTypeDef r = HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, rxdata);
-
+#elif defined(HAL_FDCAN_MODULE_ENABLED)  
+    FDCAN_RxHeaderTypeDef headerRX = {0}; // KEEP IT IN STACK   
+    HAL_FDCAN_GetRxMessage(hcan, FDCAN_RX_FIFO0, &headerRX, frame.data);
     frame.id = headerRX.Identifier & 0x7ff;
-
-   
-    #if defined(STM32HAL_DRIVER_V1A0)
-        frame.size = headerRX.DataLength >> 16; // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
-    #else //from stm32h7xx-hal driver version 1B3
-        frame.size = headerRX.DataLength;
-    #endif   
-
-    for(uint8_t i = 0; i < 8; i++)
-    {
-        frame.data[i] = rxdata[i];
-    }
-
-    embot::core::print(
-        "rx id=" + std::to_string(frame.id) +
-        " size=" + std::to_string(frame.size) +
-        " data=" +
-        std::to_string(frame.data[0]) + " " +
-        std::to_string(frame.data[1]) + " " +
-        std::to_string(frame.data[2]) + " " +
-        std::to_string(frame.data[3]) + " " +
-        std::to_string(frame.data[4]) + " " +
-        std::to_string(frame.data[5]) + " " +
-        std::to_string(frame.data[6]) + " " +
-        std::to_string(frame.data[7]) +
-        " hal=" + std::to_string(r)
-    );
-
-#endif
+    
+    #if defined(STM32HAL_DRIVER_V1B5)
+        frame.size = headerRX.DataLength; //from stm32h7xx-hal driver version 1B3
+    #else 
+        frame.size = headerRX.DataLength >> 16;   // DataLength uses FDCAN_DLC_BYTES_0, FDCAN_DLC_BYTES_1, etc. where FDCAN_DLC_BYTES_x is x << 16    
+    #endif 
+    
+#endif  
+    
 }
+
  
 // not used, so far
 //void can::callbackOnError(embot::hw::can::CAN_Handle* hcan)

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc.cpp
@@ -60,8 +60,7 @@ std::string embot::hw::motor::bldc::to_string(embot::hw::MOTOR id)
 
 namespace embot::hw::motor::bldc {
 
-    const std::vector<embot::hw::MOTOR> & supported() { static const std::vector<embot::hw::MOTOR> themotors {}; return themotors;  }
-    bool supported(MOTOR m) { return false; }
+    const std::initializer_list<embot::hw::MOTOR> & supported() { static const std::initializer_list<embot::hw::MOTOR> themotors {}; return themotors;  }    bool supported(MOTOR m) { return false; }
     bool initialised(MOTOR m) { return false; }
     
     bool init(MOTOR m, const Config &config) { return false; } 


### PR DESCRIPTION
Improved the `embot_hw_can.cpp` file to handle a change in `stm32h7xx-hal-driver`  to file  [stm32h7xx_hal_fdcan.h](https://github.com/STMicroelectronics/stm32h7xx-hal-driver/compare/v1.10.0...v1.11.5#diff-c2ba6df8cde8e9d30e9aa9281f30bc3015592a1a011e8e9283bb4a45fc379481) .

Improved the amcmj1 CAN BSP: configured the pin that enables the 5V on the CAN BUS, and the pin that reads the status of the chip that power the line. We do not use this last reading atm.
Added the `EMBOT_ENABLE_hw_can_5V` macro to enable the 5V independently from the `init` of the CAN peripheral. 

Improved the `xx_config.h` files, fixed scatter file for cm4 of app.mot., removed deinit from motor.