### PR TITLE
Add AutoFirmwareCompilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ JLinkSettings.ini
 *.iex
 .vscode
 
+# AutoFirmwareCompilation
+AutoFirmwareCompilation/*.log
+AutoFirmwareCompilation/python/
+
 # To explicitly override the above, define any exceptions here; e.g.:
 # !my_customized_scatter_file.sct
 !mtb_battery/AD7147_Serial2.map

--- a/AutoFirmwareCompilation/README.md
+++ b/AutoFirmwareCompilation/README.md
@@ -1,0 +1,162 @@
+# AutoFirmwareCompilation
+
+`AutoFirmwareCompilation` is a small set of tools intended to simplify and speed up the firmware development workflow in `icub-firmware`.
+
+The tool is a **first step toward a more automated firmware build process**, with the long-term goal of moving part of this workflow to CI and automatically generating firmware executables.
+
+## Motivation
+
+A typical firmware development workflow often starts with a change for a single board. However, since several boards share a significant amount of code, a change may require rebuilding multiple firmware targets even when only one board was directly modified.
+
+In addition, every firmware release requires updating the corresponding version number and build date. Doing this manually means opening several project and source files, changing the metadata, compiling each firmware separately, and finally collecting the generated binaries.
+
+These scripts reduce this manual work by allowing developers to:
+
+- update firmware versions and build dates from a single interface;
+- update multiple boards in the same session;
+- build several firmware targets in sequence;
+- collect the generated `.hex` files;
+- inspect the compilation logs before publishing the generated binaries.
+
+This is intentionally an initial implementation. Contributions, fixes, improvements, and ideas are very welcome.
+
+## Location
+
+The `AutoFirmwareCompilation` folder is expected to live inside the `icub-firmware` repository:
+
+```text
+icub-firmware/
+├── AutoFirmwareCompilation/
+│   ├── buildAllBoards.bat
+│   ├── firmware_versions.yaml
+│   └── update_versions.py
+├── emBODY/
+└── ...
+```
+
+The scripts also support the previous layout where `AutoFirmwareCompilation` and `icub-firmware` were sibling directories, but the layout above is the recommended one.
+
+## Requirements
+
+### Python
+
+The version update script requires Python 3 and PyYAML:
+
+```bash
+pip install pyyaml
+```
+
+### Keil
+
+The firmware build script uses Keil µVision (`UV4.exe`).
+
+The script automatically checks the following common installation locations:
+
+```text
+C:\Keil_v5\UV4\UV4.exe
+%LOCALAPPDATA%\Keil_v5\UV4\UV4.exe
+```
+
+## Updating firmware versions and build dates
+
+Run:
+
+```bash
+python update_versions.py
+```
+
+The script reads the firmware definitions from `firmware_versions.yaml`, displays the current versions found in the source files, and lets you interactively select one or more boards to update.
+
+For each selected board you can update:
+
+- major version;
+- minor version;
+- build date;
+- build time.
+
+The source files are patched automatically and the corresponding values in `firmware_versions.yaml` are kept in sync.
+
+To update the versions and immediately start the firmware build, use:
+
+```bash
+python update_versions.py --build
+```
+
+You can also specify a different YAML registry:
+
+```bash
+python update_versions.py --yaml path/to/firmware_versions.yaml
+```
+
+## Building all supported firmware
+
+Run:
+
+```bat
+buildAllBoards.bat
+```
+
+The script builds the supported firmware targets sequentially using Keil µVision.
+
+At the moment this includes firmware and required libraries for boards such as:
+
+- EMS;
+- MC2PLUS;
+- MC4PLUS;
+- AMC;
+- AMC2C.
+
+Some AMC targets depend on additional libraries such as HAL and IPAL, therefore those libraries are built as part of the process as well.
+
+Compilation output is stored in log files. Please inspect the logs before publishing or distributing the generated firmware binaries.
+
+The generated `.hex` files are copied to the corresponding folders under `icub-firmware-build`.
+
+## Typical workflow
+
+A typical workflow is:
+
+```text
+1. Modify the firmware code.
+2. Run update_versions.py.
+3. Select the firmware targets that need a new version/build date.
+4. Update the versions and dates interactively.
+5. Launch buildAllBoards.bat, or use update_versions.py --build.
+6. Check the compilation logs.
+7. Test and publish the generated firmware binaries.
+```
+
+This avoids manually opening all the affected source/project files just to update version metadata and rebuild related boards.
+
+## Build errors
+
+If a project path is incorrect or Keil cannot open a project, you may see an error such as:
+
+```text
+ERROR: EMS compilation failed with error code 15
+```
+
+In this case, check:
+
+- that `icub-firmware` is in the expected location;
+- that Keil µVision is installed;
+- that the project files referenced by `buildAllBoards.bat` exist;
+- the corresponding compilation log for additional details.
+
+## Future work
+
+This tool should be considered a first step toward a more automated firmware generation workflow.
+
+A possible future direction is to move the firmware compilation and artifact generation into CI, reducing the amount of manual work required during firmware development and release preparation.
+
+The current scripts are meant to make the existing workflow faster and less error-prone while providing a practical starting point for that automation.
+
+Contributions, bug fixes, additional board support, and workflow improvements are very welcome.
+
+## Previous version
+
+This tool is an evolution of the original standalone repository:
+
+https://github.com/valegagge/AutoFirmwareCompilation
+
+That repository is expected to be archived/closed and should be considered obsolete once this version is integrated into `icub-firmware`.

--- a/AutoFirmwareCompilation/buildAllBoards.bat
+++ b/AutoFirmwareCompilation/buildAllBoards.bat
@@ -1,0 +1,232 @@
+
+@echo off
+setlocal
+
+:: Determine the workspace root automatically.
+::
+:: Supported layouts:
+::
+::   WORKSPACE\
+::     AutoFirmwareCompilation\
+::     icub-firmware\
+::
+:: and:
+::
+::   WORKSPACE\
+::     icub-firmware\
+::       AutoFirmwareCompilation\
+::
+:: The project paths below already contain the "icub-firmware" component,
+:: therefore default_path must always point to WORKSPACE.
+for %%a in ("%~dp0..") do set "script_parent=%%~fa"
+for %%a in ("%script_parent%") do set "script_parent_name=%%~nxa"
+
+if /I "%script_parent_name%"=="icub-firmware" (
+    for %%a in ("%script_parent%\..") do set "default_path=%%~fa"
+) else (
+    set "default_path=%script_parent%"
+)
+
+if "%~1"=="-p" (
+  set "user_path=%~2"
+  echo User path provided: %user_path%
+) else (
+  set "user_path=%default_path%"
+  echo No user path provided, using default path: %user_path%
+)
+
+:: Automatically detect the UV4.exe out of possible default installation paths
+
+echo User path used: %user_path%
+
+if exist "C:\Keil_v5\UV4\UV4.exe" (
+    set "UV4_PATH=C:\Keil_v5\UV4\UV4.exe"
+) else (
+    if exist "%LOCALAPPDATA%\Keil_v5\UV4\UV4.exe" (
+        set "UV4_PATH=%LOCALAPPDATA%\Keil_v5\UV4\UV4.exe"
+    ) else (
+        echo "UV4.exe not found."
+    )
+)
+
+echo "Detected Keil's UV4 at %UV4_PATH%"
+
+set "pjoj_EMS_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\ems004\appl\v2\proj\ems4rd.diagnostic2ready.uvprojx"
+set "pjoj_MC2PLUS_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\mc2plus\appl\v2\proj\mc2plus.diagnostic2ready.uvprojx"
+set "pjoj_MC4PLUS_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\mc4plus\appl\v2\proj\mc4plus.diagnostic2ready.uvprojx"
+set "pjoj_AMC_LIB_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\libs\lowlevel\stm32hal\proj\stm32hal.h7.uvprojx"
+set "pjoj_AMC2C_LIB_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\libs\lowlevel\stm32hal\proj\stm32hal.h7.dualcore.uvprojx"
+set "pjoj_AMC_LIB_IPAL_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\libs\highlevel\abslayer\ipal\ipal-lwip-h7.uvprojx"
+set "pjoj_AMC_YRI_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\amc\application\v2\proj\amc-icc.uvprojx"
+set "pjoj_AMC_MOT_path=%user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\amc2c\application\proj\amc2c-appl-dual-icc-can.uvprojx"
+
+
+
+set "out_path=%CD%"
+
+
+
+echo EMS compilation starts...
+"%UV4_PATH%" -o "%out_path%\ems.log" -j0 -b "%pjoj_EMS_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo EMS compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: EMS compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\ems.log"
+    ) else (
+        echo ERROR: EMS compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\ems.log"
+        exit /b %err%
+    )
+)
+
+
+echo MC2PLUS compilation starts...
+"%UV4_PATH%" -o "%out_path%\mc2plus.log" -j0 -b "%pjoj_MC2PLUS_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo MC2PLUS compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: MC2PLUS compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\mc2plus.log"
+    ) else (
+        echo ERROR: MC2PLUS compilation failed with error code %err%.
+        echo Displaying log file:
+        type "%out_path%\mc2plus.log"
+        exit /b %err%
+    )
+)
+
+echo MC4PLUS compilation starts...
+"%UV4_PATH%" -o "%out_path%\mc4plus.log" -j0 -b "%pjoj_MC4PLUS_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo MC4PLUS compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: MC4PLUS compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\mc4plus.log"
+    ) else (
+        echo ERROR: MC4PLUS compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\mc4plus.log"
+        exit /b %err%
+    )
+)
+
+echo AMC compilation starts...
+echo AMC_LIB compilation starts...
+"%UV4_PATH%" -o "%out_path%\amc_lib.log" -j0 -b "%pjoj_AMC_LIB_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC_LIB compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC_LIB compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc_lib.log"
+    ) else (
+        echo ERROR: AMC_LIB compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc_lib.log"
+        exit /b %err%
+    )
+)
+
+echo AMC_LIB_IPAL compilation starts...
+"%UV4_PATH%" -o "%out_path%\amc_lib_ipal.log" -j0 -b "%pjoj_AMC_LIB_IPAL_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC_LIB_IPAL compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC_LIB_IPAL compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc_lib_ipal.log"
+    ) else (
+        echo ERROR: AMC_LIB compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc_lib_ipal.log"
+        exit /b %err%
+    )
+)
+
+echo AMC_YRI compilation starts...
+"%UV4_PATH%" -o "%out_path%\amc_yri.log" -j0 -b "%pjoj_AMC_YRI_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC_YRI compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC_YRI compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc_yri.log"
+    ) else (
+        echo ERROR: AMC_YRI compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc_yri.log"
+        exit /b %err%
+    )
+)
+
+echo AMC2C_LIB compilation starts...
+"%UV4_PATH%" -o "%out_path%\amc2c_lib.log" -j0 -b "%pjoj_AMC2C_LIB_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC2C_LIB compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC2C_LIB compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc2c_lib.log"
+    ) else (
+        echo ERROR: AMC2C_LIB compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc2c_lib.log"
+        exit /b %err%
+    )
+)
+
+echo AMC_MOT compilation starts...
+"%UV4_PATH%" -o "%out_path%\amc_mot.log" -j0 -b "%pjoj_AMC_MOT_path%"
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC_MOT compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC_MOT compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc_mot.log"
+    ) else (
+        echo ERROR: AMC_MOT compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc_mot.log"
+        exit /b %err%
+    )
+)
+
+echo Compilations Done!!!
+
+
+COPY %user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\amc\application\v2\bin\*.hex %user_path%\icub-firmware-build\ETH\AMC
+COPY %user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\amc2c\application\bin\*.hex %user_path%\icub-firmware-build\ETH\AMC
+COPY %user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\ems004\appl\v2\bin\*.hex %user_path%\icub-firmware-build\ETH\EMS\bin\application
+COPY %user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\mc2plus\appl\v2\bin\*.hex %user_path%\icub-firmware-build\ETH\MC2PLUS\bin\application
+COPY %user_path%\icub-firmware\emBODY\eBcode\arch-arm\board\mc4plus\appl\v2\bin\*.hex %user_path%\icub-firmware-build\ETH\MC4PLUS\bin\application
+
+
+echo Copy Done!!!
+
+
+
+echo Press a key to continue...
+pause > nul
+
+endlocal

--- a/AutoFirmwareCompilation/firmware_versions.yaml
+++ b/AutoFirmwareCompilation/firmware_versions.yaml
@@ -1,0 +1,77 @@
+boards:
+- id: ems
+  name: EMS
+  description: EMS004 - Motion control board (Ethernet)
+  version_file: icub-firmware/emBODY/eBcode/arch-arm/board/ems004/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+  format: c_defines
+  define_prefix: EOMTHEEMSAPPLCFG
+  has_offset: true
+  version:
+    major: 9
+    minor: 236
+  build_date:
+    year: 2026
+    month: 8
+    day: 10
+    hour: 11
+    minute: 28
+- id: mc2plus
+  name: MC2PLUS
+  description: MC2PLUS - 2-axis motor control board
+  version_file: icub-firmware/emBODY/eBcode/arch-arm/board/mc2plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+  format: c_defines
+  define_prefix: EOMTHEEMSAPPLCFG
+  has_offset: false
+  version:
+    major: 4
+    minor: 91
+  build_date:
+    year: 2026
+    month: 8
+    day: 10
+    hour: 11
+    minute: 28
+- id: mc4plus
+  name: MC4PLUS
+  description: MC4PLUS - 4-axis motor control board
+  version_file: icub-firmware/emBODY/eBcode/arch-arm/board/mc4plus/appl/v2/cfg/eoemsappl/EOMtheEMSapplCfg_cfg.h
+  format: c_defines
+  define_prefix: EOMTHEEMSAPPLCFG
+  has_offset: true
+  version:
+    major: 4
+    minor: 114
+  build_date:
+    year: 2026
+    month: 8
+    day: 10
+    hour: 11
+    minute: 28
+- id: amc
+  name: AMC
+  description: AMC - Advanced Motor Controller (Ethernet, dual-core STM32H7)
+  version_file: icub-firmware/emBODY/eBcode/arch-arm/board/amc/application/v2/cfg/theApplication_config.h
+  format: cpp_theapplication
+  version:
+    major: 4
+    minor: 33
+  build_date:
+    year: 2026
+    month: 8
+    day: 10
+    hour: 11
+    minute: 28
+- id: amc2c
+  name: AMC2C
+  description: AMC2C - Advanced Motor Controller CAN/ICC slave
+  version_file: icub-firmware/emBODY/eBcode/arch-arm/board/amc2c/application/src/app-board-amc2c/embot_app_board_amc2c_info.cpp
+  format: cpp_amc2c_sig
+  version:
+    major: 4
+    minor: 12
+  build_date:
+    year: 2026
+    month: 8
+    day: 10
+    hour: 11
+    minute: 28

--- a/AutoFirmwareCompilation/update_versions.py
+++ b/AutoFirmwareCompilation/update_versions.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""
+iCub Firmware Version Manager
+==============================
+Reads firmware_versions.yaml, shows current versions, lets the user
+update one or more boards interactively, patches the source files,
+and writes the new values back to the YAML.
+
+Usage:
+    python update_versions.py [--build] [--yaml PATH]
+
+Options:
+    --build     Launch buildAllBoards.bat automatically after updating.
+    --yaml PATH Use an alternate YAML registry (default: firmware_versions.yaml
+                in the same directory as this script).
+
+Requirements:
+    pip install pyyaml
+"""
+
+import os
+import re
+import sys
+import shutil
+import subprocess
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required. Run:  pip install pyyaml")
+    sys.exit(1)
+
+
+# ── Month / Day name tables (used by AMC and AMC2C source formats) ────────────
+
+MONTH_NAME = {
+    1: 'Jan', 2: 'Feb', 3: 'Mar',  4: 'Apr',  5: 'May',  6: 'Jun',
+    7: 'Jul', 8: 'Aug', 9: 'Sep', 10: 'Oct', 11: 'Nov', 12: 'Dec',
+}
+MONTH_FROM_NAME = {v: k for k, v in MONTH_NAME.items()}
+
+DAY_NAME = {
+    1: 'one',        2: 'two',       3: 'three',     4: 'four',
+    5: 'five',       6: 'six',       7: 'seven',     8: 'eight',
+    9: 'nine',      10: 'ten',      11: 'eleven',   12: 'twelve',
+   13: 'thirteen',  14: 'fourteen', 15: 'fifteen',  16: 'sixteen',
+   17: 'seventeen', 18: 'eighteen', 19: 'nineteen', 20: 'twenty',
+   21: 'twentyone', 22: 'twentytwo',23: 'twentythree', 24: 'twentyfour',
+   25: 'twentyfive',26: 'twentysix',27: 'twentyseven',28: 'twentyeight',
+   29: 'twentynine',30: 'thirty',   31: 'thirtyone',
+}
+DAY_FROM_NAME = {v: k for k, v in DAY_NAME.items()}
+
+
+# ── Path helpers ──────────────────────────────────────────────────────────────
+
+def workspace_root(script_dir: Path) -> Path:
+    """
+    Return the workspace root used by paths stored in firmware_versions.yaml.
+
+    Supported layouts:
+
+        WORKSPACE/
+        ├── AutoFirmwareCompilation/
+        └── icub-firmware/
+
+    and:
+
+        WORKSPACE/
+        └── icub-firmware/
+            └── AutoFirmwareCompilation/
+
+    The YAML paths already include the "icub-firmware/" prefix, therefore
+    when this script lives inside icub-firmware we must go up two levels.
+    """
+    parent = script_dir.parent
+
+    if parent.name.lower() == "icub-firmware":
+        return parent.parent
+
+    return parent
+
+
+def version_file_path(board: dict, root: Path) -> Path:
+    rel = board['version_file'].replace('/', os.sep)
+    return root / rel
+
+
+# ── File I/O ──────────────────────────────────────────────────────────────────
+
+def read_file(path: Path) -> str:
+    for enc in ('utf-8', 'utf-8-sig', 'latin-1'):
+        try:
+            return path.read_text(encoding=enc)
+        except Exception:
+            continue
+    raise OSError(f"Cannot read {path}")
+
+
+def write_file(path: Path, content: str) -> None:
+    path.write_text(content, encoding='utf-8')
+
+
+def backup(path: Path) -> None:
+    shutil.copy2(path, str(path) + '.bak')
+
+
+# ── Version data model ────────────────────────────────────────────────────────
+
+def ver_str(v: dict) -> str:
+    """Pretty-print a version/build_date dict."""
+    vv = v.get('version', {})
+    dd = v.get('build_date', {})
+    maj = vv.get('major', '?')
+    min_ = vv.get('minor', '?')
+    y = dd.get('year', '????')
+    mo = dd.get('month', 0) or 0
+    d = dd.get('day',   0) or 0
+    h = dd.get('hour',  0) or 0
+    mi = dd.get('minute', 0) or 0
+    return f"v{maj}.{min_}  ({y}-{mo:02d}-{d:02d} {h:02d}:{mi:02d})"
+
+
+def yaml_current(board: dict) -> dict:
+    return {
+        'version':    dict(board['version']),
+        'build_date': dict(board['build_date']),
+    }
+
+
+# ── Source-file readers (extract version from actual C/C++ file) ──────────────
+
+def _read_c_defines(content: str, board: dict):
+    p = board.get('define_prefix', 'EOMTHEEMSAPPLCFG')
+    has_off = board.get('has_offset', False)
+
+    if has_off:
+        m = re.search(rf'#define {p}_VERSION_MAJOR\s+\(VERSION_MAJOR_OFFSET\+(\d+)\)', content)
+    else:
+        m = re.search(rf'#define {p}_VERSION_MAJOR\s+(\d+)', content)
+    major = int(m.group(1)) if m else None
+
+    def def_int(key):
+        m2 = re.search(rf'#define {p}_{key}\s+(\d+)', content)
+        return int(m2.group(1)) if m2 else None
+
+    return {
+        'version':    {'major': major, 'minor': def_int('VERSION_MINOR')},
+        'build_date': {
+            'year':   def_int('BUILDDATE_YEAR'),
+            'month':  def_int('BUILDDATE_MONTH'),
+            'day':    def_int('BUILDDATE_DAY'),
+            'hour':   def_int('BUILDDATE_HOUR'),
+            'minute': def_int('BUILDDATE_MIN'),
+        },
+    }
+
+
+def _read_cpp_theapplication(content: str, _board: dict):
+    m = re.search(r'Process::eApplication,\s*\n\s*\{(\d+),\s*(\d+)\}', content)
+    major = int(m.group(1)) if m else None
+    minor = int(m.group(2)) if m else None
+
+    m2 = re.search(r'\{(\d+),\s*Month::(\w+),\s*Day::(\w+),\s*(\d+),\s*(\d+)\}', content)
+    if m2:
+        year   = int(m2.group(1))
+        month  = MONTH_FROM_NAME.get(m2.group(2))
+        day    = DAY_FROM_NAME.get(m2.group(3))
+        hour   = int(m2.group(4))
+        minute = int(m2.group(5))
+    else:
+        year = month = day = hour = minute = None
+
+    return {
+        'version':    {'major': major, 'minor': minor},
+        'build_date': {'year': year, 'month': month, 'day': day,
+                       'hour': hour, 'minute': minute},
+    }
+
+
+def _read_cpp_amc2c_sig(content: str, _board: dict):
+    m = re.search(r'\{(\d+),\s*(\d+),\s*\d+,\s*\d+\},?\s*//\s*application version', content)
+    major = int(m.group(1)) if m else None
+    minor = int(m.group(2)) if m else None
+
+    m2 = re.search(
+        r'\{(\d+),\s*embot::app::eth::Month::(\w+),\s*embot::app::eth::Day::(\w+),\s*(\d+),\s*(\d+)\}',
+        content)
+    if m2:
+        year   = int(m2.group(1))
+        month  = MONTH_FROM_NAME.get(m2.group(2))
+        day    = DAY_FROM_NAME.get(m2.group(3))
+        hour   = int(m2.group(4))
+        minute = int(m2.group(5))
+    else:
+        year = month = day = hour = minute = None
+
+    return {
+        'version':    {'major': major, 'minor': minor},
+        'build_date': {'year': year, 'month': month, 'day': day,
+                       'hour': hour, 'minute': minute},
+    }
+
+
+_READERS = {
+    'c_defines':          _read_c_defines,
+    'cpp_theapplication': _read_cpp_theapplication,
+    'cpp_amc2c_sig':      _read_cpp_amc2c_sig,
+}
+
+
+def read_version_from_file(board: dict, file_path: Path):
+    """Returns version dict read from the source file, or None on failure."""
+    try:
+        content = read_file(file_path)
+        reader = _READERS.get(board['format'])
+        return reader(content, board) if reader else None
+    except Exception:
+        return None
+
+
+# ── Source-file updaters ──────────────────────────────────────────────────────
+
+def _update_c_defines(content: str, board: dict, ver: dict) -> str:
+    p     = board.get('define_prefix', 'EOMTHEEMSAPPLCFG')
+    has_off = board.get('has_offset', False)
+    v  = ver['version']
+    dd = ver['build_date']
+    maj, min_ = v['major'], v['minor']
+    y, mo, d, h, mi = dd['year'], dd['month'], dd['day'], dd['hour'], dd['minute']
+
+    if has_off:
+        content = re.sub(
+            rf'(#define {p}_VERSION_MAJOR\s+\(VERSION_MAJOR_OFFSET\+)\d+(\))',
+            lambda m: f'{m.group(1)}{maj}{m.group(2)}',
+            content)
+    else:
+        content = re.sub(rf'(#define {p}_VERSION_MAJOR\s+)\d+',
+                         f'\\g<1>{maj}', content)
+
+    content = re.sub(rf'(#define {p}_VERSION_MINOR\s+)\d+',   f'\\g<1>{min_}', content)
+    content = re.sub(rf'(#define {p}_BUILDDATE_YEAR\s+)\d+',  f'\\g<1>{y}',    content)
+    content = re.sub(rf'(#define {p}_BUILDDATE_MONTH\s+)\d+', f'\\g<1>{mo}',   content)
+    content = re.sub(rf'(#define {p}_BUILDDATE_DAY\s+)\d+',   f'\\g<1>{d}',    content)
+    content = re.sub(rf'(#define {p}_BUILDDATE_HOUR\s+)\d+',  f'\\g<1>{h}',    content)
+    content = re.sub(rf'(#define {p}_BUILDDATE_MIN\s+)\d+',   f'\\g<1>{mi}',   content)
+    return content
+
+
+def _update_cpp_theapplication(content: str, _board: dict, ver: dict) -> str:
+    v  = ver['version']
+    dd = ver['build_date']
+    maj, min_ = v['major'], v['minor']
+    y, mo, d, h, mi = dd['year'], dd['month'], dd['day'], dd['hour'], dd['minute']
+    mname = MONTH_NAME[mo]
+    dname = DAY_NAME[d]
+
+    # {major, minor} right after Process::eApplication,
+    content = re.sub(
+        r'(Process::eApplication,\s*\n\s*)\{\d+,\s*\d+\}',
+        f'\\g<1>{{{maj}, {min_}}}',
+        content)
+
+    # date line: {year, Month::xxx, Day::xxx, hour, minute}
+    content = re.sub(
+        r'\{\d+,\s*Month::\w+,\s*Day::\w+,\s*\d+,\s*\d+\}',
+        f'{{{y}, Month::{mname}, Day::{dname}, {h}, {mi}}}',
+        content)
+    return content
+
+
+def _update_cpp_amc2c_sig(content: str, _board: dict, ver: dict) -> str:
+    v  = ver['version']
+    dd = ver['build_date']
+    maj, min_ = v['major'], v['minor']
+    y, mo, d, h, mi = dd['year'], dd['month'], dd['day'], dd['hour'], dd['minute']
+    mname = MONTH_NAME[mo]
+    dname = DAY_NAME[d]
+
+    # {major, minor, 0, 0},  // application version  (update all occurrences = both #ifdef branches)
+    content = re.sub(
+        r'\{\d+,\s*\d+,\s*\d+,\s*\d+\}(,?\s*//\s*application version)',
+        f'{{{maj}, {min_}, 0, 0}}\\1',
+        content)
+
+    # date with embot::app::eth:: prefix (all occurrences)
+    content = re.sub(
+        r'\{\d+,\s*embot::app::eth::Month::\w+,\s*embot::app::eth::Day::\w+,\s*\d+,\s*\d+\}',
+        f'{{{y}, embot::app::eth::Month::{mname}, embot::app::eth::Day::{dname}, {h}, {mi}}}',
+        content)
+    return content
+
+
+_UPDATERS = {
+    'c_defines':          _update_c_defines,
+    'cpp_theapplication': _update_cpp_theapplication,
+    'cpp_amc2c_sig':      _update_cpp_amc2c_sig,
+}
+
+
+def apply_update(board: dict, new_ver: dict, file_path: Path) -> bool:
+    """Patches the source file. Returns True on success."""
+    updater = _UPDATERS.get(board['format'])
+    if not updater:
+        print(f"  ERROR: unknown format '{board['format']}' for board {board['name']}")
+        return False
+    try:
+        content = read_file(file_path)
+        new_content = updater(content, board, new_ver)
+        if new_content == content:
+            print(f"  WARNING: no changes applied to {file_path.name} — check regex patterns")
+            return False
+        backup(file_path)
+        write_file(file_path, new_content)
+        print(f"  ✓ Patched: {file_path}")
+        return True
+    except Exception as e:
+        print(f"  ERROR: could not update {file_path}: {e}")
+        return False
+
+
+# ── Interactive prompt ────────────────────────────────────────────────────────
+
+def prompt_int(label: str, default: int) -> int:
+    val = input(f"    {label} [{default}]: ").strip()
+    if val == '':
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        print(f"    Invalid input, keeping {default}")
+        return default
+
+
+def prompt_board(board: dict, current: dict):
+    """
+    Interactively asks the user for new version values.
+    Returns the new version dict, or None if nothing changed / user cancelled.
+    """
+    print(f"\n  ╔══ {board['name']} — {board.get('description', '')} ══")
+    print(f"  ║  Current: {ver_str(current)}")
+
+    today = datetime.now()
+
+    maj  = prompt_int("Version major", current['version']['major'])
+    min_ = prompt_int("Version minor", current['version']['minor'])
+
+    use_today = input(
+        f"    Use today's date ({today.strftime('%Y-%m-%d %H:%M')})? [y/N]: "
+    ).strip().lower()
+
+    if use_today == 'y':
+        y, mo, d, h, mi = today.year, today.month, today.day, today.hour, today.minute
+    else:
+        dd = current['build_date']
+        y  = prompt_int("Year",   dd['year'])
+        mo = prompt_int("Month",  dd['month'])
+        d  = prompt_int("Day",    dd['day'])
+        h  = prompt_int("Hour",   dd['hour'])
+        mi = prompt_int("Minute", dd['minute'])
+
+    # Basic date validation
+    if not (1 <= mo <= 12 and 1 <= d <= 31 and 0 <= h <= 23 and 0 <= mi <= 59):
+        print("  ERROR: invalid date/time values. Skipping this board.")
+        return None
+
+    new_ver = {
+        'version':    {'major': maj, 'minor': min_},
+        'build_date': {'year': y, 'month': mo, 'day': d, 'hour': h, 'minute': mi},
+    }
+
+    if new_ver == current:
+        print("  ║  No changes.")
+        return None
+
+    print(f"  ║  New:     {ver_str(new_ver)}")
+    confirm = input("  ╚═ Apply? [Y/n]: ").strip().lower()
+    return new_ver if confirm != 'n' else None
+
+
+# ── YAML write-back ───────────────────────────────────────────────────────────
+
+def update_yaml_entry(board: dict, new_ver: dict) -> None:
+    board['version']['major']    = new_ver['version']['major']
+    board['version']['minor']    = new_ver['version']['minor']
+    board['build_date']['year']   = new_ver['build_date']['year']
+    board['build_date']['month']  = new_ver['build_date']['month']
+    board['build_date']['day']    = new_ver['build_date']['day']
+    board['build_date']['hour']   = new_ver['build_date']['hour']
+    board['build_date']['minute'] = new_ver['build_date']['minute']
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='iCub firmware version manager — patches source files from a YAML registry.')
+    parser.add_argument('--build', action='store_true',
+                        help='Launch buildAllBoards.bat after updating versions.')
+    parser.add_argument('--yaml', default=None,
+                        help='Path to the YAML registry (default: firmware_versions.yaml '
+                             'in the same folder as this script).')
+    args = parser.parse_args()
+
+    script_dir   = Path(__file__).parent.resolve()
+    yaml_path    = Path(args.yaml).resolve() if args.yaml else script_dir / 'firmware_versions.yaml'
+    root         = workspace_root(script_dir)
+
+    print()
+    print("╔══════════════════════════════════════════════════════════╗")
+    print("║          iCub Firmware Version Manager                   ║")
+    print("╚══════════════════════════════════════════════════════════╝")
+    print(f"  Workspace : {root}")
+    print(f"  Registry  : {yaml_path}")
+    print()
+
+    with open(yaml_path, encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    boards = config['boards']
+
+    # ── Read current versions from source files ────────────────────────────
+    file_versions = {}
+    for b in boards:
+        fp = version_file_path(b, root)
+        file_versions[b['id']] = read_version_from_file(b, fp)
+
+    # ── Display table ──────────────────────────────────────────────────────
+    print("  Current firmware versions (read from source files):")
+    print()
+    for i, b in enumerate(boards, 1):
+        fv = file_versions.get(b['id'])
+        if fv:
+            vs = ver_str(fv)
+            yv = yaml_current(b)
+            mismatch = (fv['version'] != yv['version'] or
+                        fv['build_date'] != yv['build_date'])
+            flag = "  ← YAML out of sync!" if mismatch else ""
+        else:
+            vs = "[file not found]"
+            flag = ""
+        print(f"  [{i}] {b['name']:<10} {vs}{flag}")
+
+    print()
+    print("  [A] Update ALL boards")
+    print("  [Q] Quit without changes")
+    print()
+    sel = input("  Select boards to update (e.g. 1,2  or  A  or  Q): ").strip().upper()
+
+    if not sel or sel == 'Q':
+        print("\n  No changes made. Bye.")
+        return
+
+    if sel == 'A':
+        chosen = [b['id'] for b in boards]
+    else:
+        chosen = []
+        for token in sel.split(','):
+            token = token.strip()
+            try:
+                idx = int(token) - 1
+                if 0 <= idx < len(boards):
+                    chosen.append(boards[idx]['id'])
+                else:
+                    print(f"  WARNING: index {token} out of range, skipped.")
+            except ValueError:
+                print(f"  WARNING: '{token}' is not a valid number, skipped.")
+
+    if not chosen:
+        print("\n  Nothing selected. Bye.")
+        return
+
+    # ── Process each selected board ────────────────────────────────────────
+    yaml_dirty   = False
+    files_patched = 0
+
+    for bid in chosen:
+        board = next((b for b in boards if b['id'] == bid), None)
+        if board is None:
+            continue
+
+        # Use the version read from the file as the "current" baseline;
+        # fall back to YAML if the file could not be parsed.
+        current = file_versions.get(bid) or yaml_current(board)
+
+        new_ver = prompt_board(board, current)
+        if new_ver is None:
+            continue
+
+        fp = version_file_path(board, root)
+        if apply_update(board, new_ver, fp):
+            update_yaml_entry(board, new_ver)
+            yaml_dirty = True
+            files_patched += 1
+
+    # ── Write YAML if changed ─────────────────────────────────────────────
+    if yaml_dirty:
+        with open(yaml_path, 'w', encoding='utf-8') as f:
+            yaml.dump(config, f, default_flow_style=False,
+                      allow_unicode=True, sort_keys=False)
+        print(f"\n  ✓ Registry updated: {yaml_path.name}")
+
+    if files_patched == 0:
+        print("\n  No files were modified.")
+        return
+
+    # ── Optionally launch the build ────────────────────────────────────────
+    if args.build:
+        launch = 'y'
+    else:
+        print()
+        launch = input("  Launch buildAllBoards.bat now? [y/N]: ").strip().lower()
+
+    if launch == 'y':
+        bat = script_dir / 'buildAllBoards.bat'
+        if bat.exists():
+            print(f"\n  Launching {bat.name} …\n")
+            subprocess.run([str(bat)], shell=True)
+        else:
+            print(f"  ERROR: {bat} not found.")
+
+    print("\n  Done.\n")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR introduces the **AutoFirmwareCompilation** tool into `icub-firmware` as a first step toward a more automated firmware build workflow.

The tool simplifies a common development scenario where a change to one board may require rebuilding several firmware targets because of shared code. It allows developers to update firmware versions and build dates for multiple boards from a single interface, build the supported firmware targets in sequence, collect the generated binaries, and inspect the compilation logs without manually opening and editing every project/source file.

The long-term goal is to move more of this workflow toward CI-based firmware generation. This is still an initial implementation, so fixes, improvements, additional board support, and contributions are very welcome.

This version supersedes the previous standalone tool hosted in my personal repository, which should now be considered obsolete.
