### PR TITLE
amcmj1 - adding button and macro for disabling motor interrupt

### DIFF
--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_analog_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_analog_bsp_amcmj1.cpp
@@ -264,115 +264,7 @@ namespace embot::hw::analog::bsp::impl {
         ADC_HandleTypeDef *adcHandle = reinterpret_cast<ADC_HandleTypeDef*>(p);
 
         GPIO_InitTypeDef GPIO_InitStruct = {0};
-//        if(adcHandle->Instance==ADC1)
-//        {
-//        /* USER CODE BEGIN ADC1_MspInit 0 */
 
-//        /* USER CODE END ADC1_MspInit 0 */
-//        /* ADC1 clock enable */
-//        HAL_RCC_ADC12_CLK_ENABLED++;
-//        if(HAL_RCC_ADC12_CLK_ENABLED==1){
-//          __HAL_RCC_ADC12_CLK_ENABLE();
-//        }
-
-//        __HAL_RCC_GPIOF_CLK_ENABLE();
-//        __HAL_RCC_GPIOA_CLK_ENABLE();
-//        /**ADC1 GPIO Configuration
-//        PF12     ------> ADC1_INP6
-//        PF11     ------> ADC1_INP2
-//        PA6     ------> ADC1_INP3
-//        */
-//        GPIO_InitStruct.Pin = MOT_VPHASE3_Pin|MOT_VPHASE1_Pin;
-//        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-//        GPIO_InitStruct.Pull = GPIO_NOPULL;
-//        HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
-//        GPIO_InitStruct.Pin = MOT_VPHASE2_Pin;
-//        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-//        GPIO_InitStruct.Pull = GPIO_NOPULL;
-//        HAL_GPIO_Init(MOT_VPHASE2_GPIO_Port, &GPIO_InitStruct);
-
-//        /* ADC1 DMA Init */
-//        /* ADC1 Init */
-//        hdma_adc1.Instance = DMA2_Stream7;
-//        hdma_adc1.Init.Request = DMA_REQUEST_ADC1;
-//        hdma_adc1.Init.Direction = DMA_PERIPH_TO_MEMORY;
-//        hdma_adc1.Init.PeriphInc = DMA_PINC_DISABLE;
-//        hdma_adc1.Init.MemInc = DMA_MINC_ENABLE;
-//        hdma_adc1.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
-//        hdma_adc1.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
-//        hdma_adc1.Init.Mode = DMA_CIRCULAR;
-//        hdma_adc1.Init.Priority = DMA_PRIORITY_VERY_HIGH;
-//        hdma_adc1.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-//        if (HAL_DMA_Init(&hdma_adc1) != HAL_OK)
-//        {
-//          Error_Handler();
-//        }
-
-//        __HAL_LINKDMA(adcHandle,DMA_Handle,hdma_adc1);
-
-//        /* ADC1 interrupt Init */
-//        HAL_NVIC_SetPriority(ADC_IRQn, 5, 0);
-//        HAL_NVIC_EnableIRQ(ADC_IRQn);
-//        /* USER CODE BEGIN ADC1_MspInit 1 */
-
-//        /* USER CODE END ADC1_MspInit 1 */
-//        }
-//        else if(adcHandle->Instance==ADC2)
-//        {
-//        /* USER CODE BEGIN ADC2_MspInit 0 */
-
-//        /* USER CODE END ADC2_MspInit 0 */
-//        /* ADC2 clock enable */
-//        HAL_RCC_ADC12_CLK_ENABLED++;
-//        if(HAL_RCC_ADC12_CLK_ENABLED==1){
-//          __HAL_RCC_ADC12_CLK_ENABLE();
-//        }
-
-//        __HAL_RCC_GPIOF_CLK_ENABLE();
-//        __HAL_RCC_GPIOA_CLK_ENABLE();
-//        /**ADC2 GPIO Configuration
-//        PF13     ------> ADC2_INP2
-//        PA3     ------> ADC2_INP15
-//        PF14     ------> ADC2_INP6
-//        */
-//        GPIO_InitStruct.Pin = MOT_CPHASE1_Pin|MOT_CPHASE2_Pin;
-//        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-//        GPIO_InitStruct.Pull = GPIO_NOPULL;
-//        HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
-//        GPIO_InitStruct.Pin = MOT_CPHASE3_Pin;
-//        GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-//        GPIO_InitStruct.Pull = GPIO_NOPULL;
-//        HAL_GPIO_Init(MOT_CPHASE3_GPIO_Port, &GPIO_InitStruct);
-
-//        /* ADC2 DMA Init */
-//        /* ADC2 Init */
-//        hdma_adc2.Instance = DMA2_Stream0;
-//        hdma_adc2.Init.Request = DMA_REQUEST_ADC2;
-//        hdma_adc2.Init.Direction = DMA_PERIPH_TO_MEMORY;
-//        hdma_adc2.Init.PeriphInc = DMA_PINC_DISABLE;
-//        hdma_adc2.Init.MemInc = DMA_MINC_ENABLE;
-//        hdma_adc2.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
-//        hdma_adc2.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
-//        hdma_adc2.Init.Mode = DMA_CIRCULAR;
-//        hdma_adc2.Init.Priority = DMA_PRIORITY_VERY_HIGH;
-//        hdma_adc2.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-//        if (HAL_DMA_Init(&hdma_adc2) != HAL_OK)
-//        {
-//          Error_Handler();
-//        }
-
-//        __HAL_LINKDMA(adcHandle,DMA_Handle,hdma_adc2);
-
-//        /* ADC2 interrupt Init */
-//        HAL_NVIC_SetPriority(ADC_IRQn, 5, 0);
-//        HAL_NVIC_EnableIRQ(ADC_IRQn);
-//        /* USER CODE BEGIN ADC2_MspInit 1 */
-
-//        /* USER CODE END ADC2_MspInit 1 */
-//        }
-//        else if(adcHandle->Instance==ADC3)
         if(ADC3 == adcHandle->Instance)
         {
             /* USER CODE BEGIN ADC3_MspInit 0 */
@@ -429,84 +321,9 @@ namespace embot::hw::analog::bsp::impl {
     {        
         ADC_HandleTypeDef *adcHandle = reinterpret_cast<ADC_HandleTypeDef*>(p);
 
-//        if(adcHandle->Instance==ADC1)
-//        {
-//        /* USER CODE BEGIN ADC1_MspDeInit 0 */
-
-//        /* USER CODE END ADC1_MspDeInit 0 */
-//        /* Peripheral clock disable */
-//        HAL_RCC_ADC12_CLK_ENABLED--;
-//        if(HAL_RCC_ADC12_CLK_ENABLED==0){
-//          __HAL_RCC_ADC12_CLK_DISABLE();
-//        }
-
-//        /**ADC1 GPIO Configuration
-//        PF12     ------> ADC1_INP6
-//        PF11     ------> ADC1_INP2
-//        PA6     ------> ADC1_INP3
-//        */
-//        HAL_GPIO_DeInit(GPIOF, MOT_VPHASE3_Pin|MOT_VPHASE1_Pin);
-
-//        HAL_GPIO_DeInit(MOT_VPHASE2_GPIO_Port, MOT_VPHASE2_Pin);
-
-//        /* ADC1 DMA DeInit */
-//        HAL_DMA_DeInit(adcHandle->DMA_Handle);
-
-//        /* ADC1 interrupt Deinit */
-//        /* USER CODE BEGIN ADC1:ADC_IRQn disable */
-//        /**
-//        * Uncomment the line below to disable the "ADC_IRQn" interrupt
-//        * Be aware, disabling shared interrupt may affect other IPs
-//        */
-//        /* HAL_NVIC_DisableIRQ(ADC_IRQn); */
-//        /* USER CODE END ADC1:ADC_IRQn disable */
-
-//        /* USER CODE BEGIN ADC1_MspDeInit 1 */
-
-//        /* USER CODE END ADC1_MspDeInit 1 */
-//        }
-//        else if(adcHandle->Instance==ADC2)
-//        {
-//        /* USER CODE BEGIN ADC2_MspDeInit 0 */
-
-//        /* USER CODE END ADC2_MspDeInit 0 */
-//        /* Peripheral clock disable */
-//        HAL_RCC_ADC12_CLK_ENABLED--;
-//        if(HAL_RCC_ADC12_CLK_ENABLED==0){
-//          __HAL_RCC_ADC12_CLK_DISABLE();
-//        }
-
-//        /**ADC2 GPIO Configuration
-//        PF13     ------> ADC2_INP2
-//        PA3     ------> ADC2_INP15
-//        PF14     ------> ADC2_INP6
-//        */
-//        HAL_GPIO_DeInit(GPIOF, MOT_CPHASE1_Pin|MOT_CPHASE2_Pin);
-
-//        HAL_GPIO_DeInit(MOT_CPHASE3_GPIO_Port, MOT_CPHASE3_Pin);
-
-//        /* ADC2 DMA DeInit */
-//        HAL_DMA_DeInit(adcHandle->DMA_Handle);
-
-//        /* ADC2 interrupt Deinit */
-//        /* USER CODE BEGIN ADC2:ADC_IRQn disable */
-//        /**
-//        * Uncomment the line below to disable the "ADC_IRQn" interrupt
-//        * Be aware, disabling shared interrupt may affect other IPs
-//        */
-//        /* HAL_NVIC_DisableIRQ(ADC_IRQn); */
-//        /* USER CODE END ADC2:ADC_IRQn disable */
-
-//        /* USER CODE BEGIN ADC2_MspDeInit 1 */
-
-//        /* USER CODE END ADC2_MspDeInit 1 */
-//        }
-//        else if(adcHandle->Instance==ADC3)
         if(ADC3 == adcHandle->Instance)
         {
-            /* USER CODE BEGIN ADC3_MspDeInit 0 */
-
-            /* USER CODE END ADC3_MspDeInit 0 */
+            
             /* Peripheral clock disable */
             __HAL_RCC_ADC3_CLK_DISABLE();
 
@@ -527,9 +344,7 @@ namespace embot::hw::analog::bsp::impl {
 
             /* ADC3 interrupt Deinit */
             HAL_NVIC_DisableIRQ(ADC3_IRQn);
-            /* USER CODE BEGIN ADC3_MspDeInit 1 */
 
-            /* USER CODE END ADC3_MspDeInit 1 */
         }
     }        
 }
@@ -575,15 +390,7 @@ namespace embot::hw::analog::bsp::impl {
     void MX_ADC3_Init(void)
     {
 
-        /* USER CODE BEGIN ADC3_Init 0 */
-
-        /* USER CODE END ADC3_Init 0 */
-
         ADC_ChannelConfTypeDef sConfig = {0};
-
-        /* USER CODE BEGIN ADC3_Init 1 */
-
-        /* USER CODE END ADC3_Init 1 */
 
         /** Common config
         */
@@ -711,9 +518,6 @@ namespace embot::hw::analog::bsp::impl {
         {
         Error_Handler();
         }
-        /* USER CODE BEGIN ADC3_Init 2 */
-
-        /* USER CODE END ADC3_Init 2 */
 
     }    
     
@@ -899,12 +703,9 @@ namespace embot::hw::analog::bsp::impl {
         resetlogvalues();
 
         /* Stop all ADCs */
-    //    HAL_ADC_Stop_DMA(&hadc2);
         HAL_ADC_Stop_DMA(&hadc3);
         
         /* Remove all callback functions */
-    //    HAL_ADC_UnRegisterCallback(&hadc2, HAL_ADC_CONVERSION_COMPLETE_CB_ID);
-    //    HAL_ADC_UnRegisterCallback(&hadc2, HAL_ADC_CONVERSION_HALF_CB_ID);
 
         HAL_ADC_UnRegisterCallback(&hadc3, HAL_ADC_CONVERSION_COMPLETE_CB_ID);
         HAL_ADC_UnRegisterCallback(&hadc3, HAL_ADC_CONVERSION_HALF_CB_ID);
@@ -1171,8 +972,6 @@ extern "C"
 #endif // #elif !defined(EMBOT_HW_MOTOR_BLDC_board_use_fake_implementation__hw_analog)
 
  
-
-
 
 
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_button_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_button_bsp_amcmj1.cpp
@@ -1,0 +1,81 @@
+
+/*
+ * Copyright (C) 2026 MESH - Istituto Italiano di Tecnologia
+ * Author:  Marco Accame, Kevin Sangalli
+ * email:   marco.accame@iit.it, kevin.sanngalli@iit.it
+*/
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - public interface
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_button_bsp.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - external dependencies
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// - configuration of peripherals and chips. it is done board by board. it contains a check vs correct STM32HAL_BOARD_*
+// --------------------------------------------------------------------------------------------------------------------
+
+#include "embot_hw_bsp_config.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// - all the rest
+// --------------------------------------------------------------------------------------------------------------------
+
+
+#include "embot_hw_button.h"
+#include "embot_hw_gpio_bsp.h"
+
+#if !defined(EMBOT_ENABLE_hw_button)
+
+namespace embot::hw::button {
+    
+    constexpr BSP thebsp { };
+    void BSP::init(embot::hw::BTN h) const {}
+    void BSP::onEXTI(const embot::hw::gpio::PROP &p) const {}
+    const BSP& getBSP() { return thebsp; }
+    
+}
+
+#else
+
+namespace embot::hw::button {
+    
+//  #define EXT_FAULT_Pin GPIO_PIN_3    #define EXT_FAULT_GPIO_Port GPIOG
+    constexpr PROP btn1p = { .pressed = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::G, embot::hw::GPIO::PIN::three},  
+                             .pull = embot::hw::gpio::Pull::nopull, .irqn = EXTI15_10_IRQn  };  
+ 
+        
+    constexpr BSP thebsp {        
+        // maskofsupported
+        embot::core::binary::mask::pos2mask<uint32_t>(BTN::one),        
+        // properties
+        {{
+            &btn1p, nullptr, nullptr            
+        }}        
+    };
+    
+    
+    void BSP::init(embot::hw::BTN h) const {}
+    
+    void BSP::onEXTI(const embot::hw::gpio::PROP &p) const
+    {
+        return;      
+    }
+    
+    const BSP& getBSP() 
+    {
+        return thebsp;
+    }
+    
+} // namespace embot::hw::button {
+
+#endif // button
+
+// - support map: end of embot::hw::button
+

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_adc_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_adc_bsp_amcmj1.cpp
@@ -215,9 +215,7 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
         GPIO_InitTypeDef GPIO_InitStruct = {0};
         if(adcHandle->Instance==ADC1)
         {
-        /* USER CODE BEGIN ADC1_MspInit 0 */
-
-        /* USER CODE END ADC1_MspInit 0 */
+            
         /* ADC1 clock enable */
         HAL_RCC_ADC12_CLK_ENABLED++;
         if(HAL_RCC_ADC12_CLK_ENABLED==1){
@@ -263,15 +261,11 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
         /* ADC1 interrupt Init */
         HAL_NVIC_SetPriority(ADC_IRQn, 5, 0);
         HAL_NVIC_EnableIRQ(ADC_IRQn);
-        /* USER CODE BEGIN ADC1_MspInit 1 */
 
-        /* USER CODE END ADC1_MspInit 1 */
         }
         else if(adcHandle->Instance==ADC2)
         {
-        /* USER CODE BEGIN ADC2_MspInit 0 */
 
-        /* USER CODE END ADC2_MspInit 0 */
         /* ADC2 clock enable */
         HAL_RCC_ADC12_CLK_ENABLED++;
         if(HAL_RCC_ADC12_CLK_ENABLED==1){
@@ -321,56 +315,7 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
 
         /* USER CODE END ADC2_MspInit 1 */
         }
-//        else if(adcHandle->Instance==ADC3)
-//        {
-//            /* USER CODE BEGIN ADC3_MspInit 0 */
 
-//            /* USER CODE END ADC3_MspInit 0 */
-//            /* ADC3 clock enable */
-//            __HAL_RCC_ADC3_CLK_ENABLE();
-
-//            __HAL_RCC_GPIOF_CLK_ENABLE();
-//            /**ADC3 GPIO Configuration
-//            PF3     ------> ADC3_INP5
-//            PF5     ------> ADC3_INP4
-//            PF6     ------> ADC3_INP8
-//            PF7     ------> ADC3_INP3
-//            PF8     ------> ADC3_INP7
-//            PF9     ------> ADC3_INP2
-//            PF10     ------> ADC3_INP6
-//            */
-//            GPIO_InitStruct.Pin = PWR_VCC_Pin|PWR_VAUX_Pin|PWR_TEMP_DRV_Pin|PWR_VIN_Pin
-//                                  |PWR_TEMP_MOT_Pin|PWR_CIN_Pin|PWR_VCORE_Pin;
-//            GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
-//            GPIO_InitStruct.Pull = GPIO_NOPULL;
-//            HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
-//            /* ADC3 DMA Init */
-//            /* ADC3 Init */
-//            hdma_adc3.Instance = DMA2_Stream2;
-//            hdma_adc3.Init.Request = DMA_REQUEST_ADC3;
-//            hdma_adc3.Init.Direction = DMA_PERIPH_TO_MEMORY;
-//            hdma_adc3.Init.PeriphInc = DMA_PINC_DISABLE;
-//            hdma_adc3.Init.MemInc = DMA_MINC_ENABLE;
-//            hdma_adc3.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
-//            hdma_adc3.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
-//            hdma_adc3.Init.Mode = DMA_CIRCULAR;
-//            hdma_adc3.Init.Priority = DMA_PRIORITY_HIGH;
-//            hdma_adc3.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-//            if (HAL_DMA_Init(&hdma_adc3) != HAL_OK)
-//            {
-//              Error_Handler();
-//            }
-
-//            __HAL_LINKDMA(adcHandle,DMA_Handle,hdma_adc3);
-
-//            /* ADC3 interrupt Init */
-//            HAL_NVIC_SetPriority(ADC3_IRQn, 5, 0);
-//            HAL_NVIC_EnableIRQ(ADC3_IRQn);
-//            /* USER CODE BEGIN ADC3_MspInit 1 */
-
-//            /* USER CODE END ADC3_MspInit 1 */
-//        }
     }
 
     void HAL_ADC_MspDeInit(void* p)
@@ -379,9 +324,7 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
 
         if(adcHandle->Instance==ADC1)
         {
-        /* USER CODE BEGIN ADC1_MspDeInit 0 */
 
-        /* USER CODE END ADC1_MspDeInit 0 */
         /* Peripheral clock disable */
         HAL_RCC_ADC12_CLK_ENABLED--;
         if(HAL_RCC_ADC12_CLK_ENABLED==0){
@@ -409,15 +352,10 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
         /* HAL_NVIC_DisableIRQ(ADC_IRQn); */
         /* USER CODE END ADC1:ADC_IRQn disable */
 
-        /* USER CODE BEGIN ADC1_MspDeInit 1 */
-
-        /* USER CODE END ADC1_MspDeInit 1 */
         }
         else if(adcHandle->Instance==ADC2)
         {
-        /* USER CODE BEGIN ADC2_MspDeInit 0 */
 
-        /* USER CODE END ADC2_MspDeInit 0 */
         /* Peripheral clock disable */
         HAL_RCC_ADC12_CLK_ENABLED--;
         if(HAL_RCC_ADC12_CLK_ENABLED==0){
@@ -445,40 +383,8 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
         /* HAL_NVIC_DisableIRQ(ADC_IRQn); */
         /* USER CODE END ADC2:ADC_IRQn disable */
 
-        /* USER CODE BEGIN ADC2_MspDeInit 1 */
-
-        /* USER CODE END ADC2_MspDeInit 1 */
         }
-//        else if(adcHandle->Instance==ADC3)
-//        if(ADC3 == adcHandle->Instance)
-//        {
-//            /* USER CODE BEGIN ADC3_MspDeInit 0 */
 
-//            /* USER CODE END ADC3_MspDeInit 0 */
-//            /* Peripheral clock disable */
-//            __HAL_RCC_ADC3_CLK_DISABLE();
-
-//            /**ADC3 GPIO Configuration
-//            PF3     ------> ADC3_INP5
-//            PF5     ------> ADC3_INP4
-//            PF6     ------> ADC3_INP8
-//            PF7     ------> ADC3_INP3
-//            PF8     ------> ADC3_INP7
-//            PF9     ------> ADC3_INP2
-//            PF10     ------> ADC3_INP6
-//            */
-//            HAL_GPIO_DeInit(GPIOF, PWR_VCC_Pin|PWR_VAUX_Pin|PWR_TEMP_DRV_Pin|PWR_VIN_Pin
-//                                  |PWR_TEMP_MOT_Pin|PWR_CIN_Pin|PWR_VCORE_Pin);
-
-//            /* ADC3 DMA DeInit */
-//            HAL_DMA_DeInit(adcHandle->DMA_Handle);
-
-//            /* ADC3 interrupt Deinit */
-//            HAL_NVIC_DisableIRQ(ADC3_IRQn);
-//            /* USER CODE BEGIN ADC3_MspDeInit 1 */
-
-//            /* USER CODE END ADC3_MspDeInit 1 */
-//        }
     }         
         
 } // namespace embot::hw::motor::bldc::adc::bsp::impl {
@@ -527,15 +433,7 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
     void MX_ADC2_Init(void)
     {
 
-      /* USER CODE BEGIN ADC2_Init 0 */
-
-      /* USER CODE END ADC2_Init 0 */
-
       ADC_ChannelConfTypeDef sConfig = {0};
-
-      /* USER CODE BEGIN ADC2_Init 1 */
-
-      /* USER CODE END ADC2_Init 1 */
 
       /** Common config
       */
@@ -619,9 +517,6 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
       {
         Error_Handler();
       }
-      /* USER CODE BEGIN ADC2_Init 2 */
-
-      /* USER CODE END ADC2_Init 2 */
 
     }
     
@@ -768,21 +663,16 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
             {
                 /* Stop all ADCs */
                 HAL_ADC_Stop_DMA(&hadc2);
-    //            HAL_ADC_Stop_DMA(&hadc3);
         
                 /* Calibrate all ADCs. Caution: blocking functions! */
                 HAL_ADCEx_Calibration_Start(&hadc2, ADC_CALIB_OFFSET_LINEARITY, ADC_SINGLE_ENDED);
-    //            HAL_ADCEx_Calibration_Start(&hadc3, ADC_CALIB_OFFSET_LINEARITY, ADC_SINGLE_ENDED);
 
                 /* Register all the callback functions */
                 HAL_ADC_RegisterCallback(&hadc2, HAL_ADC_CONVERSION_COMPLETE_CB_ID, AinAdc2HT_cb);
                 HAL_ADC_RegisterCallback(&hadc2, HAL_ADC_CONVERSION_HALF_CB_ID,     AinAdc2TC_cb);
-    //            HAL_ADC_RegisterCallback(&hadc3, HAL_ADC_CONVERSION_COMPLETE_CB_ID, AinAdc3HT_cb);
-    //            HAL_ADC_RegisterCallback(&hadc3, HAL_ADC_CONVERSION_HALF_CB_ID,     AinAdc3TC_cb);
 
                 /* Start conversions */
                 HAL_ADC_Start_DMA(&hadc2, (uint32_t *)AinDma2Buffer, lengthof(AinDma2Buffer));
-    //            HAL_ADC_Start_DMA(&hadc3, (uint32_t *)AinDma3Buffer, lengthof(AinDma3Buffer));
                 
                 /* All done */
                 return HAL_OK;
@@ -801,14 +691,11 @@ namespace embot::hw::motor::bldc::adc::bsp::impl {
 
         /* Stop all ADCs */
         HAL_ADC_Stop_DMA(&hadc2);
-    //    HAL_ADC_Stop_DMA(&hadc3);
         
         /* Remove all callback functions */
         HAL_ADC_UnRegisterCallback(&hadc2, HAL_ADC_CONVERSION_COMPLETE_CB_ID);
         HAL_ADC_UnRegisterCallback(&hadc2, HAL_ADC_CONVERSION_HALF_CB_ID);
 
-    //    HAL_ADC_UnRegisterCallback(&hadc3, HAL_ADC_CONVERSION_COMPLETE_CB_ID);
-    //    HAL_ADC_UnRegisterCallback(&hadc3, HAL_ADC_CONVERSION_HALF_CB_ID);
     }    
 
 } // namespace embot::hw::motor::bldc::adc::bsp::impl {

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp
@@ -125,7 +125,7 @@ namespace embot::hw::motor::bldc::extfault::bsp {
 
 
 
-#endif // #if defined(EMBOT_ENABLE_hw_analog)
+#endif // #if defined(EMBOT_ENABLE_hw_motor_bldc_extfault)
 
 
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp
@@ -38,20 +38,11 @@ namespace embot::hw::motor::bldc::extfault::bsp {
     
     constexpr BSP thebsp { };   
     
-    bool BSP::init() const 
-    {
-        return false;       
-    } 
+    bool BSP::init()    const { return false; } 
 
-    bool BSP::deinit() const 
-    {
-        return false;       
-    } 
+    bool BSP::deinit()  const { return false; } 
     
-    bool BSP::pressed() const
-    {     
-        return false;
-    }     
+    bool BSP::pressed() const { return false; } 
 
     embot::hw::BTN BSP::btn() const
     {     
@@ -79,7 +70,7 @@ namespace embot::hw::motor::bldc::extfault::bsp {
         
     constexpr uint32_t supportedmask = 1;
     
-    constexpr PROP p { embot::hw::BTN::one, embot::hw::LED::one };
+    constexpr PROP p { embot::hw::BTN::one, embot::hw::LED::two };
     
     constexpr BSP thebsp { supportedmask, &p };   
 
@@ -126,7 +117,6 @@ namespace embot::hw::motor::bldc::extfault::bsp {
 
 
 #endif // #if defined(EMBOT_ENABLE_hw_motor_bldc_extfault)
-
 
 
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_pwm_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_pwm_bsp_amcmj1.cpp
@@ -253,9 +253,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
       GPIO_InitTypeDef GPIO_InitStruct = {0};
       if(tim_baseHandle->Instance==TIM8)
       {
-      /* USER CODE BEGIN TIM8_MspInit 0 */
 
-      /* USER CODE END TIM8_MspInit 0 */
         /* TIM8 clock enable */
         __HAL_RCC_TIM8_CLK_ENABLE();
 
@@ -278,9 +276,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         HAL_NVIC_EnableIRQ(TIM8_UP_TIM13_IRQn);
 //        HAL_NVIC_SetPriority(TIM8_CC_IRQn, 5, 0);
 //        HAL_NVIC_EnableIRQ(TIM8_CC_IRQn);
-      /* USER CODE BEGIN TIM8_MspInit 1 */
 
-      /* USER CODE END TIM8_MspInit 1 */
       }
     }
     
@@ -291,9 +287,6 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
       GPIO_InitTypeDef GPIO_InitStruct = {0};
       if(timHandle->Instance==TIM8)
       {
-      /* USER CODE BEGIN TIM8_MspPostInit 0 */
-
-      /* USER CODE END TIM8_MspPostInit 0 */
 
         __HAL_RCC_GPIOC_CLK_ENABLE();
         __HAL_RCC_GPIOA_CLK_ENABLE();
@@ -328,9 +321,6 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         GPIO_InitStruct.Alternate = GPIO_AF3_TIM8;
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-      /* USER CODE BEGIN TIM8_MspPostInit 1 */
-
-      /* USER CODE END TIM8_MspPostInit 1 */
       }
 
     }
@@ -341,9 +331,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
 
       if(tim_baseHandle->Instance==TIM8)
       {
-      /* USER CODE BEGIN TIM8_MspDeInit 0 */
 
-      /* USER CODE END TIM8_MspDeInit 0 */
         /* Peripheral clock disable */
         __HAL_RCC_TIM8_CLK_DISABLE();
 
@@ -370,9 +358,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         HAL_NVIC_DisableIRQ(TIM8_BRK_TIM12_IRQn);
         HAL_NVIC_DisableIRQ(TIM8_UP_TIM13_IRQn);
         HAL_NVIC_DisableIRQ(TIM8_CC_IRQn);
-      /* USER CODE BEGIN TIM8_MspDeInit 1 */
 
-      /* USER CODE END TIM8_MspDeInit 1 */
       }
     }    
     
@@ -385,19 +371,13 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
     void MX_TIM8_Init(void)
     {
 
-      /* USER CODE BEGIN TIM8_Init 0 */
-
-      /* USER CODE END TIM8_Init 0 */
-
       TIM_ClockConfigTypeDef sClockSourceConfig = {0};
       TIM_MasterConfigTypeDef sMasterConfig = {0};
       TIMEx_BreakInputConfigTypeDef sBreakInputConfig = {0};
       TIM_OC_InitTypeDef sConfigOC = {0};
       TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
 
-      /* USER CODE BEGIN TIM8_Init 1 */
 
-      /* USER CODE END TIM8_Init 1 */
       htim8.Instance = TIM8;
       htim8.Init.Prescaler = 0;
       htim8.Init.CounterMode = TIM_COUNTERMODE_CENTERALIGNED1;
@@ -491,9 +471,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
       {
         Error_Handler();
       }
-      /* USER CODE BEGIN TIM8_Init 2 */
 
-      /* USER CODE END TIM8_Init 2 */
       HAL_TIM_MspPostInit(&htim8);
 
     }

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_pwm_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_pwm_bsp_amcmj1.cpp
@@ -226,8 +226,8 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
     
     TIM_HandleTypeDef htim8 {};
     
-    #define EXT_FAULT_Pin GPIO_PIN_3
-    #define EXT_FAULT_GPIO_Port GPIOG
+//    #define EXT_FAULT_Pin GPIO_PIN_3
+//    #define EXT_FAULT_GPIO_Port GPIOG
     #define MOT_BREAK_Pin GPIO_PIN_2
     #define MOT_BREAK_GPIO_Port GPIOG
         
@@ -262,12 +262,13 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         PG3     ------> TIM8_BKIN2
         PG2     ------> TIM8_BKIN
         */
-        GPIO_InitStruct.Pin = EXT_FAULT_Pin|MOT_BREAK_Pin;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF3_TIM8;
-        HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
+          
+        // GPIO_InitStruct.Pin = EXT_FAULT_Pin;
+        // GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        // GPIO_InitStruct.Pull = GPIO_NOPULL;
+        // GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        // GPIO_InitStruct.Alternate = GPIO_AF3_TIM8;
+        // HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
           
 #if defined (MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
 #else
@@ -361,7 +362,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         */
         HAL_GPIO_DeInit(GPIOC, MOT_PWM2H_Pin|MOT_PWM4_Pin|MOT_PWM3H_Pin|MOT_PWM1H_Pin);
 
-        HAL_GPIO_DeInit(GPIOG, EXT_FAULT_Pin);
+        // HAL_GPIO_DeInit(GPIOG, EXT_FAULT_Pin);
 
 #if defined (MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
 #else
@@ -506,9 +507,9 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
 #define hMot1 (htim8)    
     
     /* Motor numbers */
-    #define PWM_MOTOR_NONE              (0x00000000UL)
+//    #define PWM_MOTOR_NONE              (0x00000000UL)
     #define PWM_MOTOR_1                 (0x00000001UL)
-    #define PWM_MOTOR_ALL               (0x00000003UL)    
+//    #define PWM_MOTOR_ALL               (0x00000003UL)    
         
     /* PWM phase mask */
     #define PWM_PHASE1                  (0x00000001U)
@@ -609,7 +610,7 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         // HAL_TIM_PWM_PULSE_FINISHED_CB_ID
         //HAL_TIM_RegisterCallback(&hMot1, HAL_TIM_PWM_PULSE_FINISHED_CB_ID,  Pwm1_pulse_finished_cb);
         
-        /* Start Motor 1 (TIM8 slave timer) */
+        /* Start Motor 1 (TIM8 timer) */
         HAL_TIMEx_PWMN_Start_IT(&hMot1, TIM_CHANNEL_1);
         HAL_TIMEx_PWMN_Start_IT(&hMot1, TIM_CHANNEL_2);
         HAL_TIMEx_PWMN_Start_IT(&hMot1, TIM_CHANNEL_3);

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_pwm_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/portable/motor/embot_hw_motor_bldc_pwm_bsp_amcmj1.cpp
@@ -268,10 +268,23 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF3_TIM8;
         HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
-
+          
+#if defined (MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else
+        GPIO_InitStruct.Pin = MOT_BREAK_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF3_TIM8;
+        HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
+#endif  
+          
         /* TIM8 interrupt Init */
+#if defined (MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else
         HAL_NVIC_SetPriority(TIM8_BRK_TIM12_IRQn, 5, 0);
         HAL_NVIC_EnableIRQ(TIM8_BRK_TIM12_IRQn);
+#endif  
         HAL_NVIC_SetPriority(TIM8_UP_TIM13_IRQn, 5, 0);
         HAL_NVIC_EnableIRQ(TIM8_UP_TIM13_IRQn);
 //        HAL_NVIC_SetPriority(TIM8_CC_IRQn, 5, 0);
@@ -348,14 +361,22 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         */
         HAL_GPIO_DeInit(GPIOC, MOT_PWM2H_Pin|MOT_PWM4_Pin|MOT_PWM3H_Pin|MOT_PWM1H_Pin);
 
-        HAL_GPIO_DeInit(GPIOG, EXT_FAULT_Pin|MOT_BREAK_Pin);
+        HAL_GPIO_DeInit(GPIOG, EXT_FAULT_Pin);
 
+#if defined (MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else
+        HAL_GPIO_DeInit(GPIOG, MOT_BREAK_Pin);
+#endif
+          
         HAL_GPIO_DeInit(MOT_PWM1L_GPIO_Port, MOT_PWM1L_Pin);
 
         HAL_GPIO_DeInit(GPIOB, MOT_PWM3L_Pin|MOT_PWM2L_Pin);
 
         /* TIM8 interrupt Deinit */
+#if defined (MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else
         HAL_NVIC_DisableIRQ(TIM8_BRK_TIM12_IRQn);
+#endif
         HAL_NVIC_DisableIRQ(TIM8_UP_TIM13_IRQn);
         HAL_NVIC_DisableIRQ(TIM8_CC_IRQn);
 
@@ -507,6 +528,9 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
     uint32_t PwmSetWidth(uint32_t mot, int32_t ph1, int32_t ph2, int32_t ph3, Saturation sat);
     
     
+    
+#if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else  
     /*******************************************************************************************************************//**
      * @brief Call back function. Called by the TIM interrupt manager following the BRAEAK input activation
      * @param   *htim   pointer to the TIM peripheral handler
@@ -527,6 +551,8 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
     {
         if (0 != __HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK2)) Pwm1Status |= PWM_FAULT_EMERGENCY_BUTTON; 
     }    
+
+#endif
 
     /*******************************************************************************************************************//**
      * @brief Register TIM8 call-back functions and start TIM8 
@@ -573,9 +599,12 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         /* Clear the status registers */
         Pwm1Status = 0;
         
+#if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else  
         /* Register the callback functions */
         HAL_TIM_RegisterCallback(&hMot1, HAL_TIM_BREAK_CB_ID,  Pwm1_break_cb);
         HAL_TIM_RegisterCallback(&hMot1, HAL_TIM_BREAK2_CB_ID, Pwm1_break2_cb);
+#endif  
         
         // HAL_TIM_PWM_PULSE_FINISHED_CB_ID
         //HAL_TIM_RegisterCallback(&hMot1, HAL_TIM_PWM_PULSE_FINISHED_CB_ID,  Pwm1_pulse_finished_cb);
@@ -633,10 +662,12 @@ namespace embot::hw::motor::bldc::pwm::bsp::impl {
         HAL_TIM_PWM_Stop_IT(&hMot1, TIM_CHANNEL_3);
         HAL_TIM_PWM_Stop_IT(&hMot1, TIM_CHANNEL_4);
 
-        
+#if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove)
+#else  
         /* Remove the registered functions */
         HAL_TIM_UnRegisterCallback(&hMot1, HAL_TIM_BREAK_CB_ID);
         HAL_TIM_UnRegisterCallback(&hMot1, HAL_TIM_BREAK2_CB_ID);
+#endif
 
     }    
     
@@ -733,7 +764,12 @@ extern "C"
 {
     void TIM8_BRK_TIM12_IRQHandler(void)
     {
+#if defined(MOTORHALCONFIG_MOT_BREAK_IRQ_remove) 
+        // this mode is not enabled and we get the external fault w/ polling
+        for(;;);
+#else        
         HAL_TIM_IRQHandler(&embot::hw::motor::bldc::pwm::bsp::impl::htim8);
+#endif
     }
 
     void TIM8_UP_TIM13_IRQHandler(void)

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_app_mot_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_app_mot_config.h
@@ -73,12 +73,16 @@ the appl.yri must:
         #define EMBOT_ENABLE_hw_motor_bldc_qenc
         #define EMBOT_ENABLE_hw_analog
         #define EMBOT_ENABLE_hw_motor_bldc_extfault
+        #define EMBOT_ENABLE_hw_button
+        #define MOTORHALCONFIG_MOT_BREAK_IRQ_remove
+
         // on cm7 the adc factory calibration needed by hw_analog is read from rom, on cm4 from eeprom 
         #if defined(STM32HAL_CORE_CM7) 
             #define EMBOT_CONFIG_hw_adc_bsp_getfactorycalibration_useROM
         #else    
             #define EMBOT_CONFIG_hw_adc_bsp_getfactorycalibration_useICC
         #endif        
+
     #endif
   
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
@@ -71,7 +71,6 @@ we may need CAN even if we prefer give the only CAN (for now) to appl.mot becaus
         #undef EMBOT_ENABLE_hw_can
     #endif
     
-#endif // EMBOT_CORE_master
 
     #define EMBOT_ENABLE_hw_can
     #define EMBOT_ENABLE_hw_can_one

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_bsp_amcmj1_updater_maintainer_config.h
@@ -61,6 +61,17 @@ we may need CAN even if we prefer give the only CAN (for now) to appl.mot becaus
     #endif // STM32HAL_CORE_CM4
     
     #define EMBOT_ENABLE_hw_eth
+    
+    #undef EMBOT_ENABLE_hw_can
+    #if defined(EMBOT_ENABLE_hw_can)
+        #define EMBOT_ENABLE_hw_can_5V
+    #endif
+    
+    #if defined(_MAINTAINER_APPL_)
+        #undef EMBOT_ENABLE_hw_can
+    #endif
+    
+#endif // EMBOT_CORE_master
 
     #define EMBOT_ENABLE_hw_can
     #define EMBOT_ENABLE_hw_can_one

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_led_bsp_amcmj1.cpp
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_led_bsp_amcmj1.cpp
@@ -67,28 +67,32 @@ namespace embot::hw::led {
 
 namespace embot::hw::led {         
     
-#if defined(STM32HAL_BOARD_AMCMJ1_1CM7)    
+#if defined( EMBOT_HW_BSP__appl_MOT ) 
+    
+constexpr BSP thebsp {        
+    // maskofsupported
+    mask::pos2mask<uint32_t>(LED::one) | mask::pos2mask<uint32_t>(LED::two) 
+    ,        
+    // properties
+    {{
+        &pled1, &pled2, 
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr         
+    }}        
+};
+    
+#else     
+
     constexpr BSP thebsp {        
         // maskofsupported
         mask::pos2mask<uint32_t>(LED::one) | mask::pos2mask<uint32_t>(LED::two) | mask::pos2mask<uint32_t>(LED::three) 
         ,        
         // properties
         {{
-            &pled3red, &pled4green, &pled5blue,
+            &pled4green, &pled3red, &pled5blue,
             nullptr, nullptr, nullptr, nullptr, nullptr         
         }}        
     };
-#elif defined(STM32HAL_BOARD_AMCMJ1_2CM4)
-    constexpr BSP thebsp {        
-        // maskofsupported
-        mask::pos2mask<uint32_t>(LED::one) | mask::pos2mask<uint32_t>(LED::two) 
-        ,        
-        // properties
-        {{
-            &pled1, &pled2, 
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr         
-        }}        
-    };
+
 #endif
     
     void BSP::init(embot::hw::LED h) const 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_led_bsp_pinout_amcmj1.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_led_bsp_pinout_amcmj1.h
@@ -25,11 +25,11 @@ namespace embot::hw::led { }
 
 namespace embot::hw::led {         
     
-    constexpr PROP pled1        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::four}  };  
-    constexpr PROP pled2        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::five}  };  
-    constexpr PROP pled3red     = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::eight}  }; 
-    constexpr PROP pled4green   = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::nine}  };     
-    constexpr PROP pled5blue    = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::ten}  }; 
+    constexpr PROP pled1        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::four}  };  //red led
+    constexpr PROP pled2        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::five}  };  //green led
+    constexpr PROP pled3red     = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::eight}  }; //led RGB
+    constexpr PROP pled4green   = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::nine}  };  //led RGB
+    constexpr PROP pled5blue    = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::ten}  };   //led RGB
         
 } // namespace embot::hw::led { 
 

--- a/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_led_bsp_pinout_amcmj1.h
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/bsp/shared/embot_hw_led_bsp_pinout_amcmj1.h
@@ -25,8 +25,8 @@ namespace embot::hw::led { }
 
 namespace embot::hw::led {         
     
-    constexpr PROP pled1        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::four}  };  //red led
-    constexpr PROP pled2        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::five}  };  //green led
+    constexpr PROP pled1        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::five}  };  //green led
+    constexpr PROP pled2        = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::four}  };  //red led
     constexpr PROP pled3red     = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::eight}  }; //led RGB
     constexpr PROP pled4green   = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::nine}  };  //led RGB
     constexpr PROP pled5blue    = { .on = embot::hw::gpio::State::RESET, .off = embot::hw::gpio::State::SET, .gpio = {embot::hw::GPIO::PORT::D, embot::hw::GPIO::PIN::ten}  };   //led RGB

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvoptx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvoptx
@@ -1669,6 +1669,18 @@
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>
+    <File>
+      <GroupNumber>21</GroupNumber>
+      <FileNumber>87</FileNumber>
+      <FileType>8</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>..\..\..\bsp\portable\motor\embot_hw_button_bsp_amcmj1.cpp</PathWithFileName>
+      <FilenameWithoutPath>embot_hw_button_bsp_amcmj1.cpp</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
   </Group>
 
   <Group>

--- a/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvprojx
+++ b/emBODY/eBcode/arch-arm/board/amcmj1/procs/appl.mot/proj/amcmj1.appl.mot.uvprojx
@@ -1167,6 +1167,11 @@
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\portable\motor\embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp</FilePath>
             </File>
+            <File>
+              <FileName>embot_hw_button_bsp_amcmj1.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\portable\motor\embot_hw_button_bsp_amcmj1.cpp</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>
@@ -2481,6 +2486,11 @@
               <FileName>embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>..\..\..\bsp\portable\motor\embot_hw_motor_bldc_extfault_bsp_amcmj1.cpp</FilePath>
+            </File>
+            <File>
+              <FileName>embot_hw_button_bsp_amcmj1.cpp</FileName>
+              <FileType>8</FileType>
+              <FilePath>..\..\..\bsp\portable\motor\embot_hw_button_bsp_amcmj1.cpp</FilePath>
             </File>
           </Files>
         </Group>

--- a/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc_hall.cpp
+++ b/emBODY/eBcode/arch-arm/embot/hw/embot_hw_motor_bldc_hall.cpp
@@ -37,7 +37,7 @@ namespace embot::hw::motor::bldc::hall {
     
     bool init(embot::hw::MOTOR m, const Configuration &config) { return false; }
     bool deinit(embot::hw::MOTOR m) { return false; }
-    bool initialized(embot::hw::MOTOR m) { return false; }
+    bool initialised(embot::hw::MOTOR m) { return false; }
     bool start(embot::hw::MOTOR m, const Mode &mode) { return false; }
     bool isstarted(embot::hw::MOTOR m) { return false; };
     uint8_t getstatus(embot::hw::MOTOR m) { return 0; }    


### PR DESCRIPTION
Starting from amc.app.mot I took the logic for the fault button and the handling of the IRQ linked to the fault.

Tested by: seeing the led associated to the fault becoming red without fault inserted and with fault pressed, led is off otherwise. 
Also using the debugger i could see this behaviour. I haven't noticed strange behaviour, but i ask @marcoaccame to also test this before merging.